### PR TITLE
Improved Spell Maintenance

### DIFF
--- a/include/you.h
+++ b/include/you.h
@@ -450,6 +450,7 @@ struct you {
 	uchar	uspmtime;		/* #moves between uspellprot-- */
 	uchar	sowdisc;		/* sowing discord (spirit special attack) */
 	unsigned long long int spells_maintained;
+	int maintained_en_debt;
 	int	uhp,uhpmax,uhp_real,uhpmax_real;
 	int	uen,uenmax,uen_real,uenmax_real;		/* magical energy - M. Stephenson */
 	int ugangr[GA_NUM];			/* if the gods are angry at you */

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1366,7 +1366,7 @@ karemade:
 				u.uen -= reglevel / 100;
 				u.maintained_en_debt -= reglevel / 100;
 				//Now deal with any remainder
-				if (!(moves % (100/((reglevel % 100) + 1) + 2))) {
+				if ((reglevel > 0) && !(moves % (100/((reglevel % 100) + 1) + 2))) {
 					u.uen -= 1;
 					u.maintained_en_debt -= 1;
 				}
@@ -1389,7 +1389,7 @@ karemade:
 					reglevel += uarmh->spe;
 				}
 				reglevel -= u_healing_penalty();
-				reglevel -= 10 + 2 * u.uspellprot;
+				if(u.uspellprot > 0) reglevel -= 10 + 2*u.uspellprot;
 				if(reglevel < 1) reglevel = 1;
 				//recover 1/30th energy per turn:
 				u.uen += reglevel/30;

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1359,6 +1359,20 @@ karemade:
 				}
 		    }
 
+			if (u.uen > 0 || Race_if(PM_INCANTIFIER)){
+				//maintained spells accumulate an energy debt that must be paid over time
+				int reglevel = u.maintained_en_debt;
+				//pay 1/100th energy per turn:
+				u.uen -= reglevel / 100;
+				u.maintained_en_debt -= reglevel / 100;
+				//Now deal with any remainder
+				if (!(moves % (100/((reglevel % 100) + 1) + 2))) {
+					u.uen -= 1;
+					u.maintained_en_debt -= 1;
+				}
+				if (u.uen < 0 && !Race_if(PM_INCANTIFIER))  u.uen = 0;
+				flags.botl = 1;
+			}
 		    if (u.uen < u.uenmax && 
 				wtcap < MOD_ENCUMBER && 
 				!Race_if(PM_INCANTIFIER)
@@ -1375,7 +1389,7 @@ karemade:
 					reglevel += uarmh->spe;
 				}
 				reglevel -= u_healing_penalty();
-				if(u.uspellprot > 0) reglevel -= 10 + 2*u.uspellprot;
+				reglevel -= 10 + 2 * u.uspellprot;
 				if(reglevel < 1) reglevel = 1;
 				//recover 1/30th energy per turn:
 				u.uen += reglevel/30;

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -1547,6 +1547,8 @@ u_init()
 	u.hod = 0;
 	u.daat = 0;
 	u.wardsknown = 0;
+	u.spells_maintained = 0;
+	u.maintained_en_debt = 0;
 	//u.wardsknown = ~0; //~0 should be all 1s, and is therefore debug mode.
 
 #if 0	/* documentation of more zero values as desirable */


### PR DESCRIPTION
Spells will only recast as necessary, costing normal amounts of Pw and hunger.
Pw cost is spread out over a long duration, and so appears as reduced Pw recovery.