### PR TITLE
Fix wishing related to "holy", "unholy"

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2909,11 +2909,9 @@ int wishflags;
 			bodytype = (MB_ANIMAL|MB_SLITHY);
 		} else if(!strncmpi(bp, "snakeneck ", l=10)){
 			bodytype = MB_LONGNECK;
-		} else if (!strncmpi(bp, "blessed ", l=8) ||
-			   (!strncmpi(bp, "holy ", l=5) && strncmpi(bp, "holy moonlight sword", l=20))) {
+		} else if (!strncmpi(bp, "blessed ", l=8)){
 			blessed = 1;
-		} else if (!strncmpi(bp, "cursed ", l=7) ||
-			   !strncmpi(bp, "unholy ", l=7)) {
+		} else if (!strncmpi(bp, "cursed ", l=7)){
 			iscursed = 1;
 		} else if (!strncmpi(bp, "uncursed ", l=9)) {
 			uncursed = 1;
@@ -3175,11 +3173,13 @@ int wishflags;
 		} else if (!strncmpi(bp, "axiomatic ", l=10)
 			) {
 			oproperties |= OPROP_AXIOW;
-		} else if (!strncmpi(bp, "holy ", l=5)
+		} else if (!strncmpi(bp, "holy ", l=5) && strncmpi(bp, "holy moonlight sword", 20)
 			) {
+			blessed = !(uncursed + iscursed);
 			oproperties |= OPROP_HOLYW;
 		} else if (!strncmpi(bp, "unholy ", l=7)
 			) {
+			iscursed = !(uncursed + blessed);
 			oproperties |= OPROP_UNHYW;
 		} else if (!strncmpi(bp, "vorpal ", l=7) && strncmpi(bp, "Vorpal Blade", 12)
 			) {


### PR DESCRIPTION
Bug fixed: wishing for anything "holy" was broken and would fail
Bug fixed: wishing code for "holy" and "unholy" weapon props would not be reached

Patched behaviour:
In addition to weapon properties, wishing for a "holy" item will also act as wishing for a "blessed" item, unless specified otherwise prior in the string. Same for "unholy", and "cursed". Thus, wishing for an "uncursed holy dagger" will yield a holy-property dagger with an uncursed BUC.
Note that wizard-mode wishes will force object properties, so a wizard-mode test of wishing for a "holy spellbook of remove curse" will have a different result for a real wish with the same wording.