### PR TITLE
More support for polyself gaze attacks

### DIFF
--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1166,6 +1166,7 @@ dogaze()
 		    /* No reflection check for consistency with when a monster
 		     * gazes at *you*--only medusa gaze gets reflected then.
 		     */
+		}
 		    switch (adtyp)
 			{
 			case AD_CONF:

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1166,7 +1166,7 @@ dogaze()
 		    /* No reflection check for consistency with when a monster
 		     * gazes at *you*--only medusa gaze gets reflected then.
 		     */
-		}
+		
 		    switch (adtyp)
 			{
 			case AD_CONF:


### PR DESCRIPTION
Updated from vanilla to include: AD_STDY, AD_RETR, AD_ELEC, AD_COLD, and AD_BLND; in addition to AD_FIRE and AD_CONF.
Has a real failure message on attempting an AD_SPOR or AD_MIST gaze, as opposed to an impossible() call.