### PR TITLE
Fix: Iron/Unholy, Paimon, Cleanup

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1155,7 +1155,6 @@ int thrown;
 				tmp = 0;
 		    else if(obj->oartifact == ART_LIECLEAVER) tmp = 2*(rnd(12) + rnd(10) + obj->spe);
 		    else if(obj->oartifact == ART_ROGUE_GEAR_SPIRITS) tmp = 2*(rnd(bigmonst(mon->data) ? 2 : 5) + obj->spe);
-		    else if(obj->oclass == SPBOOK_CLASS && u.sealsActive&SEAL_PAIMON) tmp = rnd(spiritDsize()) + objects[obj->otyp].oc_level;
 			else tmp = rnd(2);
 			
 		    // if (tmp && obj->oartifact &&
@@ -1177,6 +1176,16 @@ int thrown;
 				else silvermsg = TRUE;
 				silverobj = TRUE;
 		    }
+			if (obj->obj_material == IRON && hates_iron(mdat)) {
+				tmp += rnd(mon->m_lev * 2);	//I think this is the right thing to do here.  I don't think it enters the main iron section
+				ironmsg = TRUE;
+				ironobj = TRUE;
+			}
+			if (obj->cursed == TRUE && hates_unholy(mdat)) {
+				tmp += rnd(20);	//I think this is the right thing to do here.  I don't think it enters the main unholy section
+				unholymsg = TRUE;
+				unholyobj = TRUE;
+			}
 		    if (!thrown && obj == uwep && obj->otyp == BOOMERANG &&
 			    rnl(4) == 4-1 && obj->oartifact == 0) {
 			boolean more_than_1 = (obj->quan > 1L);
@@ -1695,22 +1704,31 @@ defaultvalue:
 					if(tmp < 1) tmp = 1;
 					else tmp = rnd(tmp);
 					if(tmp > 6) tmp = 6;
-					if(obj->oartifact == ART_GLAMDRING && (is_orc(mdat) || is_demon(mdat))){
-						tmp += rnd(20); //I think this is the right thing to do here.  I don't think it enters the main silver section
-						lightmsg = TRUE;
-					}
+
+					/*
+					 * Paimon's spellbook-bashing damage
+					 */
+					if (obj->oclass == SPBOOK_CLASS && u.sealsActive&SEAL_PAIMON)
+						tmp = rnd(spiritDsize()) + objects[obj->otyp].oc_level;
+
 					/*
 					 * Things like silver wands can arrive here so
 					 * so we need another silver check.
 					 */
-					if (obj && (obj->obj_material == SILVER || arti_silvered(obj) || 
-							(thrown && obj->otyp == SHURIKEN && uwep && uwep->oartifact == ART_SILVER_STARLIGHT) )
-								&& hates_silver(mdat)
-					) {
+					if (obj && (obj->obj_material == SILVER || arti_silvered(obj)) && hates_silver(mdat)) {
 						tmp += rnd(20);
-						if(obj->oartifact == ART_SUNSWORD) sunmsg = TRUE;
-						else silvermsg = TRUE;
+						silvermsg = TRUE;
 						silverobj = TRUE;
+					if (obj && obj->obj_material == IRON && hates_iron(mdat)) {
+						tmp += rnd(mon->m_lev * 2);
+						ironmsg = TRUE;
+						ironobj = TRUE;
+					}
+					if (obj && obj->cursed == TRUE && hates_unholy(mdat)) {
+						tmp += rnd(20);
+						unholymsg = TRUE;
+						unholyobj = TRUE;
+					}
 					}
 				}
 			}


### PR DESCRIPTION
Iron/unholy messages for normal attacks
Iron/unholy messages and damage for unconventional bashing
Paimon damage for spellbook bashing (draining was working fine)
Cleaned up some of the checks for unconventional bashing (artifact weapons won't make it there)