### PR TITLE
Fix logic on spears as ammo

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -480,7 +480,6 @@ struct weapon_dice {
 			   (ltmp->oartifact == ART_PEN_OF_THE_VOID && ltmp->ovar1&SEAL_EVE) ||\
 			   (ltmp->otyp == MASS_SHADOW_PISTOL && (otmp->otyp == ltmp->cobj->otyp)) ||\
 			   (ltmp->otyp == ATLATL && is_spear(otmp)) ||\
-			   (!ltmp && is_spear(otmp)) ||\
 			   (otmp->objsize == (ltmp)->objsize || objects[(ltmp)->otyp].oc_skill == P_SLING) &&\
 			    (objects[(otmp)->otyp].w_ammotyp & objects[(ltmp)->otyp].w_ammotyp) && \
 			    (objects[(otmp)->otyp].oc_skill == -objects[(ltmp)->otyp].oc_skill))\

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -646,13 +646,13 @@ autoquiver()
 	    } else if (otmp->oclass == GEM_CLASS) {
 		;	/* skip non-rock gems--they're ammo but
 			   player has to select them explicitly */
-	    } else if (is_ammo(otmp) || is_spear(otmp)) {
-		if (ammo_and_launcher(otmp, uwep) || is_spear(otmp))
+	    } else if (ammo_and_launcher(otmp, uwep)) {
 		    /* Ammo matched with launcher (bow and arrow, crossbow and bolt) */
 		    oammo = otmp;
-		else if (ammo_and_launcher(otmp, uswapwep))
+		} else if (ammo_and_launcher(otmp, uswapwep)) {
+			/* Ammo matched with launcher in swapwep */
 		    altammo = otmp;
-		else
+		} else if (is_ammo(otmp)) {
 		    /* Mismatched ammo (no better than an ordinary weapon) */
 		    omisc = otmp;
 	    } else if (is_missile(otmp)) {
@@ -660,7 +660,8 @@ autoquiver()
 		omissile = otmp;
 	    } else if (otmp->oclass == WEAPON_CLASS && throwing_weapon(otmp)) {
 		/* Ordinary weapon */
-		if (objects[otmp->otyp].oc_skill == P_DAGGER
+		if ((objects[otmp->otyp].oc_skill == P_DAGGER ||
+			objects[otmp->otyp].oc_skill == P_SPEAR)
 			&& !omissile) 
 		    omissile = otmp;
 		else
@@ -2227,37 +2228,35 @@ int thrown;
 	else if (obj->oclass == WEAPON_CLASS || is_weptool(obj) ||
 		obj->oclass == GEM_CLASS
 	) {
-	    if (is_ammo(obj) || is_spear(obj)) {
-			if (!ammo_and_launcher(obj, launcher)) {
-				if (is_spear(obj) && launcher->otyp != ATLATL){
-					tmp += 2; // throwing weapon bonus
-				} else {
-					tmp -= 4;
-				}
-			} else {
-				tmp += launcher->spe - greatest_erosion(launcher);
-				tmp += weapon_hit_bonus(launcher);
-				if (launcher->oartifact){
-					tmp += spec_abon(launcher, mon);
-					if(Role_if(PM_BARD)) //legend lore
-						tmp += 5;
-				}
-				/*
-				 * Elves and Samurais are highly trained w/bows,
-				 * especially their own special types of bow.
-				 * Polymorphing won't make you a bow expert.
-				 */
-				if ((Race_if(PM_ELF) || Role_if(PM_SAMURAI)) &&
-					(!Upolyd || your_race(youmonst.data)) &&
-					objects[launcher->otyp].oc_skill == P_BOW) {
-					tmp++;
-					if (Race_if(PM_ELF) && launcher->otyp == ELVEN_BOW)
-						tmp++;
-					else if (Role_if(PM_SAMURAI) && launcher->otyp == YUMI)
-						tmp++;
-		    	}
+		if (ammo_and_launcher(obj, launcher)) {
+			/* ammo and launcher */
+			tmp += launcher->spe - greatest_erosion(launcher);
+			tmp += weapon_hit_bonus(launcher);
+			if (launcher->oartifact){
+				tmp += spec_abon(launcher, mon);
+				if (Role_if(PM_BARD)) //legend lore
+					tmp += 5;
 			}
-	    } else {
+			/*
+			* Elves and Samurais are highly trained w/bows,
+			* especially their own special types of bow.
+			* Polymorphing won't make you a bow expert.
+			*/
+			if ((Race_if(PM_ELF) || Role_if(PM_SAMURAI)) &&
+				(!Upolyd || your_race(youmonst.data)) &&
+				objects[launcher->otyp].oc_skill == P_BOW) {
+				tmp++;
+				if (Race_if(PM_ELF) && launcher->otyp == ELVEN_BOW)
+					tmp++;
+				else if (Role_if(PM_SAMURAI) && launcher->otyp == YUMI)
+					tmp++;
+			}
+		}
+		else if (is_ammo(obj)) {
+			/* ammo without a launcher */
+			tmp -= 4;
+		}
+		else {
 			if (is_boomerang(obj))		/* arbitrary */
 				tmp += 4;
 			else if (throwing_weapon(obj))	/* meant to be thrown */


### PR DESCRIPTION
First, check for valid launcher-ammo pair (which only includes spears when the launcher is valid).
If invalid, check for ammo (which does NOT include spears).
If not ammo, move on.

Also, don't attempt to access launcher if we haven't checked that launcher exists yet. That causes segfaults.