### PR TITLE
Update dipping for polying potions, acid

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -2351,9 +2351,16 @@ dodip()
 		pline("That is a potion bottle, not a Klein bottle!");
 		return 0;
 	}
-	//from Slashem
-	if(potion->otyp != POT_WATER && obj->otyp == POT_WATER) {
-	  /* swap roles, to ensure symmetry */
+	//from Slashem, modified
+	if(!(potion->otyp == POT_WATER || potion->otyp == POT_ACID || potion->otyp == POT_POLYMORPH ||
+		(potion->otyp == POT_BLOOD && 
+			(potion->corpsenm == PM_CHAMELEON ||
+			 potion->corpsenm == PM_SMALL_MIMIC ||
+			 potion->corpsenm == PM_LARGE_MIMIC ||
+			 potion->corpsenm == PM_GIANT_MIMIC
+			)
+		)) && obj->otyp == POT_WATER) {
+	  /* swap roles, to ensure symmetry, but don't if the potion is polymorph or acid */
 	  struct obj *otmp = potion;
 	  potion = obj;
 	  obj = otmp;


### PR DESCRIPTION
now, dipping a polymorphing kind of blood (chameleon, mimic), potion of polymorph will always polymorph the potion being dipped into. 
acid will explode if you dip something in it or dip it into something tha'ts not polymorph or (un)holy water.

before, dipping anything into water would dilute as normal, I think acid was wonky but polymorph definitely didn't do what it should