### PR TITLE
Allow mode-switches on the '+' spell menu when only knowing 1 spell

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -4654,8 +4654,6 @@ int *spell_no;
 	end_menu(tmpwin, buf);
 
 	how = PICK_ONE;
-	if (splaction == SPELLMENU_VIEW && spellid(1) == NO_SPELL)
-	    how = PICK_NONE;	/* only one spell => nothing to swap with */
 	n = select_menu(tmpwin, how, &selected);
 	destroy_nhwindow(tmpwin);
 
@@ -4665,7 +4663,8 @@ int *spell_no;
 		if (selected[0].item.a_int < 0){
 			return dospellmenu(selected[0].item.a_int, spell_no);
 		}
-		else {
+		else if (!(splaction == SPELLMENU_VIEW && spellid(1) == NO_SPELL)) {
+			/* we aren't attempting to rearrange spells with only 1 spell known */
 			switch (splaction)
 			{
 			case SPELLMENU_VIEW:
@@ -4701,9 +4700,9 @@ int *spell_no;
 				spl_book[s_no] = spl_tmp;
 				return dospellmenu(SPELLMENU_VIEW, spell_no);
 			}
-			}
-		}
-	}
+			} // switch(splaction)
+		} // doing something allowable
+	} // menu item was selected
 	return FALSE;
 }
 


### PR DESCRIPTION
Thanks for the bug report, LarienTelrunya