### PR TITLE
Add the Death-Spear of Vhaerun

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -345,7 +345,8 @@ struct artifact {
 #define WATER           (LAST_PROP+69)
 #define SINGING         (LAST_PROP+70)
 #define WIND_PETS		(LAST_PROP+71)
-#define ORACLE          (LAST_PROP+72)
+#define DEATH_TCH		(LAST_PROP+72)
+#define ORACLE          (LAST_PROP+73)
 
 
 #define MASTERY_ARTIFACT_LEVEL 20

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1334,7 +1334,7 @@ A("The Web of the Chosen",	DROVEN_CLOAK, 				0,			0,/* Drow noble quest */
 	SPFX2_SILVERED,0,0),
 
 A("The Death-Spear of Vhaerun", DROVEN_SPEAR, 					0,			0,/* Hedrow noble first gift */
-	(SPFX_NOGEN|SPFX_RESTR|SPFX_DEFN|SPFX_INTEL|SPFX_DRLI),0,
+	(SPFX_NOGEN|SPFX_RESTR|SPFX_DRLI|SPFX_DEFN|SPFX_INTEL),0,
 	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/, /*Needs encyc entry*/
 	PHYS(10,6),	DFNS(AD_MAGM),	NO_CARY,
 	DEATH_TCH, A_NEUTRAL, PM_NOBLEMAN, PM_DROW, 4000L, 

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1319,7 +1319,7 @@ A("The Armor of Erebor",	PLATE_MAIL, 				0,			0,/*Lonely Mountain dwarf noble */
 
 /*Arkenstone*/ /*Lonely Mountain dwarf noble crown*/
 
-A("The Sceptre of Lolth", KHAKKHARA, 					0,			0,/* Drow noble first gift (hedrow get lordly might) */
+A("The Sceptre of Lolth", KHAKKHARA, 					0,			0,/* Drow noble first gift (hedrow get death-spear) */
 	(SPFX_NOGEN|SPFX_RESTR|SPFX_DEFN|SPFX_INTEL),0,
 	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/, /*Needs encyc entry*/
 	PHYS(1,0),	NO_DFNS,	NO_CARY,
@@ -1332,6 +1332,13 @@ A("The Web of the Chosen",	DROVEN_CLOAK, 				0,			0,/* Drow noble quest */
 	NO_ATTK,	ACID(0,0),	ELEC(0,0), /* Plus double AC bonus */
 	0,	A_CHAOTIC,	 PM_NOBLEMAN, PM_DROW, 2500L,
 	SPFX2_SILVERED,0,0),
+
+A("The Death-Spear of Vhaerun", DROVEN_SPEAR, 					0,			0,/* Hedrow noble first gift */
+	(SPFX_NOGEN|SPFX_RESTR|SPFX_DEFN|SPFX_INTEL|SPFX_DRLI),0,
+	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/, /*Needs encyc entry*/
+	PHYS(10,6),	DFNS(AD_MAGM),	NO_CARY,
+	DEATH_TCH, A_NEUTRAL, PM_NOBLEMAN, PM_DROW, 4000L, 
+	SPFX2_SILVERED,0,0), 
 
 A("The Cloak of the Consort",	DROVEN_CLOAK, 			0,			0,/* Hedrow noble quest */
 	(SPFX_NOGEN|SPFX_RESTR|SPFX_INTEL|SPFX_HPHDAM),0,

--- a/include/obj.h
+++ b/include/obj.h
@@ -458,6 +458,7 @@ struct weapon_dice {
 			  otmp->otyp==AKLYS || \
 			  otmp->oartifact==ART_SOL_VALTIVA || \
 			  otmp->oartifact==ART_SHADOWLOCK || \
+			  otmp->oartifact==ART_DEATH_SPEAR_OF_VHAERUN || \
 			  (otmp->oartifact==ART_PEN_OF_THE_VOID && otmp->ovar1&SEAL_MARIONETTE ) \
 			 ))
 #define is_spear(otmp)	(otmp->oclass == WEAPON_CLASS && \

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -6214,6 +6214,21 @@ arti_invoke(obj)
 				}
 			}
 		break;
+		case DEATH_TCH:
+			getdir((char *)0);
+			if (!isok(u.ux + u.dx, u.uy + u.dy)) break;
+			mtmp = m_at(u.ux + u.dx, u.uy + u.dy);
+			
+			pline("You reach out and stab at %s's very soul.", mon_nam(mtmp));
+			if (nonliving_mon(mtmp) || is_demon(mtmp->data) || is_angel(mtmp->data)) 
+				pline("... but %s seems to lack one!", mon_nam(mtmp));
+			else if (ward_at(mtmp->mx,mtmp->my) == CIRCLE_OF_ACHERON)
+				pline("But %s is already beyond Acheron.", mon_nam(mtmp));
+			else 
+				xkilled(mtmp, 1);
+			
+			 
+		break;
 		case PETMASTER:{
 			int pet_effect = 0;
 			if(uarm && uarm == obj && yn("Take something out of your pockets?") == 'y'){

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -228,7 +228,9 @@ hack_artifacts()
 				artilist[ART_ROD_OF_LORDLY_MIGHT].role = NON_PM;
 				artilist[ART_SCEPTRE_OF_LOLTH].spfx &= ~(SPFX_NOGEN);
 			} else {
-				artilist[ART_ROD_OF_LORDLY_MIGHT].alignment = A_NEUTRAL;
+				artilist[ART_ROD_OF_LORDLY_MIGHT].spfx |= SPFX_NOGEN;
+				artilist[ART_ROD_OF_LORDLY_MIGHT].role = NON_PM;
+				artilist[ART_DEATH_SPEAR_OF_VHAERUN].spfx &= ~(SPFX_NOGEN);
 			}
 		} else if(Race_if(PM_DWARF) && urole.ldrnum == PM_DAIN_II_IRONFOOT){
 			artilist[ART_ROD_OF_LORDLY_MIGHT].spfx |= SPFX_NOGEN;

--- a/src/spell.c
+++ b/src/spell.c
@@ -1026,7 +1026,10 @@ int menutype;
 	int nspells, idx;
 	char ilet, lets[BUFSZ], qbuf[QBUFSZ];
 
-	if (spellid(0) == NO_SPELL)  {
+	if (spellid(0) == NO_SPELL && !((uarmh && uarmh->oartifact == ART_STORMHELM) || 
+		(uwep && uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN) ||
+		(uwep && uwep->oartifact == ART_ANNULUS && uwep->otyp == CHAKRAM))
+	){
 	    You("don't know any spells right now.");
 	    return FALSE;
 	}
@@ -1309,6 +1312,20 @@ update_alternate_spells()
 			if (spellid(i) == NO_SPELL)  {
 				spl_book[i].sp_id = SPE_LIGHTNING_STORM;
 				spl_book[i].sp_lev = objects[SPE_LIGHTNING_STORM].oc_level;
+				spl_book[i].sp_know = 1;
+				break;
+			}
+		}
+	}
+	if (uwep && uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN){
+		for (i = 0; i < MAXSPELL; i++) {
+			if (spellid(i) == SPE_DRAIN_LIFE) {
+				if (spl_book[i].sp_know < 1) spl_book[i].sp_know = 1;
+				break;
+			}
+			if (spellid(i) == NO_SPELL)  {
+				spl_book[i].sp_id = SPE_DRAIN_LIFE;
+				spl_book[i].sp_lev = objects[SPE_DRAIN_LIFE].oc_level;
 				spl_book[i].sp_know = 1;
 				break;
 			}
@@ -3871,6 +3888,7 @@ boolean atme;
 			return(0);
 		} else if (
 			!(spellid(spell) == SPE_LIGHTNING_BOLT && uarmh && uarmh->oartifact == ART_STORMHELM) &&
+			!(spellid(spell) == SPE_DRAIN_LIFE && uwep && uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN) &&
 			!((spellid(spell) == SPE_FORCE_BOLT || spellid(spell) == SPE_MAGIC_MISSILE) && 
 				uwep && uwep->oartifact == ART_ANNULUS && uwep->otyp == CHAKRAM)
 		) {
@@ -4879,6 +4897,10 @@ int spell;
 	if(
 		((spellid(spell) == SPE_FORCE_BOLT || spellid(spell) == SPE_MAGIC_MISSILE) && 
 			uwep && uwep->oartifact == ART_ANNULUS && uwep->otyp == CHAKRAM)
+	) return 100;
+	
+	if(
+		((spellid(spell) == SPE_DRAIN_LIFE) && uwep && uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN)
 	) return 100;
 	
 	/* Calculate intrinsic ability (splcaster) */

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1410,6 +1410,7 @@ int thrown;
 				obj->oartifact != ART_SILENCE_GLAIVE && 
 				obj->oartifact != ART_HEARTCLEAVER && 
 				obj->oartifact != ART_SOL_VALTIVA && 
+				obj->oartifact != ART_DEATH_SPEAR_OF_VHAERUN && 
 				obj->oartifact != ART_SHADOWLOCK && 
 				obj->oartifact != ART_PEN_OF_THE_VOID
 			) ||

--- a/src/wield.c
+++ b/src/wield.c
@@ -118,6 +118,7 @@ register struct obj *obj;
 				&& obj->oartifact != ART_HEARTCLEAVER
 				&& obj->oartifact != ART_SOL_VALTIVA
 				&& obj->oartifact != ART_SHADOWLOCK
+				&& obj->oartifact != ART_DEATH_SPEAR_OF_VHAERUN
 				  && obj->oartifact != ART_PEN_OF_THE_VOID)) :
 				!is_weptool(obj);
 	} else

--- a/src/zap.c
+++ b/src/zap.c
@@ -408,7 +408,11 @@ struct obj *otmp;
 	case WAN_DRAINING:	/* KMH */
 		reveal_invis = TRUE;
 		if(otyp == WAN_DRAINING) dmg = d((wand_damage_die(P_SKILL(P_WAND_POWER))-4)/2,8);
-		else dmg = rnd(8);
+		else {
+			dmg = rnd(8);
+			if (uwep && uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN)
+				dmg += d((u.ulevel+1)/3, 4);
+		}
 		if(dbldam) dmg *= 2;
 		if(!flags.mon_moving && Double_spell_size) dmg *= 1.5;
 		if (otyp == SPE_DRAIN_LIFE){


### PR DESCRIPTION
- neutral drow-favoring noble-favoring silvered droven spear
- first gift for hedrow nobles
- +1d10 to-hit and +1d6 (and +1d8 draining) damage
- grants magic resistance when wielded
- cast cast drain life at 0% failure when wielded (and drain life does (lvl/3)d4 extra damage)
- can be applied like a polearm based on spear skill
- drains 1d8 from non-drain resistance enemies, reducing their level by one and healing you for half of the dmg
- invoke to instantly kill adjacent non-death-magic-resistant (so not nonliving, angel, demon) monster