### PR TITLE
Fix weapons not being enchanted above +1

### DIFF
--- a/src/wield.c
+++ b/src/wield.c
@@ -787,7 +787,7 @@ register int amount;
 	    return(1);
 	}
 	/* there is a (soft) upper and lower limit to uwep->spe */
-	safelim = uwep->otyp == 5;
+	safelim == 5;
 	if(((uwep->spe > safelim && amount >= 0) || (uwep->spe < -safelim && amount < 0))
 								&& rn2(3) && uwep->oartifact != ART_ROD_OF_SEVEN_PARTS
 								&& uwep->oartifact != ART_PEN_OF_THE_VOID
@@ -836,7 +836,7 @@ register int amount;
 
 	/* an elven magic clue, cookie@keebler */
 	/* elven weapons vibrate warningly when enchanted beyond a limit */
-	if ((uwep->otyp == CRYSTAL_SWORD ? (uwep->spe > 8) : (uwep->spe > 5)) 
+	if ((uwep->spe > 5) 
 		&& uwep->oartifact != ART_PEN_OF_THE_VOID && uwep->oartifact != ART_ANNULUS &&
 		(is_elven_weapon(uwep) || uwep->oartifact || !rn2(7)) &&
 		uwep->oartifact != ART_ROD_OF_SEVEN_PARTS


### PR DESCRIPTION
In addition, remove crystal swords only vibrating at +8 and above, since they can't be enchnated there safely anyway now