### PR TITLE
Curses 201906

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -668,6 +668,7 @@ E struct _plinemsg *pline_msg;
 #define MSGTYP_NOREP   1
 #define MSGTYP_NOSHOW  2
 #define MSGTYP_STOP    3
+#define MSGTYP_ALERT   4
 
 
 /* FIXME: These should be integrated into objclass and permonst structs,

--- a/include/flag.h
+++ b/include/flag.h
@@ -410,6 +410,9 @@ struct instance_flags {
 #ifdef REALTIME_ON_BOTL
   boolean  showrealtime; /* show actual elapsed time */
 #endif
+  boolean msg_is_alert; /* suggest windowport should grab player's attention
+                         * and request <TAB> acknowlegement */
+
 };
 
 /*

--- a/src/files.c
+++ b/src/files.c
@@ -2002,6 +2002,8 @@ char		*tmp_levels;
 		else if (!strcasecmp("noshow", msgtype)) typ = MSGTYP_NOSHOW;
 		else if (!strcasecmp("more", msgtype)) typ = MSGTYP_STOP;
 		else if (!strcasecmp("stop", msgtype)) typ = MSGTYP_STOP;
+                /* 'alert' will fallback to 'stop' behaviour if windowport does not support it */
+		else if (!strcasecmp("alert", msgtype)) typ = MSGTYP_ALERT;
 		if ((typ != MSGTYP_NORMAL) || !strcasecmp("show", msgtype)) {
 		    msgpline_add(typ, pattern);
 		}

--- a/src/options.c
+++ b/src/options.c
@@ -676,6 +676,7 @@ initoptions()
 #ifdef SORTLOOT
 	iflags.sortloot = 'n';
 #endif
+        iflags.msg_is_alert = FALSE;
 
      /* assert( sizeof flags.inv_order == sizeof def_inv_order ); */
 	(void)memcpy((genericptr_t)flags.inv_order,

--- a/src/pline.c
+++ b/src/pline.c
@@ -156,7 +156,15 @@ pline VA_DECL(const char *, line)
 	if (typ == MSGTYP_NOREP && !strcmp(line, prevmsg)) return;
 	putstr(WIN_MESSAGE, 0, line);
 	strncpy(prevmsg, line, BUFSZ);
-	if (typ == MSGTYP_STOP) display_nhwindow(WIN_MESSAGE, TRUE); /* --more-- */
+	switch (typ) {
+	case MSGTYP_ALERT:
+	    iflags.msg_is_alert = TRUE; /* <TAB> */
+	    /* FT */
+	case MSGTYP_STOP:
+	    display_nhwindow(WIN_MESSAGE, TRUE); /* --more-- */
+	    break;
+	}
+	iflags.msg_is_alert = FALSE;
 }
 
 /*VARARGS1*/

--- a/win/curses/cursdial.c
+++ b/win/curses/cursdial.c
@@ -578,14 +578,14 @@ curses_display_nhmenu(winid wid, int how, MENU_ITEM_P ** _selected)
 
     if (current_menu == NULL) {
         impossible("curses_display_nhmenu: attempt to display nonexistent menu");
-		return '\033';
+        return '\033';
     }
 
     menu_item_ptr = current_menu->entries;
 
     if (menu_item_ptr == NULL) {
         impossible("curses_display_nhmenu: attempt to display empty menu");
-		return '\033';
+        return '\033';
     }
 
     /* Reset items to unselected to clear out selections from previous

--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -134,26 +134,33 @@ curses_message_win_puts(const char *message, boolean recursed)
 
 
 int
-curses_block(boolean require_tab)
+curses_block(boolean noscroll)
+/* noscroll - blocking because of msgtype = stop/alert */
+/* else blocking because window is full, so need to scroll after */
 {
-    int height, width, ret;
+    int height, width, ret = 0;
     WINDOW *win = curses_get_nhwin(MESSAGE_WIN);
+    char *resp = " \n\033"; /* space, enter, esc */
 
     curses_get_window_size(MESSAGE_WIN, &height, &width);
     curses_toggle_color_attr(win, MORECOLOR, NONE, ON);
-    mvwprintw(win, my, mx, require_tab ? "<TAB!>" : ">>");
+    mvwprintw(win, my, mx, iflags.msg_is_alert ? "<TAB!>" : ">>");
     curses_toggle_color_attr(win, MORECOLOR, NONE, OFF);
-    if (require_tab)
+    if (iflags.msg_is_alert)
         curses_alert_main_borders(TRUE);
     wrefresh(win);
-    while ((ret = wgetch(win) != '\t') && require_tab);
-    if (require_tab)
+    while (iflags.msg_is_alert && (ret = wgetch(win) != '\t'));
+    /* msgtype=stop should require space/enter rather than
+     * just any key, as we want to prevent YASD from
+     * riding direction keys. */
+    while (!iflags.msg_is_alert && (ret = wgetch(win)) && !index(resp,(char)ret));
+    if (iflags.msg_is_alert)
         curses_alert_main_borders(FALSE);
     if (height == 1) {
         curses_clear_unhighlight_message_window();
     } else {
         mvwprintw(win, my, mx, "      ");
-        if (!require_tab) {
+        if (noscroll) {
             scroll_window(MESSAGE_WIN);
             turn_lines = 1;
         }

--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -160,7 +160,7 @@ curses_block(boolean noscroll)
         curses_clear_unhighlight_message_window();
     } else {
         mvwprintw(win, my, mx, "      ");
-        if (noscroll) {
+        if (!noscroll) {
             scroll_window(MESSAGE_WIN);
             turn_lines = 1;
         }

--- a/win/tty/topl.c
+++ b/win/tty/topl.c
@@ -188,11 +188,17 @@ more()
 
     if(flags.standout)
 	standoutbeg();
-    putsyms(defmorestr);
-    if(flags.standout)
-	standoutend();
-
-    xwaitforspace("\033 ");
+    if (iflags.msg_is_alert) {
+        term_start_color(CLR_ORANGE);
+        putsyms("<TAB>");
+        term_end_color();
+        xwaitforspace("\t");
+    } else {
+        putsyms(defmorestr);
+        xwaitforspace("\033 ");
+    }
+     if (flags.standout)
+         standoutend();
 
     if(morc == '\033')
 	cw->flags |= WIN_STOP;


### PR DESCRIPTION
Hi Chris.
This PR reverts msgtype=stop behaviour to the regular '>>' prompt in curses, but enforces space, enter, or ESC. to dismiss prompt, rather than any key (the original behaviour, which was dangerous because keystrokes could get out of sequence and messages could be missed).
It introduces msgtype=alert for the <TAB!> prompt behaviour (which will fall through to msgtype=stop behaviour if the windowport does not support alert).
It also adds support for msgtype=alert to the tty windowport.
We've been running this code on hardfought on other variants for some time now.
Cheers
Tangles.