### PR TITLE
Replace "poofy" as an adjective

### DIFF
--- a/src/shk.c
+++ b/src/shk.c
@@ -4315,7 +4315,7 @@ const char *Izchak_speaks[]={
     "%s says: 'These shopping malls give me a headache.'",
     "%s says: 'Slow down.  Think clearly.'",
     "%s says: 'You need to take things one at a time.'",
-    "%s says: 'I don't like poofy coffee... give me Columbian Supremo.'",
+    "%s says: 'I don't like wimpy coffee... give me Columbian Supremo.'",
     "%s says that getting the devteam's agreement on anything is difficult.",
     "%s says that he has noticed those who serve their deity will prosper.",
     "%s says: 'Don't try to steal from me - I have friends in high places!'",


### PR DESCRIPTION
Context, from the dnh IRC:
<monstergrin> whoa
<monstergrin> just got an izchak line that says "i don't like poofy coffee"
<monstergrin> that... sucks
<[Demo]> hmm thrown potions dont take monster AC into consideration
<monstergrin> i know nethack isn't exactly a super queer game
<NeroOneTrueKing> "The succubus cajoles you"
<monstergrin> but like... "poofy" is some homophobic shit
<monstergrin> that sucks
<[Demo]> i always thought it was describing the texture of the coffee
<NeroOneTrueKing> I'll make a PR for dnethack to change that line to some other adjective
<monstergrin> thanks nero
<[Demo]> its probably some shit izchak actually said though
<monstergrin> full line: "I don't like poofy coffee - give me my Columbian Supremo"