### PR TITLE
windowtype:tty - use unsigned longs for terminal size

### DIFF
--- a/include/wintty.h
+++ b/include/wintty.h
@@ -28,10 +28,10 @@ struct WinDesc {
     int flags;			/* window flags */
     xchar type;			/* type of window */
     boolean active;		/* true if window is active */
-    uchar offx, offy;		/* offset from topleft of display */
-    long rows, cols;		/* dimensions */
-    long curx, cury;		/* current cursor position */
-    long maxrow, maxcol;	/* the maximum size used -- for MENU wins */
+    unsigned long offx, offy;		/* offset from topleft of display */
+    unsigned long rows, cols;		/* dimensions */
+    unsigned long curx, cury;		/* current cursor position */
+    unsigned long maxrow, maxcol;	/* the maximum size used -- for MENU wins */
 				/* maxcol is also used by WIN_MESSAGE for */
 				/* tracking the ^P command */
     short *datlen;		/* allocation size for *data */
@@ -52,8 +52,8 @@ struct WinDesc {
 
 /* descriptor for tty-based displays -- all the per-display data */
 struct DisplayDesc {
-    uchar rows, cols;		/* width and height of tty display */
-    uchar curx, cury;		/* current cursor position on the screen */
+    unsigned long rows, cols;		/* width and height of tty display */
+    unsigned long curx, cury;		/* current cursor position on the screen */
 #ifdef TEXTCOLOR
     int color;			/* current color */
 #endif


### PR DESCRIPTION
This avoids terminal size wraparound and the associated weirdnesses with
terminals larger than 255 characters in either dimension.

I'll admit this hasn't been tested *too* much – but the game now properly starts up in my terminal, rather than restricting itself to a 16 character wide area.

    ilbelkyr@irdasul %> stty size
    59 271