### PR TITLE
Twoweapon support for bullwhips

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -3340,7 +3340,7 @@ struct obj *obj;
 	   pline("A monster is there that you couldn't see.");
 	   map_invisible(rx, ry);
 	}
-	otmp = MON_WEP(mtmp);	/* can be null */
+	otmp = rn2(3) ? MON_WEP(mtmp) : MON_SWEP(mtmp);	/* can be null */
 	if (otmp) {
 	    char onambuf[BUFSZ];
 	    const char *mon_hand;

--- a/src/muse.c
+++ b/src/muse.c
@@ -1918,7 +1918,7 @@ struct monst *mtmp;
 			m.has_misc = MUSE_POT_GAIN_ENERGY;
 		}
 		nomore(MUSE_BULLWHIP);
-		if(obj->otyp == BULLWHIP && (MON_WEP(mtmp) == obj) &&
+		if(obj->otyp == BULLWHIP && (MON_WEP(mtmp) == obj || MON_SWEP(mtmp) == obj) &&
 		   distu(mtmp->mx,mtmp->my)==1 && uwep && !mtmp->mpeaceful) {
 			m.misc = obj;
 			m.has_misc = MUSE_BULLWHIP;


### PR DESCRIPTION
Monsters wielding a bullwhip in the offhand will use it against the player.
The player will target a monster's offhand 1/3rd of the time when applying a bullwhip against a monster.