### PR TITLE
Modify Spidersilk

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1157,7 +1157,7 @@ A("Spidersilk",	ELVEN_MITHRIL_COAT, 					0,			0,/*Needs encyc entry*/
 	(SPFX_NOGEN|SPFX_RESTR|SPFX_INTEL),0,
 	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/,
 	NO_ATTK,	NO_DFNS,	NO_CARY, 
-	0,	A_CHAOTIC,	 NON_PM, PM_DROW, 5000L,
+	0,	A_NONE,	 NON_PM, PM_DROW, 5000L,
 	SPFX2_SPELLUP,0,WSFX_PLUSSEV), /*Adds sleep poison to unarmed attacks*/
 
 A("The Webweaver's Crook",	FAUCHARD, 					BONE,		0,/*Needs encyc entry*/

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2218,8 +2218,13 @@ int base_uac()
 		uac -= 10;
 	uac -= u.uuur/2;
 	if(u.edenshield > moves) uac -= 7;
-	if(u.specialSealsActive&SEAL_BLACK_WEB && u.utrap && u.utraptype == TT_WEB)
-		 uac -= 8;
+	if(u.specialSealsActive&SEAL_BLACK_WEB && (
+		(u.utrap && u.utraptype == TT_WEB) ||
+		(t_at(u.ux, u.uy) && t_at(u.ux, u.uy)->ttyp == WEB && 
+			(webmaker(youracedata) || u.sealsActive&SEAL_CHUPOCLOPS || (uarm && uarm->oartifact==ART_SPIDERSILK)))
+	)
+	)
+			 uac -= 8;
 	if(u.specialSealsActive&SEAL_UNKNOWN_GOD && uwep && uwep->oartifact == ART_PEN_OF_THE_VOID) uac -= 2*uwep->spe;
 	if(multi < 0){
 		dexbonus = -5;

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2220,8 +2220,7 @@ int base_uac()
 	if(u.edenshield > moves) uac -= 7;
 	if(u.specialSealsActive&SEAL_BLACK_WEB && (
 		(u.utrap && u.utraptype == TT_WEB) ||
-		(t_at(u.ux, u.uy) && t_at(u.ux, u.uy)->ttyp == WEB && 
-			(webmaker(youracedata) || u.sealsActive&SEAL_CHUPOCLOPS || (uarm && uarm->oartifact==ART_SPIDERSILK)))
+		(t_at(u.ux, u.uy) && t_at(u.ux, u.uy)->ttyp == WEB && (uarm && uarm->oartifact==ART_SPIDERSILK))
 	)
 	)
 			 uac -= 8;

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1111,7 +1111,13 @@ int thrown;
 			/* some artifact gloves give enchantment */
 			if (uarmg && (uarmg->oartifact == ART_PREMIUM_HEART || uarmg->oartifact == ART_GREAT_CLAWS_OF_URDLEN))
 				tmp += uarmg->spe;
-
+			
+			/*Spidersilk grants sleep poisoning*/
+			if (uarm && uarm->oartifact==ART_SPIDERSILK && !rn2(5)){
+				if (resists_sleep(mon))
+					needdrugmsg = TRUE;
+				else if(sleep_monst(mon, rnd(12), ARMOR_CLASS)) druggedmon = TRUE;
+			}
 			/* dahlver nar gives bonus damage*/
 			if (u.specialSealsActive&SEAL_DAHLVER_NAR)
 				tmp += d(2, 6) + min(u.ulevel / 2, (u.uhpmax - u.uhp) / 10);


### PR DESCRIPTION
Spidersilk is now unaligned (to prevent blasting issues) and actually applies sleep poison on an unarmed hit. The drugging chances are the same as a signet ring, but they are applied even if you're wearing gloves.

In addition, the black web's AC is no longer blocked by wearing Spidersilk, since you're already webbed enough.