### PR TITLE
Change "curse" to "rndcurse" for fountain quaff cursing

### DIFF
--- a/src/fountain.c
+++ b/src/fountain.c
@@ -290,8 +290,7 @@ drinkfountain()
 			pline("This water's no good!");
 			morehungry(rn1(20, 11));
 			exercise(A_CON, FALSE);
-			for(obj = invent; obj ; obj = obj->nobj)
-				if (!rn2(5))	curse(obj);
+			rndcurse();
 			break;
 			}
 


### PR DESCRIPTION
it's now blocked by curse resisting things, e.g. magicbane, proteus, tent rod, etc.