### PR TITLE
make this work on OS X

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -476,8 +476,6 @@ E  char *sprintf();
 #  if !defined(SVR4) && !defined(apollo)
 #   if !(defined(ULTRIX_PROTO) && defined(__GNUC__))
 #    if !(defined(SUNOS4) && defined(__STDC__)) /* Solaris unbundled cc (acc) */
-E int FDECL(vsprintf, (char *, const char *, va_list));
-E int FDECL(vfprintf, (FILE *, const char *, va_list));
 E int FDECL(vprintf, (const char *, va_list));
 #    endif
 #   endif


### PR DESCRIPTION
This took way too many tries... With those 2 lines removed (assuming you do change the compile flag in config.h), this should compile nicely with clang on mac.