### PR TITLE
Replaced dungeon level variable xchar with int.

### DIFF
--- a/src/dog.c
+++ b/src/dog.c
@@ -813,7 +813,7 @@ boolean pets_only;	/* true for ascension or final escape */
 void
 migrate_to_level(mtmp, tolev, xyloc, cc)
 	register struct monst *mtmp;
-	xchar tolev;	/* destination level */
+	int tolev;	/* destination level */
 	xchar xyloc;	/* MIGR_xxx destination xy location: */
 	coord *cc;	/* optional destination coordinates */
 {
@@ -849,8 +849,8 @@ migrate_to_level(mtmp, tolev, xyloc, cc)
 	migrating_mons = mtmp;
 	newsym(mtmp->mx,mtmp->my);
 
-	new_lev.dnum = ledger_to_dnum((xchar)tolev);
-	new_lev.dlevel = ledger_to_dlev((xchar)tolev);
+	new_lev.dnum = ledger_to_dnum(tolev);
+	new_lev.dlevel = ledger_to_dlev(tolev);
 	/* overload mtmp->[mx,my], mtmp->[mux,muy], and mtmp->mtrack[] as */
 	/* destination codes (setup flag bits before altering mx or my) */
 	xyflags = (depth(&new_lev) < depth(&u.uz));	/* 1 => up */


### PR DESCRIPTION
Was somehow missed in the original dungeon expansion patch,
theoretically could lead to crashes with pets, Illurien, or the wizard.