### PR TITLE
Fix: naiad/swamp nymph

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3962,6 +3962,8 @@ wisp_shdw_dhit:
 							/* defender dead */
 	    else {
 		(void) passive(mon, sum[i], 1, mattk->aatyp, mattk->adtyp);
+		if (DEADMONSTER(mon))
+			return TRUE;
 		nsum |= sum[i];
 	    }
 	    if (Upolyd != Old_Upolyd)


### PR DESCRIPTION
Fix a dmonsfree error when a naiad's or swamp nymph's passive kills them and the player still has more attacks queued in their polyselfed attack chain.