### PR TITLE
Elder Brain mind-blasts change

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1188,9 +1188,25 @@ register struct monst *mtmp;
 				dmg = (mdat == &mons[PM_GREAT_CTHULHU] || mdat == &mons[PM_LUGRIBOSSK] || mdat == &mons[PM_MAANZECORIAN]) ? d(5,15) : (mdat == &mons[PM_ELDER_BRAIN]) ? d(3,15) : rnd(15);
 				if (Half_spell_damage) dmg = (dmg+1) / 2;
 				losehp(dmg, "psychic blast", KILLED_BY_AN);
-				if(mdat == &mons[PM_ELDER_BRAIN]) u.ustdy = max(u.ustdy,dmg/3);
 				if(mdat == &mons[PM_SEMBLANCE]) make_hallucinated(HHallucination + dmg, FALSE, 0L);
 				if(mdat == &mons[PM_GREAT_CTHULHU]) make_stunned(HStun + dmg*10, TRUE);
+				if (mdat == &mons[PM_ELDER_BRAIN]) {
+					for (m2 = fmon; m2; m2 = nmon) {
+						nmon = m2->nmon;
+						if (!DEADMONSTER(m2) && (m2->mpeaceful == mtmp->mpeaceful) && telepathic(m2->data) && (m2!=mtmp))
+						{
+							m2->msleeping = 0;
+							if (!m2->mcanmove && !rn2(5)) {
+								m2->mfrozen = 0;
+								if (m2->data != &mons[PM_GIANT_TURTLE] || !(m2->mflee))
+									m2->mcanmove = 1;
+							}
+							m2->mux = u.ux;
+							m2->muy = u.uy;
+							m2->encouraged = max(m2->encouraged, dmg / 3);
+						}
+					}
+				}
 			}
 		}
 		for(m2=fmon; m2; m2 = nmon) {


### PR DESCRIPTION
Instead of giving the player study, all telepathic enemies on the level are alerted of your position and given an accuracy & damage boost