### PR TITLE
Turn to Stone consistency

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -3383,7 +3383,7 @@ int spellnum;
 				minstapetrify(mtmp, yours);
 		   }
 		   else
-			goto uspsibolt;
+			pline("%s stiffens momentarily.", Monnam(mtmp));
         }
 		dmg = 0;
 	 stop_occupation();


### PR DESCRIPTION
A failed casting of Turn to Stone vs a monster gives a similar message to what a player would receive, not going to psibolt.