### PR TITLE
Fix: naiad, swamp nymph

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -4012,6 +4012,8 @@ wisp_shdw_dhit:
 							/* defender dead */
 	    else {
 		(void) passive(mon, sum[i], 1, mattk->aatyp, mattk->adtyp);
+		if (DEADMONSTER(mon))
+			return TRUE;
 		nsum |= sum[i];
 	    }
 	    if (Upolyd != Old_Upolyd)
@@ -4262,6 +4264,8 @@ wisp_shdw_dhit2:
 						/* defender dead */
 	else {
 		(void) passive(mon, sum[i], 1, mattk->aatyp, mattk->adtyp);
+		if (DEADMONSTER(mon))
+			return TRUE;
 		nsum |= sum[i];
 	}
 	if (Upolyd != Old_Upolyd)


### PR DESCRIPTION
fix a dmonsfree error on killing a naiad or swamp nymph (due to their passive) while polyselfed