### PR TITLE
curses - fix EXP_ON_BOTL code block

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -1441,6 +1441,7 @@ row_refresh(start,stop,y)
     for (x = start; x <= stop; x++)
 	if (gbuf[y][x].glyph != cmap_to_glyph(S_stone))
 	    print_glyph(WIN_MAP,x,y,gbuf[y][x].glyph);
+    display_nhwindow(WIN_MAP,FALSE);
 }
 
 void

--- a/win/curses/cursinvt.c
+++ b/win/curses/cursinvt.c
@@ -53,7 +53,7 @@ curses_update_inv(void)
     if (border)
         box(win, 0, 0);
 
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 /* Adds an inventory item. */

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -287,7 +287,9 @@ curses_display_nhwindow(winid wid, BOOLEAN_P block)
     }
 
     /* actually display the window */
-    wrefresh(curses_get_nhwin(wid));
+    wnoutrefresh(curses_get_nhwin(wid));
+    /* flush pending writes from other windows too */
+    doupdate();
     if ((wid == MAP_WIN) && block) {
         (void) curses_more();
     }

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -280,7 +280,14 @@ void
 curses_display_nhwindow(winid wid, BOOLEAN_P block)
 {
     menu_item *selected = NULL;
+    if (curses_is_menu(wid) || curses_is_text(wid)) {
+        curses_end_menu(wid, "");
+        curses_select_menu(wid, PICK_NONE, &selected);
+        return;
+    }
 
+    /* actually display the window */
+    wrefresh(curses_get_nhwin(wid));
     if ((wid == MAP_WIN) && block) {
         (void) curses_more();
     }
@@ -291,12 +298,6 @@ curses_display_nhwindow(winid wid, BOOLEAN_P block)
         /* don't bug player with TAB prompt on "Saving..." or endgame */
         else
             (void) curses_more();
-    }
-
-    if (curses_is_menu(wid) || curses_is_text(wid)) {
-        curses_end_menu(wid, "");
-        curses_select_menu(wid, PICK_NONE, &selected);
-        return;
     }
 }
 
@@ -740,6 +741,9 @@ delay_output()  -- Causes a visible delay of 50ms in the output.
 void
 curses_delay_output()
 {
+    /* refreshing the whole display is a waste of time,
+     * but that's why we're here */
+    refresh();
     napms(50);
 }
 

--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -121,7 +121,6 @@ curses_message_win_puts(const char *message, boolean recursed)
         if (height > 1) {
             curses_toggle_color_attr(win, NONE, A_BOLD, OFF);
         }
-        //wrefresh(win);
         curses_message_win_puts(tmpstr = curses_str_remainder(message, (width - 2), 1),
                                 TRUE);
         free(tmpstr);
@@ -154,7 +153,6 @@ curses_block(boolean require_tab)
         curses_clear_unhighlight_message_window();
     } else {
         mvwprintw(win, my, mx, "      ");
-        //wrefresh(win);
         if (!require_tab) {
             scroll_window(MESSAGE_WIN);
             turn_lines = 1;

--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -121,7 +121,7 @@ curses_message_win_puts(const char *message, boolean recursed)
         if (height > 1) {
             curses_toggle_color_attr(win, NONE, A_BOLD, OFF);
         }
-        wrefresh(win);
+        //wrefresh(win);
         curses_message_win_puts(tmpstr = curses_str_remainder(message, (width - 2), 1),
                                 TRUE);
         free(tmpstr);
@@ -154,7 +154,7 @@ curses_block(boolean require_tab)
         curses_clear_unhighlight_message_window();
     } else {
         mvwprintw(win, my, mx, "      ");
-        wrefresh(win);
+        //wrefresh(win);
         if (!require_tab) {
             scroll_window(MESSAGE_WIN);
             turn_lines = 1;
@@ -206,7 +206,7 @@ curses_clear_unhighlight_message_window()
             }
         }
 
-        wrefresh(win);
+        wnoutrefresh(win);
     }
 }
 

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -488,7 +488,7 @@ curses_update_stats(void)
     if (border)
         box(win, 0, 0);
 
-    wrefresh(win);
+    wnoutrefresh(win);
 
     if (first) {
         first = FALSE;

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -584,8 +584,9 @@ draw_horizontal(int x, int y, int hp, int hpmax)
         /* use waddch, we don't want to highlight the '/' */
         waddch(win, '/');
         print_statdiff("", &prevexp, u.uexp, STAT_OTHER);
+    }
 #endif
-    } else
+    else
         print_statdiff(" Exp:", &prevlevel, u.ulevel, STAT_OTHER);
 
     if (flags.time)
@@ -649,8 +650,9 @@ draw_horizontal_new(int x, int y, int hp, int hpmax)
         }
         print_statdiff("", &prevexp, xp_left, STAT_AC);
         waddch(win, ')');
+    }
 #endif
-    } else
+    else
         print_statdiff(" Exp:", &prevlevel, u.ulevel, STAT_OTHER);
 
     waddch(win, ' ');
@@ -832,8 +834,9 @@ draw_vertical(int x, int y, int hp, int hpmax)
         /* use waddch, we don't want to highlight the '/' */
         waddch(win, '/');
         print_statdiff("", &prevexp, u.uexp, STAT_OTHER);
+    }
 #endif
-    } else
+    else
         print_statdiff("Level:         ", &prevlevel, u.ulevel, STAT_OTHER);
     wmove(win, y++, x);
 

--- a/win/curses/curswins.c
+++ b/win/curses/curswins.c
@@ -154,11 +154,12 @@ curses_destroy_win(WINDOW * win)
 void
 curses_refresh_nethack_windows()
 {
-    WINDOW *status_window, *message_window, *map_window;
+    WINDOW *status_window, *message_window, *map_window, *inv_window;
 
     status_window = curses_get_nhwin(STATUS_WIN);
     message_window = curses_get_nhwin(MESSAGE_WIN);
     map_window = curses_get_nhwin(MAP_WIN);
+    inv_window = curses_get_nhwin(INV_WIN);
 
     if ((moves <= 1) && !invent) {
         /* Main windows not yet displayed; refresh base window instead */
@@ -171,6 +172,10 @@ curses_refresh_nethack_windows()
         wnoutrefresh(map_window);
         touchwin(message_window);
         wnoutrefresh(message_window);
+        if (inv_window) {
+            touchwin(inv_window);
+            wnoutrefresh(inv_window);
+        }
         doupdate();
     }
 }

--- a/win/curses/curswins.c
+++ b/win/curses/curswins.c
@@ -276,7 +276,8 @@ curses_add_wid(winid wid)
 void
 curses_refresh_nhwin(winid wid)
 {
-    wrefresh(curses_get_nhwin(wid));
+    wnoutrefresh(curses_get_nhwin(wid));
+    doupdate();
 }
 
 
@@ -477,7 +478,7 @@ curses_puts(winid wid, int attr, const char *text)
                                FALSE);
     } else {
         waddstr(win, text);
-        wrefresh(win);
+        wnoutrefresh(win);
     }
 }
 
@@ -508,14 +509,14 @@ curses_alert_win_border(winid wid, boolean onoff)
 {
     WINDOW *win = curses_get_nhwin(wid);
 
-    if (!curses_window_has_border(wid))
+    if (!win || !curses_window_has_border(wid))
         return;
     if (onoff)
         curses_toggle_color_attr(win, ALERT_BORDER_COLOR, NONE, ON);
     box(win, 0, 0);
     if (onoff)
         curses_toggle_color_attr(win, ALERT_BORDER_COLOR, NONE, OFF);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 
@@ -525,6 +526,7 @@ curses_alert_main_borders(boolean onoff)
     curses_alert_win_border(MAP_WIN, onoff);
     curses_alert_win_border(MESSAGE_WIN, onoff);
     curses_alert_win_border(STATUS_WIN, onoff);
+    curses_alert_win_border(INV_WIN, onoff);
 }
 
 /* Return true if given wid is a main NetHack window */

--- a/win/curses/curswins.c
+++ b/win/curses/curswins.c
@@ -369,8 +369,9 @@ curses_putch(winid wid, int x, int y, int ch, int color, int attr)
 
         write_char(mapwin, x - sx, y - sy, nch);
     }
-
-    wrefresh(mapwin);
+    /* refresh after every character?
+     * Fair go, mate! Some of us are playing from Australia! */
+    /* wrefresh(mapwin); */
 }
 
 


### PR DESCRIPTION
Hey Chris,
I just cleaned up a whole bunch of unnecessary wrefresh() calls in curses. Makes a BIG difference on a laggy connection.  Please merge when you get a chance. I can't wait to try it out on hdf :)

The other commit was just tidying up some mismatched braces if you don't define EXP_ON_BOTL.
Cheers!