### PR TITLE
Fix: Mjollnir self-hit

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2059,6 +2059,10 @@ int dieroll; /* needed for Magicbane and vorpal blades */
 	 */
 	*dmgptr += spec_dbon(otmp, mdef, *dmgptr);
 	
+	//If there is no attacker (ie. you threw the artifact at yourself), make yourself the attacker
+	if (!magr)
+		magr = &youmonst;
+
 	if(otmp->oartifact == ART_LIMITED_MOON && magr == &youmonst){
 		*dmgptr *= ((double)u.uen/u.uenmax);
 		// if(u.uen >= 10) u.uen -= 10;


### PR DESCRIPTION
Being hit by an elementally-exploding artifact you threw (Mjollnir being the most common case, but throwing others upwards works too) no longer causes a crash.
Assumes you were the attacker when there is no attacker given; hopefully no other effects?