### PR TITLE
Fix '=' vs '==' mix-up

### DIFF
--- a/src/wield.c
+++ b/src/wield.c
@@ -787,7 +787,7 @@ register int amount;
 	    return(1);
 	}
 	/* there is a (soft) upper and lower limit to uwep->spe */
-	safelim == 5;
+	safelim = 5;
 	if(((uwep->spe > safelim && amount >= 0) || (uwep->spe < -safelim && amount < 0))
 								&& rn2(3) && uwep->oartifact != ART_ROD_OF_SEVEN_PARTS
 								&& uwep->oartifact != ART_PEN_OF_THE_VOID


### PR DESCRIPTION
Otherwise, weapons have no safe lower limit of enchantment. Unless this was intentional?