### PR TITLE
Gaze improvements and fixes

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1189,6 +1189,8 @@ E int FDECL(mattacku, (struct monst *));
 E int FDECL(hitmu, (struct monst *,struct attack *));
 E int FDECL(passiveum, (struct permonst *,struct monst *,struct attack *));
 E int FDECL(magic_negation, (struct monst *));
+E int NDECL(randomgaze);
+E int NDECL(elementalgaze);
 E int FDECL(gazemu, (struct monst *,struct attack *));
 E void FDECL(mdamageu, (struct monst *,int));
 E int FDECL(could_seduce, (struct monst *,struct monst *,struct attack *));

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -1094,6 +1094,14 @@ defaultmmhit:
 	return(mdamagem(magr, mdef, mattk));
 }
 
+boolean
+mmetgaze(looker, lookie)
+struct monst *looker;
+struct monst *lookie;
+{
+	return (mon_can_see_mon(looker, lookie) && !(is_blind(looker) || is_blind(lookie)) && !(looker->msleeping || lookie->msleeping));
+}
+
 /* Returns the same values as mdamagem(). */
 int
 gazemm(magr, mdef, mattk)
@@ -1104,24 +1112,35 @@ gazemm(magr, mdef, mattk)
 
 	if(magr->data->maligntyp < 0 && Is_illregrd(&u.uz)) return MM_MISS;
 	
-	if(vis) {
+	if (magr->mcan) return MM_MISS;
+
+	if (vis) {
 		/* the gaze attack of weeping (arch)angels isn't active like others */
 		if (is_weeping(magr->data)) {
 			if (mon_reflects(mdef, (char *)0)) {
 				return (MM_MISS);
-			} else {
-				Sprintf(buf,"%s is staring at", Monnam(magr));
+			}
+			else {
+				Sprintf(buf, "%s is staring at", Monnam(magr));
 				pline("%s %s.", buf, mon_nam(mdef));
 			}
 		}
 	}
 
-	if (magr->mcan || 
-	    (magr->minvis && !perceives(mdef->data)) ||
-	    is_blind(mdef) || mdef->msleeping) {
-	    // if(vis && !is_weeping(magr->data)) pline("but nothing happens.");
-	    return(MM_MISS);
+	if (mattk->aatyp == AT_GAZE){
+		if ((mdef->minvis && !perceives(magr->data))
+			|| is_blind(magr))
+			return MM_MISS;
 	}
+	else if (mattk->aatyp == AT_WDGZ){
+		if ((magr->minvis && !perceives(mdef->data))
+			|| is_blind(mdef) || mdef->msleeping)
+			return MM_MISS;
+	}
+	else {
+		impossible("weird gaze attack type called in gazemm: %d", mattk->aatyp);
+	}
+
 	/* call mon_reflects 2x, first test, then, if visible, print message */
 	if (magr->data == &mons[PM_MEDUSA] && mon_reflects(mdef, (char *)0)) {
 	    if (canseemon(mdef))
@@ -1148,10 +1167,6 @@ gazemm(magr, mdef, mattk)
 			if (magr->mhp > 0) return (MM_MISS);
 			return (MM_AGR_DIED);
 	    }
-	}
-	if (magr->data != &mons[PM_MEDUSA] && is_blind(magr)) {
-	    // if(vis && !is_weeping(magr->data)) pline("but nothing happens.");
-	    return(MM_MISS);
 	}
 
 	return(mdamagem(magr, mdef, mattk));
@@ -1279,6 +1294,7 @@ mdamagem(magr, mdef, mattk)
 	boolean phasearmor = FALSE;
 	boolean weaponhit = (mattk->aatyp == AT_WEAP || mattk->aatyp == AT_XWEP || mattk->aatyp == AT_DEVA || mattk->aatyp == AT_MARI);
 	struct attack alt_attk;
+	int attack_type = (weaponhit) ? AD_PHYS : mattk->adtyp;
 	
 	if(weaponhit && mattk->adtyp != AD_PHYS) tmp = 0;
 	else if(magr->mflee && pa == &mons[PM_BANDERSNATCH]) tmp = d((int)mattk->damn, 2*(int)mattk->damd);
@@ -1324,7 +1340,14 @@ mdamagem(magr, mdef, mattk)
 	armpro = magic_negation(mdef);
 	cancelled = magr->mcan || !((rn2(3) >= armpro) || !rn2(50));
 
-	switch (weaponhit ? AD_PHYS : mattk->adtyp) {
+	if (attack_type == AD_RGAZ){
+		attack_type = randomgaze();
+	}
+	else if (attack_type == AD_RETR){
+		attack_type = elementalgaze();
+	}
+
+	switch (attack_type) {
 	    case AD_DGST:
 		/* eating a Rider or its corpse is fatal */
 		if (is_rider(mdef->data)) {
@@ -1373,17 +1396,21 @@ mdamagem(magr, mdef, mattk)
 		break;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	    case AD_STUN:
-		if (magr->mcan) break;
-		if(mattk->aatyp == AT_GAZE){
-			if(canseemon(magr)){
-				Sprintf(buf,"%s gazes at", Monnam(magr));
-				pline("%s %s...", buf, mon_nam(mdef));
-			}
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
 			tmp = 0;
+		if (magr->mcan || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr,mdef)))
+			break;
+		if (canseemon(magr)){
+			if (mattk->aatyp == AT_GAZE)
+				Sprintf(buf, "from %s gaze", s_suffix(mon_nam(magr)));	// gaze stun is assumed to be eye-contact
+			else if (mattk->aatyp == AT_WDGZ)
+				Sprintf(buf, "under %s gaze", s_suffix(mon_nam(magr)));	// gaze stun is assumed to be eye-contact
 		}
+		else
+			Sprintf(buf, "for a moment");
 		if (canseemon(mdef))
-		    pline("%s %s for a moment.", Monnam(mdef),
-			  makeplural(stagger(mdef->data, "stagger")));
+		    pline("%s %s %s.", Monnam(mdef),
+			  makeplural(stagger(mdef->data, "stagger")), buf);
 		mdef->mstun = 1;
 		goto physical;
 	    case AD_LEGS:
@@ -1596,9 +1623,13 @@ physical:{
 		    tmp = 0;
 		    break;
 		}
-		if(canseemon(magr) && mattk->aatyp == AT_GAZE){
-			Sprintf(buf,"%s gazes at", Monnam(magr));
-			pline("%s %s...", buf, mon_nam(mdef));
+		if(canseemon(magr)){
+			Sprintf(buf, "%s", Monnam(magr));
+			if (mattk->aatyp == AT_GAZE){
+				pline("%s gazes at %s...", buf, mon_nam(mdef));
+			}
+			else if (mattk->aatyp == AT_WDGZ)
+				pline("%s can see %s...", buf, mon_nam(magr));
 		}
 		if (vis)
 		    pline("%s is %s!", Monnam(mdef),
@@ -1637,14 +1668,19 @@ physical:{
 		break;
 /////////////////////////////////////////////////
 		case AD_STDY:
-			if(canseemon(magr) && mattk->aatyp == AT_GAZE){
-				Sprintf(buf,"%s studies", Monnam(magr));
+		if (magr->mcan || is_blind(magr)){
+			tmp = 0;
+			break;
+		}
+		if (tmp > mdef->mstdy){
+			mdef->mstdy = max(tmp, mdef->mstdy);
+
+			if (canseemon(magr) && (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)){
+				Sprintf(buf, "%s studies", Monnam(magr));
 				pline("%s %s intently.", buf, mon_nam(mdef));
 			}
-			if (!magr->mcan && !is_blind(magr)) {
-				mdef->mstdy = max(tmp,mdef->mstdy);
-			}
-			tmp = 0;
+		}
+		tmp = 0;
 		break;
 /////////////////////////////////////////////////
 	    case AD_COLD:
@@ -1653,9 +1689,13 @@ physical:{
 		    tmp = 0;
 		    break;
 		}
-		if(canseemon(magr) && mattk->aatyp == AT_GAZE){
-			Sprintf(buf,"%s gazes at", Monnam(magr));
-			pline("%s %s...", buf, mon_nam(mdef));
+		if (canseemon(magr)){
+			Sprintf(buf, "%s", Monnam(magr));
+			if (mattk->aatyp == AT_GAZE){
+				pline("%s gazes at %s...", buf, mon_nam(mdef));
+			}
+			else if (mattk->aatyp == AT_WDGZ)
+				pline("%s can see %s...", buf, mon_nam(magr));
 		}
 		if (vis) pline("%s is covered in frost!", Monnam(mdef));
 		if (resists_cold(mdef)) {
@@ -1674,9 +1714,13 @@ physical:{
 		    tmp = 0;
 		    break;
 		}
-		if(canseemon(magr) && mattk->aatyp == AT_GAZE){
-			Sprintf(buf,"%s gazes at", Monnam(magr));
-			pline("%s %s...", buf, mon_nam(mdef));
+		if (canseemon(magr)){
+			Sprintf(buf, "%s", Monnam(magr));
+			if (mattk->aatyp == AT_GAZE){
+				pline("%s gazes at %s...", buf, mon_nam(mdef));
+			}
+			else if (mattk->aatyp == AT_WDGZ)
+				pline("%s can see %s...", buf, mon_nam(magr));
 		}
 		if (vis) pline("%s gets zapped!", Monnam(mdef));
 		tmp += destroy_mitem(mdef, WAND_CLASS, AD_ELEC);
@@ -1766,9 +1810,13 @@ physical:{
 		    tmp = 0;
 		    break;
 		}
-		if(canseemon(magr) && mattk->aatyp == AT_GAZE){
-			Sprintf(buf,"%s gazes at", Monnam(magr));
-			pline("%s %s...", buf, mon_nam(mdef));
+		if (canseemon(magr)){
+			Sprintf(buf, "%s", Monnam(magr));
+			if (mattk->aatyp == AT_GAZE){
+				pline("%s gazes at %s...", buf, mon_nam(mdef));
+			}
+			else if (mattk->aatyp == AT_WDGZ)
+				pline("%s can see %s...", buf, mon_nam(magr));
 		}
 		if (resists_acid(mdef)) {
 		    if (vis)
@@ -1822,7 +1870,18 @@ physical:{
 		tmp = 0;
 		break;
 	    case AD_STON:
-		if (magr->mcan) break;
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
+			tmp = 0;
+		if (magr->mcan || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr,mdef)))
+			break;
+		if (canseemon(magr)){
+			Sprintf(buf, "%s", Monnam(magr));
+			if (mattk->aatyp == AT_GAZE){
+				pline("%s gazes at %s...", buf, mon_nam(mdef));
+			}
+			else if (mattk->aatyp == AT_WDGZ)
+				pline("%s can see %s...", buf, mon_nam(magr));
+		}
  do_stone:
 		/* may die from the acid if it eats a stone-curing corpse */
 		if (munstone(mdef, FALSE)) goto post_stone;
@@ -1892,21 +1951,23 @@ physical:{
 		}
 		break;
 	    case AD_SLEE:
-		if (!cancelled && !mdef->msleeping &&
-			sleep_monst(mdef, rnd(10), -1)) {
-			if(mattk->aatyp == AT_GAZE){
-				if(canseemon(magr)){
-					Sprintf(buf,"%s gazes at", Monnam(magr));
-					pline("%s %s...", buf, mon_nam(mdef));
-				}
-				tmp = 0;
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
+			tmp = 0;
+		if (cancelled || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr, mdef)))
+			break;
+		if (sleep_monst(mdef, rnd(10), -1)) {
+			if (canseemon(magr)) {
+				if (mattk->aatyp == AT_GAZE)
+					Sprintf(buf, "is put to sleep by %s gaze.", s_suffix(mon_nam(magr)));
+				else if (mattk->aatyp == AT_WDGZ)
+					Sprintf(buf, "is put to sleep under %s gaze.", s_suffix(mon_nam(magr)));	// gaze sleep is assumed to be have an eye-contact component
+				else
+					Sprintf(buf, "is put to sleep by %s.", mon_nam(magr));
 			}
-			else if(mattk->aatyp == AT_WDGZ){
-				tmp = 0;
-			}
-		    if (vis) {
-			Strcpy(buf, Monnam(mdef));
-			pline("%s is put to sleep by %s.", buf, mon_nam(magr));
+			else
+				Sprintf(buf, "falls asleep!");
+		    if (canseemon(mdef)) {
+			pline("%s %s", Monnam(mdef), buf);
 		    }
 		    mdef->mstrategy &= ~STRAT_WAITFORU;
 		    slept_monst(mdef);
@@ -1917,25 +1978,28 @@ physical:{
 		    tmp = 0;
 		    break;
 		}
-		if(mattk->aatyp == AT_GAZE){
-			if(canseemon(magr)){
-				Sprintf(buf,"%s gazes at", Monnam(magr));
-				pline("%s %s...", buf, mon_nam(mdef));
-			}
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
 			tmp = 0;
+		if (cancelled || !mdef->mcanmove || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr, mdef)))
+			break;
+
+		if (canseemon(magr)) {
+			if (mattk->aatyp == AT_GAZE)
+				Sprintf(buf, "is frozen by %s gaze.", s_suffix(mon_nam(magr)));
+			else if (mattk->aatyp == AT_WDGZ)
+				Sprintf(buf, "is frozen under %s gaze.", s_suffix(mon_nam(magr)));	// gaze paralysis is assumed to be have an eye-contact component
+			else
+				Sprintf(buf, "is frozen by %s.", mon_nam(magr));
 		}
-		else if(mattk->aatyp == AT_WDGZ){
-			tmp = 0;
+		else
+			Sprintf(buf, "freezes!");
+
+		if (canseemon(mdef)) {
+			pline("%s %s", Monnam(mdef), buf);
 		}
-		if(!cancelled && mdef->mcanmove) {
-		    if (vis) {
-			Strcpy(buf, Monnam(mdef));
-			pline("%s is frozen by %s.", buf, mon_nam(magr));
-		    }
-		    mdef->mcanmove = 0;
-		    mdef->mfrozen = rnd(10);
-		    mdef->mstrategy &= ~STRAT_WAITFORU;
-		}
+		mdef->mcanmove = 0;
+		mdef->mfrozen = rnd(10);
+		mdef->mstrategy &= ~STRAT_WAITFORU;
 		break;
 	    case AD_TCKL:
 		if (is_weeping(mdef->data)) {
@@ -1957,24 +2021,28 @@ physical:{
 		    tmp = 0;
 		    break;
 		}
-		if(mattk->aatyp == AT_GAZE){
-			if(canseemon(magr)){
-				Sprintf(buf,"%s gazes at", Monnam(magr));
-				pline("%s %s...", buf, mon_nam(mdef));
-			}
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
 			tmp = 0;
-		}
-		else if(mattk->aatyp == AT_WDGZ){
-			tmp = 0;
-		}
-		if (!cancelled && mdef->mspeed != MSLOW) {
-		    unsigned int oldspeed = mdef->mspeed;
+		if (cancelled || mdef->mspeed == MSLOW || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr, mdef)))
+			break;
 
-		    mon_adjust_speed(mdef, -1, (struct obj *)0);
-		    mdef->mstrategy &= ~STRAT_WAITFORU;
-		    if (mdef->mspeed != oldspeed && vis)
-			pline("%s slows down.", Monnam(mdef));
+		if (canseemon(magr)) {
+			if (mattk->aatyp == AT_GAZE)
+				Sprintf(buf, "is slowed by %s gaze.", s_suffix(mon_nam(magr)));
+			else if (mattk->aatyp == AT_WDGZ)
+				Sprintf(buf, "is slowed under %s gaze.", s_suffix(mon_nam(magr)));	// gaze slow is assumed to be have an eye-contact component
+			else
+				Sprintf(buf, "is slowed by %s.", mon_nam(magr));
 		}
+		else
+			Sprintf(buf, "slows down.");
+
+		unsigned int oldspeed = mdef->mspeed;
+
+		mon_adjust_speed(mdef, -1, (struct obj *)0);
+		mdef->mstrategy &= ~STRAT_WAITFORU;
+		if (mdef->mspeed != oldspeed && canseemon(mdef))
+			pline("%s %s", Monnam(mdef), buf);
 		break;
 	    case AD_LUCK: 
 		/* Luck drain only makes sense for the player, so let's make 
@@ -1984,44 +2052,69 @@ physical:{
 		 * limit, setting spec_used would not really be right (though
 		 * we still should check for it).
 		 */
-		if(mattk->aatyp == AT_GAZE){
-			if(canseemon(magr)){
-				Sprintf(buf,"%s gazes at", Monnam(magr));
-				pline("%s %s...", buf, mon_nam(mdef));
-			}
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
 			tmp = 0;
+		if (magr->mcan || mdef->mconf || magr->mspec_used || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr, mdef)))
+			break;
+		
+		if (canseemon(magr)) {
+			if (mattk->aatyp == AT_GAZE)
+				Sprintf(buf, "is confused by %s gaze.", s_suffix(mon_nam(magr)));
+			else if (mattk->aatyp == AT_WDGZ)
+				Sprintf(buf, "is confused under %s gaze.", s_suffix(mon_nam(magr)));	// gaze confuse is assumed to be have an eye-contact component
+			else
+				Sprintf(buf, "looks confused.");
 		}
-		else if(mattk->aatyp == AT_WDGZ){
-			tmp = 0;
-		}
-		if (!magr->mcan && !mdef->mconf && !magr->mspec_used) {
-		    if (vis) pline("%s looks confused.", Monnam(mdef));
-		    mdef->mconf = 1;
-		    mdef->mstrategy &= ~STRAT_WAITFORU;
-		}
+		else
+			Sprintf(buf, "looks confused.");
+
+		if (canseemon(mdef))
+			pline("%s %s", Monnam(mdef), buf);
+
+		mdef->mconf = 1;
+		mdef->mstrategy &= ~STRAT_WAITFORU;
 		break;
 	    case AD_BLND:
-		if(mattk->aatyp == AT_GAZE){
-			if(canseemon(magr)){
-				Sprintf(buf,"%s gazes at", Monnam(magr));
-				pline("%s %s...", buf, mon_nam(mdef));
-			}
+		if (mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ)
 			tmp = 0;
-		}
-		else if(mattk->aatyp == AT_WDGZ){
-			tmp = 0;
-		}
-		if (can_blnd(magr, mdef, mattk->aatyp, (struct obj*)0)) {
-		    register unsigned rnd_tmp;
+		if (!(can_blnd(magr, mdef, mattk->aatyp, (struct obj*)0)) || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !(mmetgaze(magr, mdef) || is_angel(magr->data))))
+			break;
 
-		    if (vis && !is_blind(mdef))
-			pline("%s is blinded.", Monnam(mdef));
-		    rnd_tmp = d((int)mattk->damn, (int)mattk->damd);
-		    if ((rnd_tmp += mdef->mblinded) > 127) rnd_tmp = 127;
-		    mdef->mblinded = rnd_tmp;
-		    mdef->mcansee = 0;
-		    mdef->mstrategy &= ~STRAT_WAITFORU;
+		if (is_angel(magr->data)){
+			if (canseemon(magr))
+				Sprintf(buf, "is blinded by %s radiance!", s_suffix(mon_nam(magr)));
+			else
+				Sprintf(buf, "is blinded!");
 		}
+		else{
+			if (canseemon(magr)) {
+				if (mattk->aatyp == AT_GAZE)
+					Sprintf(buf, "is blinded by %s gaze.", s_suffix(mon_nam(magr)));
+				else if (mattk->aatyp == AT_WDGZ)
+					Sprintf(buf, "is blinded under %s gaze.", s_suffix(mon_nam(magr))); // non-angelic gaze blind is assumed to be have an eye-contact component
+				else
+					Sprintf(buf, "is blinded by %s.", mon_nam(magr));
+			}
+			else
+				Sprintf(buf, "is blinded!");
+		}
+
+		if (canseemon(mdef) && !is_blind(mdef))
+			pline("%s %s", Monnam(mdef), buf);
+
+		register unsigned rnd_tmp;
+		rnd_tmp = d((int)mattk->damn, (int)mattk->damd);
+		if ((rnd_tmp += mdef->mblinded) > 127) rnd_tmp = 127;
+		mdef->mblinded = rnd_tmp;
+		mdef->mcansee = 0;
+		mdef->mstrategy &= ~STRAT_WAITFORU;
+
+		if (is_angel(magr->data) && !mdef->mstun){	// angelic blinding also stuns
+			if (canseemon(mdef))
+				pline("%s %s.", Monnam(mdef), makeplural(stagger(mdef->data, "stagger")));
+			mdef->mstun = 1;
+		}
+
 		tmp = 0;
 		break;
 	    case AD_BLNK:
@@ -2038,20 +2131,26 @@ physical:{
 		}
 		break;
 	    case AD_HALU:
-		if (!magr->mcan && haseyes(pd) && !is_blind(mdef)) {
-			if(mattk->aatyp == AT_GAZE){
-				if(canseemon(magr)){
-					Sprintf(buf,"%s gazes at", Monnam(magr));
-					pline("%s %s...", buf, mon_nam(mdef));
-				}
-				tmp = 0;
-			}
-		    if (vis) pline("%s looks %sconfused.",
-				    Monnam(mdef), mdef->mconf ? "more " : "");
-		    mdef->mconf = 1;
-		    mdef->mstrategy &= ~STRAT_WAITFORU;
-		}
 		tmp = 0;
+		if (magr->mcan || !haseyes(pd) || ((mattk->aatyp == AT_GAZE || mattk->aatyp == AT_WDGZ) && !mmetgaze(magr, mdef)))
+			break;
+
+		if (canseemon(magr)) {
+			if (mattk->aatyp == AT_GAZE)
+				Sprintf(buf, "looks %sconfused by %s gaze.", mdef->mconf ? "more " : "", s_suffix(mon_nam(magr)));
+			else if (mattk->aatyp == AT_WDGZ)
+				Sprintf(buf, "looks %sconfused under %s gaze.", mdef->mconf ? "more " : "", s_suffix(mon_nam(magr)));	// gaze halu is assumed to be have an eye-contact component
+			else
+				Sprintf(buf, "looks %sconfused.", mdef->mconf ? "more " : "");
+		}
+		else
+			Sprintf(buf, "looks %sconfused.", mdef->mconf ? "more " : "");
+
+		if (canseemon(mdef))
+			pline("%s %s", Monnam(mdef), buf);
+
+		mdef->mconf = 1;
+		mdef->mstrategy &= ~STRAT_WAITFORU;
 		break;
 	    case AD_CURS:
 		if (!night() && (pa == &mons[PM_GREMLIN])) break;

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -36,11 +36,7 @@ STATIC_DCL void FDECL(wildmiss, (struct monst *,struct attack *));
 
 STATIC_DCL void FDECL(hurtarmor,(int));
 STATIC_DCL void FDECL(hitmsg,(struct monst *,struct attack *));
-
-static const int gazeattacks[] = {AD_DEAD, AD_CNCL, AD_PLYS, AD_DRLI, AD_ENCH, AD_STON, AD_LUCK,
-										AD_CONF, AD_SLOW, AD_STUN, AD_BLND, AD_FIRE, AD_FIRE,
-										AD_COLD, AD_COLD, AD_ELEC, AD_ELEC, AD_HALU, AD_SLEE };
-static const int elementalgaze[] = {AD_FIRE,AD_COLD,AD_ELEC};
+STATIC_DCL boolean FDECL(umetgaze, (struct monst *));
 
 /* See comment in mhitm.c.  If we use this a lot it probably should be */
 /* changed to a parameter to mhitu. */
@@ -4213,6 +4209,29 @@ common:
 }
 
 int
+randomgaze()
+{
+	static const int gazeattacks[] = { AD_DEAD, AD_CNCL, AD_PLYS, AD_DRLI, AD_ENCH, AD_STON, AD_LUCK,
+		AD_CONF, AD_SLOW, AD_STUN, AD_BLND, AD_FIRE, AD_FIRE,
+		AD_COLD, AD_COLD, AD_ELEC, AD_ELEC, AD_HALU, AD_SLEE };
+	return gazeattacks[rn2(SIZE(gazeattacks))];	//flat random member of gazeattacks
+}
+
+int
+elementalgaze()
+{
+	static const int gazeattacks[] = { AD_FIRE, AD_COLD, AD_ELEC };
+	return gazeattacks[rn2(SIZE(gazeattacks))];	//flat random member of gazeattacks
+}
+
+boolean
+umetgaze(mtmp)
+struct monst *mtmp;
+{
+	return (canseemon_eyes(mtmp) && couldsee(mtmp->mx, mtmp->my) && !(ublindf && ublindf->oartifact == ART_EYES_OF_THE_OVERWORLD));
+}
+
+int
 gazemu(mtmp, mattk)	/* monster gazes at you */
 	register struct monst *mtmp;
 	register struct attack  *mattk;
@@ -4221,14 +4240,15 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 	int attack_type = mattk->adtyp;
 	struct	permonst *mdat = mtmp->data;
 	char buf[BUFSZ];
+
 	if(mtmp->data->maligntyp < 0 && Is_illregrd(&u.uz)) return 0;
 	if(ward_at(u.ux,u.uy) == HAMSA) return 0;
-	if(ublindf && ublindf->oartifact == ART_EYES_OF_THE_OVERWORLD) return 0;
+	//if(ublindf && ublindf->oartifact == ART_EYES_OF_THE_OVERWORLD) return 0;
 	if(mattk->adtyp == AD_RGAZ){
-		attack_type = gazeattacks[rn2(SIZE(gazeattacks))];	//flat random member of gazeattacks
+		attack_type = randomgaze();
 	}
 	else if(mattk->adtyp == AD_RETR){
-		attack_type = elementalgaze[rn2(SIZE(elementalgaze))];	//flat random member of elementalgaze
+		attack_type = elementalgaze();
 	}
 	switch(attack_type) {
 //ifdef SEDUCE
@@ -4240,7 +4260,8 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			break;
 				if(could_seduce(mtmp, &youmonst, mattk) == 1
 					&& !mtmp->mcan
-					&& !Blind && !is_blind(mtmp) && canseemon(mtmp)
+					&& !is_blind(mtmp)
+					&&  umetgaze(mtmp)
 					&& 	distu(mtmp->mx,mtmp->my) == 1) 
 						if (doseduce(mtmp))
 								return 3;
@@ -4254,9 +4275,8 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 				if(u.sealsActive&SEAL_ANDROMALIUS) break;
 				if(distu(mtmp->mx,mtmp->my) > 1 ||
 					mtmp->mcan ||
-					Blind ||
-					is_blind(mtmp) ||
-					!canseemon(mtmp) 
+					!umetgaze(mtmp) ||
+					is_blind(mtmp)
 				) return 0;//fail
 				//else
 				if(mdat == &mons[PM_DEMOGORGON]){
@@ -4317,8 +4337,8 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			}
 			break;
 			case AD_DEAD:
-			   if(!Blind && !is_blind(mtmp) && canseemon(mtmp)){
-				pline("Oh no, %s's using the gaze of death!", mhe(mtmp));
+			   if(!is_blind(mtmp) && umetgaze(mtmp)){
+				pline("Oh no, you meet %s's gaze of death!", s_suffix(mon_nam(mtmp)));
 				if (nonliving(youracedata) || is_demon(youracedata)) {
 				    You("seem no deader than before.");
 				} else if (!Antimagic && !(u.sealsActive&SEAL_OSE)) {
@@ -4337,15 +4357,22 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			   }
 			break;
 		case AD_CNCL:
-			if(!is_blind(mtmp) && couldsee(mtmp->mx, mtmp->my)){
-				pline("Your magic fades.");
-				(void) cancel_monst(&youmonst, mksobj(SPE_CANCELLATION, FALSE, FALSE), FALSE, TRUE, FALSE,!rn2(4) ? rnd(mtmp->m_lev) : 0);
+			if (!is_blind(mtmp) && couldsee(mtmp->mx, mtmp->my) &&
+					cancel_monst(&youmonst, mksobj(SPE_CANCELLATION, FALSE, FALSE), FALSE, TRUE, FALSE, !rn2(4) ? rnd(mtmp->m_lev) : 0)){
+
+				if (!Blind && canseemon(mtmp))
+				{
+					pline("%s stares at you.", Monnam(mtmp));
+					pline("Your magic fades.");
+				}
+				else
+					You_feel("your magic fade.");
 				succeeded=1;
 			}
 		break;
 	    case AD_PLYS:
 		if(mtmp->data == &mons[PM_DEMOGORGON]){
-		  if(!Blind && !is_blind(mtmp) && canseemon(mtmp)){
+		  if(!is_blind(mtmp) && umetgaze(mtmp)){
 			if((!Free_action || rn2(2)) && (!Sleep_resistance || rn2(4))){
 				You("meet the gaze of Aameul, left head of Demogorgon!");
 				You("are mesmerized!");
@@ -4360,8 +4387,8 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		   }
 		 //else succeeded = 0
 		}
-		else if (!mtmp->mcan && multi >= 0 && !rn2(3) && !is_blind(mtmp) && canseemon(mtmp)) {
-		    if (Blind || Free_action ) {
+		else if (!mtmp->mcan && multi >= 0 && !rn2(3) && !is_blind(mtmp) && umetgaze(mtmp)) {
+		    if (Free_action) {
 				You("momentarily stiffen.");
 				succeeded=0;
 		    }
@@ -4376,7 +4403,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		break;
 		case AD_DRLI:
 			if(mtmp->data == &mons[PM_DEMOGORGON]){
-			  if(!Blind && !is_blind(mtmp) && canseemon(mtmp)){
+			  if(!is_blind(mtmp) && umetgaze(mtmp)){
 				if(!Drain_resistance || !rn2(3)){
 					You("meet the gaze of Hethradiah, right head of Demogorgon!");
 					You("feel a primal darkness fall upon your soul!");
@@ -4394,9 +4421,11 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			   }
 			  //else succeeded = 0
 			}
-			else if (!mtmp->mcan && !rn2(3) && !Drain_resistance 
-						&& !is_blind(mtmp) && canseemon(mtmp)) {
-				You("feel your life force whither before the gaze of %s!", mon_nam(mtmp));
+			else if (!mtmp->mcan && !rn2(3) && !Drain_resistance && !is_blind(mtmp)) {
+				if (!Blind && canseemon(mtmp))
+					You("feel your life force wither before the gaze of %s!", mon_nam(mtmp));
+				else
+					You("feel your life force wither!");
 			    losexp("life force drain",TRUE,FALSE,FALSE);
 //				forget(10);
 				succeeded=1;
@@ -4404,9 +4433,10 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		break;
 		case AD_ENCH:
 			if(mtmp->data == &mons[PM_DEMOGORGON]){
-			 if(!Blind && !is_blind(mtmp) && canseemon(mtmp)){
+			 if(!is_blind(mtmp) && umetgaze(mtmp)){
 				struct obj *obj = some_armor(&youmonst);
 			    if (drain_item(obj)) {
+					You("meet Demogorgon's gaze!");
 					Your("%s less effective.", aobjnam(obj, "seem"));
 			    }
 				succeeded=1;
@@ -4414,6 +4444,10 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			} else if (!mtmp->mcan && !rn2(4) && !is_blind(mtmp) && couldsee(mtmp->mx, mtmp->my)) {
 				struct obj *obj = some_armor(&youmonst);
 			    if (drain_item(obj)) {
+					if (!Blind && canseemon(mtmp))
+						pline("%s stares at you.", Monnam(mtmp));
+					else
+						You_feel("watched.");
 					Your("%s less effective.", aobjnam(obj, "seem"));
 			    }
 				succeeded=1;
@@ -4451,9 +4485,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 				if (mtmp->mhp > 0) break;
 				return 2;
 			}
-			if (canseemon_eyes(mtmp) && couldsee(mtmp->mx, mtmp->my) &&
-				!Stone_resistance
-			) {
+			if (umetgaze(mtmp) && !Stone_resistance) {
 				You("see %s.", mon_nam(mtmp));
 				stop_occupation();
 				if(poly_when_stoned(youracedata) && polymon(PM_STONE_GOLEM)) break;
@@ -4495,6 +4527,10 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			}
 			if (couldsee(mtmp->mx, mtmp->my) &&
 				!Stone_resistance) {
+				if (ublindf && ublindf->oartifact == ART_EYES_OF_THE_OVERWORLD) {
+					Your("lenses block out your sight!");
+					break;
+				}
 				You("see the truth behind the veil!");
 				stop_occupation();
 				if(poly_when_stoned(youracedata) && polymon(PM_STONE_GOLEM))
@@ -4507,9 +4543,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			return 0;
 		}
 		else if (mtmp->data == &mons[PM_BEHOLDER]){
-			if(canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my) &&
-				!Stone_resistance
-			) {
+			if(umetgaze(mtmp) && !Stone_resistance) {
 				You("meet %s gaze.", s_suffix(mon_nam(mtmp)));
 				stop_occupation();
 				if(poly_when_stoned(youracedata) && polymon(PM_STONE_GOLEM)) break;
@@ -4518,9 +4552,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 				killer_format = KILLED_BY;
 			}
 		} else {
-			if (canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my) &&
-				!Stone_resistance
-			) {
+			if (umetgaze(mtmp) && !Stone_resistance) {
 				You("meet %s gaze.", s_suffix(mon_nam(mtmp)));
 				stop_occupation();
 				if(poly_when_stoned(youracedata) && polymon(PM_STONE_GOLEM)) break;
@@ -4532,8 +4564,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 	    case AD_CONF:
-		if(!mtmp->mcan && canseemon(mtmp) &&
-		   couldsee(mtmp->mx, mtmp->my) &&
+		if(!mtmp->mcan && umetgaze(mtmp) &&
 		   !is_blind(mtmp) && !mtmp->mspec_used && rn2(5)) {
 		    int conf;
 			if((int)mattk->damn == 0 || (int)mattk->damd == 0) 
@@ -4552,8 +4583,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 		case AD_SLOW:
-		if(!mtmp->mcan && canseemon(mtmp) &&
-		   couldsee(mtmp->mx, mtmp->my) &&
+		if(!mtmp->mcan && umetgaze(mtmp) &&
 		   !is_blind(mtmp) && !mtmp->mspec_used && rn2(5)) {
 			pline("%s stares piercingly at you!", Monnam(mtmp));
 			u_slow_down();
@@ -4563,8 +4593,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 	    case AD_STUN:
-		if(!mtmp->mcan && canseemon(mtmp) &&
-		   couldsee(mtmp->mx, mtmp->my) &&
+		if(!mtmp->mcan && umetgaze(mtmp) &&
 		   !is_blind(mtmp) && !mtmp->mspec_used && rn2(5)) {
 		    int stun = d(2,6);
 
@@ -4576,21 +4605,27 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 	    case AD_BLND:
-		if (!mtmp->mcan && canseemon(mtmp) && !resists_blnd(&youmonst)
-			&& distu(mtmp->mx,mtmp->my) <= BOLT_LIM*BOLT_LIM) {
-		    int blnd = d((int)mattk->damn, (int)mattk->damd);
+		if (!mtmp->mcan && canseemon(mtmp) && !resists_blnd(&youmonst)) {
+			// assumes that angels with AD_BLND have a blinding radiance
+			if (is_angel(mtmp->data) && distu(mtmp->mx, mtmp->my) <= BOLT_LIM*BOLT_LIM)
+			{
+				int blnd = d((int)mattk->damn, (int)mattk->damd);
 
-		    You("are blinded by %s radiance!",
-			              s_suffix(mon_nam(mtmp)));
-		    make_blinded((long)blnd,FALSE);
-		    stop_occupation();
-		    /* not blind at this point implies you're wearing
-		       the Eyes of the Overworld; make them block this
-		       particular stun attack too */
-		    if (!Blind) Your1(vision_clears);
-		    else make_stunned((long)d(1,3),TRUE);
-			succeeded=1;
+				You("are blinded by %s radiance!", s_suffix(mon_nam(mtmp)));
+				make_blinded((long)blnd, FALSE);
+				stop_occupation();
+				make_stunned((long)d(1, 3), TRUE);
+				succeeded = 1;
+			} else if (umetgaze(mtmp))	// any others are a blinding gaze attack
+			{
+				int blnd = d((int)mattk->damn, (int)mattk->damd);
+
+				You("are blinded by %s gaze!", s_suffix(mon_nam(mtmp)));
+				make_blinded((long)blnd, FALSE);
+				stop_occupation();
+			}
 		}
+		    
 		break;
 	    case AD_SSUN:
 		if (!mtmp->mcan && couldsee(mtmp->mx, mtmp->my) &&
@@ -4702,8 +4737,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 	    case AD_BLNK:
-		if (!mtmp->mcan && canseemon(mtmp) &&
-			couldsee(mtmp->mx, mtmp->my) &&
+		if (!mtmp->mcan && umetgaze(mtmp) &&
 			!is_blind(mtmp) && !mtmp->mspec_used && rn2(5)
 		) {
 		    int dmg = d(1,4);
@@ -4734,8 +4768,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 		case AD_HALU:
-		if (!mtmp->mcan && canseemon(mtmp) &&
-			couldsee(mtmp->mx, mtmp->my) &&
+		if (!mtmp->mcan && umetgaze(mtmp) &&
 			!is_blind(mtmp) && !mtmp->mspec_used && rn2(5)) {
 			boolean not_affected=0;
 			//int tmp = rn2(12);
@@ -4755,8 +4788,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		}
 		break;
 	    case AD_SLEE:
-			if(!mtmp->mcan && canseemon(mtmp) &&
-			   couldsee(mtmp->mx, mtmp->my) && !is_blind(mtmp) &&
+			if(!mtmp->mcan && umetgaze(mtmp) && !is_blind(mtmp) &&
 			   multi >= 0 && !rn2(5) && !Sleep_resistance) {
 	
 			    fall_asleep(-rnd(10), TRUE);
@@ -4811,8 +4843,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 			}
 		break;
 	    case AD_LUCK:
-		if(!mtmp->mcan && canseemon(mtmp) && 
-			couldsee(mtmp->mx, mtmp->my) && 
+		if(!mtmp->mcan && umetgaze(mtmp) && 
 			!is_blind(mtmp) && !mtmp->mspec_used && rn2(5)) {
 		    pline("%s glares ominously at you!", Monnam(mtmp));
 		    mtmp->mspec_used = mtmp->mspec_used + d(2,6);
@@ -4904,7 +4935,7 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 		break;
 */
 		case AD_WISD:{ //Cthulhu's attack
-			if(canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my) && !mtmp->mspec_used) {
+			if(umetgaze(mtmp) && !mtmp->mspec_used) {
 				int dmg = d((int)mattk->damn, (int)mattk->damd);
 //				if(!couldsee(mtmp->mx, mtmp->my)) dmg /= 10;
 				if(!dmg) break;
@@ -4938,11 +4969,13 @@ gazemu(mtmp, mattk)	/* monster gazes at you */
 				!is_blind(mtmp)
 			) {
 				int dmg = d((int)mattk->damn, (int)mattk->damd);
-				if(is_orc(mtmp->data)) pline("%s curses and urges %s followers on.", Monnam(mtmp), mhis(mtmp));
-				else if(mtmp->data == &mons[PM_LEGION] || mtmp->data == &mons[PM_LEGIONNAIRE]); //no message
-				else if(canseemon(mtmp)) pline("%s studies you with a level stare.", Monnam(mtmp));
-				//else no message
-				u.ustdy = max(dmg,u.ustdy);
+				if (dmg > u.ustdy){	// reduce message spam by only showing when study is actually increased
+					if (is_orc(mtmp->data)) pline("%s curses and urges %s followers on.", Monnam(mtmp), mhis(mtmp));
+					else if (mtmp->data == &mons[PM_LEGION] || mtmp->data == &mons[PM_LEGIONNAIRE]); //no message
+					else if (canseemon(mtmp)) pline("%s studies you with a level stare.", Monnam(mtmp));
+					//else no message
+					u.ustdy = max(dmg, u.ustdy);
+				}
 				dmg = 0;
 			}
 		break;

--- a/src/mon.c
+++ b/src/mon.c
@@ -5072,7 +5072,8 @@ register struct monst *mtmp;
     }
 	for(i = 0; i < NATTK; i++)
 		 if(mtmp->data->mattk[i].aatyp == AT_WDGZ) {
-			 (void) gazemu(mtmp, &mtmp->data->mattk[i]);
+			 if (!(ublindf && ublindf->oartifact == ART_EYES_OF_THE_OVERWORLD))	// the Eyes of the Overworld protect you from whatever you might see
+				(void) gazemu(mtmp, &mtmp->data->mattk[i]);
 		 }
     if(is_weeping(mtmp->data)) {
 		for(i = 0; i < NATTK; i++)

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1000,10 +1000,11 @@ register struct monst *mtmp;
 					) && (dmgtype_fromattack(mtmp->data, AD_CONF, AT_WDGZ)
 						|| dmgtype_fromattack(mtmp->data, AD_WISD, AT_WDGZ)
 					)) continue;
+					/*
 					if(canseemon(mtmp) && canseemon(gazemon)){
 						Sprintf(buf,"%s can see", Monnam(mtmp));
 						pline("%s %s...", buf, mon_nam(gazemon));
-					}
+					}*/
 					(void) gazemm(gazemon, mtmp, &gazemon->data->mattk[i]);
 					break;
 				 }

--- a/src/zap.c
+++ b/src/zap.c
@@ -2611,10 +2611,12 @@ int gaze_cancel;
 			invsize = 0;
 			for (otmp = (youdefend ? invent : mdef->minvent);
 					otmp; otmp = otmp->nobj) invsize++;
-			otmp = (youdefend ? invent : mdef->minvent);
-			for(j=rn2(invsize);j>=0;j--){
-				otmp=otmp->nobj;
-				if(!j) cancel_item(otmp);
+			if (invsize){
+				otmp = (youdefend ? invent : mdef->minvent);
+				for (j = rn2(invsize); j >= 0; j--){
+					if (!j) cancel_item(otmp);
+					otmp = otmp->nobj;
+				}
 			}
 		}
 		


### PR DESCRIPTION
Changes:
Replace generic WDGZ message with specific appropriate ones
Reduce message spam from some gazes
The Eyes of the Overworld only protect you from gazes where being blind would have helped
Changed a few gazes from eye-contact to agr-sees-def
Hopefully made it clear which gazes have what requirements
Hopefully added backend functionality for more AT_WDGZ AD_TYPEs (like study)

Fixes:
beholders can mvm gaze
fix CNCL gaze segfaults