### PR TITLE
Make Mirrorbright and Y'ha-Talla's whip form usable

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -5490,9 +5490,11 @@ arti_invoke(obj)
 					break;
 					case COMMAND_SCIMITAR:
 						uwep->otyp = SCIMITAR;
+						if(obj->oartifact == ART_GOLDEN_SWORD_OF_Y_HA_TALLA) obj->obj_material = GOLD;
 					break;
 					case COMMAND_WHIP:
 						uwep->otyp = BULLWHIP;
+						if(obj->oartifact == ART_GOLDEN_SWORD_OF_Y_HA_TALLA) obj->obj_material = DRAGON_HIDE;
 					break;
 					/*These effects are limited by timeout*/
 					case COMMAND_LADDER:

--- a/src/objects.c
+++ b/src/objects.c
@@ -628,7 +628,7 @@ SHIELD("orcish shield", "red-eyed shield",
 SHIELD("kite shield", (char *)0,
 		1, 0, 1, 0,	     6, 0,100, 10,  8, 1, IRON, HI_METAL),
 SHIELD("roundshield", "round shield",
-		0, 0, 1, 0,	     1, 0,120,  7,  8, 1, WOOD, HI_COPPER),
+		0, 0, 1, 0,	     1, 0,120,  7,  8, 1, COPPER, HI_COPPER),
 SHIELD("dwarvish roundshield", "round shield",
 		0, 0, 0, 0,	     4, 0, 80, 10,  7, 1, IRON, HI_METAL),
 SHIELD("crystal shield", "glass shield", /*Needs encyc entry*//*Needs tile*/


### PR DESCRIPTION
Previously due to bad or awkward materials, they both weighed a ton. Fixed now.