### PR TITLE
Balance treasure vault monsters, give them some thematic loot

### DIFF
--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -226,7 +226,7 @@ mkmivault()
 			mon = makemon(mivaultmon(), x+rnd(2)+1, y+rnd(2)+1, 0);
 			// lovecraft monsters
 			if (mon->data == &mons[PM_SHOGGOTH] || mon->data == &mons[PM_NIGHTGAUNT]
-					|| mon->data == &mons[PM_DARK_YOUNG] || mon->data == &mons[PM_HUNTING_HORROR] || mon->data == &mos[PM_HUNTING_HORROR_TAIL]){
+					|| mon->data == &mons[PM_DARK_YOUNG] || mon->data == &mons[PM_HUNTING_HORROR] || mon->data == &mon[PM_HUNTING_HORROR_TAIL]){
 				otmp2 = mksobj(FIGURINE, TRUE, FALSE);
 				switch(rn2(4)){
 					case 0:					
@@ -363,7 +363,7 @@ mkmivaultlolth()
 			
 			// lovecraft monsters
 			if (mon->data == &mons[PM_SHOGGOTH] || mon->data == &mons[PM_NIGHTGAUNT] 
-				|| mon->data == &mons[PM_DARK_YOUNG] || mon->data == &mons[PM_HUNTING_HORROR] || mon->data == &mos[PM_HUNTING_HORROR_TAIL]){
+				|| mon->data == &mons[PM_DARK_YOUNG] || mon->data == &mons[PM_HUNTING_HORROR] || mon->data == &mon[PM_HUNTING_HORROR_TAIL]){
 				otmp2 = mksobj(FIGURINE, TRUE, FALSE);
 				switch(rn2(4)){
 					case 0:					

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -185,6 +185,7 @@ mkmivault()
 	int x,y,tries=0;
 	int i,j;
 	struct obj *otmp;
+	struct obj *otmp2;
 	struct monst *mon;
 	boolean good=FALSE,okspot;
 	while(!good && tries < 50){
@@ -223,6 +224,65 @@ mkmivault()
 			for(i = d(2,4);i>0;i--) mkmivaultitem(otmp);
 			
 			mon = makemon(mivaultmon(), x+rnd(2)+1, y+rnd(2)+1, 0);
+			// lovecraft monsters
+			if (mon->data == &mons[PM_SHOGGOTH] || mon->data == &mons[PM_NIGHTGAUNT]
+					|| mon->data == &mons[PM_DARK_YOUNG] || mon->data == &mons[PM_HUNTING_HORROR] || mon->data == &mos[PM_HUNTING_HORROR_TAIL]){
+				otmp2 = mksobj(FIGURINE, TRUE, FALSE);
+				switch(rn2(4)){
+					case 0:					
+						otmp2->corpsenm = PM_DARK_YOUNG;
+					break;
+					case 1:
+						otmp2->corpsenm = PM_SHOGGOTH;
+						if(rn2(5)){
+							otmp2->corpsenm = PM_PRIEST_OF_GHAUNADAUR;
+						}
+					break;
+					case 2:
+						otmp2->corpsenm = PM_DARKNESS_GIVEN_HUNGER;
+					break;
+					case 3:
+						otmp2->corpsenm = PM_MASTER_MIND_FLAYER;
+					break;
+					case 4:
+						otmp2->corpsenm = PM_DEEPEST_ONE;
+					break;
+				}
+				bless(otmp2);
+				add_to_container(otmp, otmp2);
+			}
+			// clockworks
+			else if (mon->data == &mons[PM_JUGGERNAUT] || mon->data == &mons[PM_HOOLOOVOO] 
+					|| mon->data == &mons[PM_SCRAP_TITAN] || mon->data == &mons[PM_HELLFIRE_COLOSSUS]){
+				if (rn2(2)){
+					add_to_container(otmp, mksobj(SUBETHAIC_COMPONENT, TRUE, FALSE));
+				} else {
+					add_to_container(otmp, mksobj(SCRAP, TRUE, FALSE));
+				}
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+			}
+			// spellcasters
+			else if (mon->data == &mons[PM_TITAN] || mon->data == &mons[PM_EYE_OF_DOOM] 
+					|| mon->data == &mons[PM_PRIEST_OF_GHAUNADAUR] || mon->data == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
+						|| mon->data == &mons[PM_SERPENT_MAN_OF_YOTH]){
+				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+			}
 			mon->mstrategy |= STRAT_WAITFORU;
 			mon->mpeaceful = FALSE;
 			set_malign(mon);
@@ -264,6 +324,7 @@ mkmivaultlolth()
 	int x,y,tries=0;
 	int i,j;
 	struct obj *otmp;
+	struct obj *otmp2;
 	struct monst *mon;
 	boolean good=FALSE,okspot;
 	while(!good && tries < 50){
@@ -300,7 +361,65 @@ mkmivaultlolth()
 			otmp = mksobj_at(CHEST, x+2, y+2, TRUE, FALSE);
 			for(i = d(2,4);i>0;i--) mkmivaultitem(otmp);
 			
-			mon = makemon(mivaultmon(), x+rnd(2), y+rnd(2), 0);
+			// lovecraft monsters
+			if (mon->data == &mons[PM_SHOGGOTH] || mon->data == &mons[PM_NIGHTGAUNT] 
+				|| mon->data == &mons[PM_DARK_YOUNG] || mon->data == &mons[PM_HUNTING_HORROR] || mon->data == &mos[PM_HUNTING_HORROR_TAIL]){
+				otmp2 = mksobj(FIGURINE, TRUE, FALSE);
+				switch(rn2(4)){
+					case 0:					
+						otmp2->corpsenm = PM_DARK_YOUNG;
+					break;
+					case 1:
+						otmp2->corpsenm = PM_SHOGGOTH;
+						if(rn2(5)){
+							otmp2->corpsenm = PM_PRIEST_OF_GHAUNADAUR;
+						}
+					break;
+					case 2:
+						otmp2->corpsenm = PM_DARKNESS_GIVEN_HUNGER;
+					break;
+					case 3:
+						otmp2->corpsenm = PM_MASTER_MIND_FLAYER;
+					break;
+					case 4:
+						otmp2->corpsenm = PM_DEEPEST_ONE;
+					break;
+				}
+				bless(otmp2);
+				add_to_container(otmp, otmp2);
+			}
+			// clockworks
+			else if (mon->data == &mons[PM_JUGGERNAUT] || mon->data == &mons[PM_HOOLOOVOO] 
+					|| mon->data == &mons[PM_SCRAP_TITAN] || mon->data == &mons[PM_HELLFIRE_COLOSSUS]){
+				if (rn2(2)){
+					add_to_container(otmp, mksobj(SUBETHAIC_COMPONENT, TRUE, FALSE));
+				} else {
+					add_to_container(otmp, mksobj(SCRAP, TRUE, FALSE));
+				}
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
+			}
+			// spellcasters
+			else if (mon->data == &mons[PM_TITAN] || mon->data == &mons[PM_EYE_OF_DOOM] 
+					|| mon->data == &mons[PM_PRIEST_OF_GHAUNADAUR] || mon->data == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
+						|| mon->data == &mons[PM_SERPENT_MAN_OF_YOTH]){
+				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
+			}
 			mon->mstrategy |= STRAT_WAITFORU;
 			mon->mpeaceful = FALSE;
 			set_malign(mon);


### PR DESCRIPTION
Tries to balance some of the monsters in the vaults (and diversify), and gives them extra loot depending on what monster.

Lovecraft:

* Shoggoth
* Nightgaunt
* Dark Young
* Hunting Horror

(start with a blessed fig of shoggoth (rarely priest of ghaun), dark young, darkness given hunger, mmf, or deepest one)

Clockworks:

* Juggernaut
* Hooloovoo
* Scrap Titan
* Hellfire Colussus

(start with 9 clockwork components and either a subethaic component or a scrap)

Spellcasters:

* Titan
* Eye of Doom
* Priest of Ghaun
* Priestess of Ghaun
* Serpent Man of Yoth

(2-3 spellbooks, 3-6 scrolls)

Assorted:

* Mirkwood Elder
* Ammit
* Gigantic Pseudodragon
* Jabberwock
* Ancient Naga
* Gug
* Balrog

(no bonus loot)
