### PR TITLE
Scroll anti-farming

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -653,7 +653,7 @@ register struct monst *mtmp;
 			mtmp->mnamelth = 0;
 		break;
 		case PM_PAPER_GOLEM:
-			num = rnd(4);
+			num = (u.uz.dlevel != sum_of_all_level.dlevel || mvitals[PM_PAPER_GOLEM].born < 30) ? rnd(4) : 1;
 			while (num--)
 				obj = mksobj_at(SCR_BLANK_PAPER, x, y, TRUE, FALSE);
 			mtmp->mnamelth = 0;
@@ -668,7 +668,7 @@ register struct monst *mtmp;
 		case PM_SPELL_GOLEM:{
 			int scrnum = 0;
 			int scrrng = SCR_STINKING_CLOUD-SCR_ENCHANT_ARMOR;
-			num = rnd(8);
+			num = (u.uz.dlevel != sum_of_all_level.dlevel || mvitals[PM_SPELL_GOLEM].born < 20) ? rnd(8) : rnd(2);
 			while (num--){
 				scrnum = d(1, scrrng)-1;
 				obj = mksobj_at(scrnum+SCR_ENCHANT_ARMOR, x, y, TRUE, FALSE);

--- a/src/potion.c
+++ b/src/potion.c
@@ -2117,7 +2117,7 @@ boolean amnesia;
 		used = TRUE;
 		break;
 	    case SCROLL_CLASS:
-		if (obj->otyp != SCR_BLANK_PAPER  && !obj->oartifact
+		if (obj->otyp != SCR_BLANK_PAPER  && !obj->oartifact && obj->otyp != SCR_GOLD_SCROLL_OF_LAW
 #ifdef MAIL
 		    && obj->otyp != SCR_MAIL
 #endif

--- a/src/zap.c
+++ b/src/zap.c
@@ -958,6 +958,7 @@ register struct obj *obj;
 	    }
 	    switch (obj->oclass) {
 	      case SCROLL_CLASS:
+		if (obj->otyp == SCR_GOLD_SCROLL_OF_LAW) break;	//no cancelling these
 		costly_cancel(obj);
 		obj->otyp = SCR_BLANK_PAPER;
 		obj->spe = 0;

--- a/src/zap.c
+++ b/src/zap.c
@@ -1487,6 +1487,15 @@ poly_obj(obj, id)
 				(can_merge && otmp->quan > (long)rn2(1000))))
 	    otmp->quan = 1L;
 
+	if (id == STRANGE_OBJECT && obj->otyp == SCR_GOLD_SCROLL_OF_LAW)
+	{
+		/* turn gold scrolls of law into a handful of gold pieces */
+		otmp->otyp = GOLD_PIECE;
+		otmp->oclass = COIN_CLASS;
+		otmp->obj_material = GOLD;
+		otmp->quan = rnd(50 * obj->quan) + 50 * obj->quan;
+	}
+
 	switch (otmp->oclass) {
 
 	case TOOL_CLASS:


### PR DESCRIPTION
Reduces farmability of scrolls from:
Gold Scrolls of Law (no polypiling, or cancelling/diluting)
Sum of All (paper / spell golems drop far fewer scrolls on this level after 30 / 20 of each have been generated)