### PR TITLE
Fix: PYEC blessed charging

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3910,7 +3910,7 @@ arti_invoke(obj)
 		return 0;
 	    }
 	    b_effect = obj->blessed &&
-		((Role_switch == oart->role || !oart->role) && (Race_switch == oart->race || !oart->race));
+		((Role_switch == oart->role || oart->role == NON_PM) && (Race_switch == oart->race || oart->race == NON_PM));
 	    recharge(otmp, b_effect ? 1 : obj->cursed ? -1 : 0);
 	    update_inventory();
 	    break;
@@ -4427,7 +4427,7 @@ arti_invoke(obj)
            cc.x = u.ux;
            cc.y = u.uy;
            /* Cause trouble if cursed or player is wrong role */
-           if (obj->cursed || ((Role_switch == oart->role || !oart->role) && (Race_switch == oart->race || !oart->race))) {
+           if (obj->cursed || ((Role_switch == oart->role || oart->role == NON_PM) && (Race_switch == oart->race || oart->race == NON_PM))) {
               You("may summon a stinking cloud.");
                pline("Where do you want to center the cloud?");
                if (getpos(&cc, TRUE, "the desired position") < 0) {
@@ -5742,7 +5742,7 @@ arti_invoke(obj)
 						boolean b_effect;
 						
 						b_effect = obj->blessed &&
-							((Role_switch == oart->role || !oart->role) && (Race_switch == oart->race || !oart->race));
+							((Role_switch == oart->role || oart->role == NON_PM) && (Race_switch == oart->race || oart->race == NON_PM));
 						recharge(uwep, b_effect ? 1 : obj->cursed ? -1 : 0);
 						update_inventory();
 						break;


### PR DESCRIPTION
Since NON_PM is -1,  "!oart->race"  equates to  "False"  if  "oart->race"  is  "NON_PM"
This is not how it should be.