### PR TITLE
Clean up unarmed damage calculation

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2760,6 +2760,7 @@ E int NDECL(dosuspend);
 
 E int FDECL(hitval, (struct obj *,struct monst *));
 E int FDECL(dmgval_core, (struct weapon_dice *, boolean, struct obj *, int));
+E int FDECL(weapon_dmg_roll, (struct attack *, boolean));
 E int FDECL(dmgval, (struct obj *,struct monst *, int));
 E struct obj *FDECL(select_rwep, (struct monst *));
 E struct obj *FDECL(select_hwep, (struct monst *));


### PR DESCRIPTION
Minor functional difference: when the Grandmaster's Robe procs its 2x dice with Eurynome bound, Eurynome's max(2x rnd(5), base-unarmed-dice) uses one roll of 2x rnd(5) twice, instead of rolling 2x rnd(5) twice when taking max(...).

Otherwise, functionally identical and much easier to read.