### PR TITLE
Backend changes for Arcadian Forest outposts

### DIFF
--- a/include/eshk.h
+++ b/include/eshk.h
@@ -54,25 +54,4 @@ struct eshk {
 #define NOTANGRY(mon)	((mon)->mpeaceful)
 #define ANGRY(mon)	(!NOTANGRY(mon))
 
-# ifdef OTHER_SERVICES
-#define SHK_NOMATCH     0       /* Shk !know this class of object       */
-#define SHK_MATCH       1       /* Shk is expert                        */
-#define SHK_GENERAL     2       /* Shk runs a general store             */
-
-/*
- * FUNCTION shk_class_match
- *
- * Return TRUE if a object class matches the shop type.
- * I.e. shk_class_match(WEAPON_CLASS, shkp)
- *
- * Return:      SHK_MATCH, SHK_NOMATCH, SHK_GENERAL
- */
-
-#define shk_class_match(class, shkp) \
-        ((shtypes[ESHK(shkp)->shoptype-SHOPBASE].symb == RANDOM_CLASS) ? \
-                SHK_GENERAL : \
-         ((shtypes[ESHK(shkp)->shoptype-SHOPBASE].symb == class) ? \
-                SHK_MATCH : SHK_NOMATCH))
-# endif
-
 #endif /* ESHK_H */

--- a/include/mkroom.h
+++ b/include/mkroom.h
@@ -22,7 +22,7 @@ struct mkroom {
 
 struct shclass {
 	const char *name;	/* name of the shop type */
-	char	symb;		/* this identifies the shop type */
+	char	shoptype;		/* this identifies the shop type */
 	int	prob;		/* the shop type probability in % */
 	schar	shdist;		/* object placement type */
 #define D_SCATTER	0	/* normal placement */
@@ -76,7 +76,8 @@ extern NEARDATA struct door doors[DOORMAX];
 #define POOLROOM	20	/*  */
 #define JOINEDROOM	21  /* is actually 2+ ordinary rooms joined together, and should have fewer corridors leading to it */
 #define SHOPBASE	22	/* everything above this is a shop */
-#define ARMORSHOP	SHOPBASE+1	/* specific shop defines for level compiler */
+#define GENERALSHOP	SHOPBASE	/* specific shop defines for level compiler */
+#define ARMORSHOP	SHOPBASE+1	
 #define SCROLLSHOP	SHOPBASE+2
 #define POTIONSHOP	SHOPBASE+3
 #define WEAPONSHOP 	SHOPBASE+4
@@ -85,18 +86,19 @@ extern NEARDATA struct door doors[DOORMAX];
 #define WANDSHOP	SHOPBASE+7
 #define TOOLSHOP	SHOPBASE+8
 #define BOOKSHOP	SHOPBASE+9
-#define UNIQUESHOP	SHOPBASE+10	/* shops here & above not randomly gen'd. */
-#define CANDLESHOP	UNIQUESHOP
-#define MAXRTYPE	UNIQUESHOP	/* maximum valid room type */
 #ifdef BARD
 #define MUSICSHOP	SHOPBASE+10
-#undef UNIQUESHOP
-#undef CANDLESHOP
-#undef MAXRTYPE
-#define UNIQUESHOP	SHOPBASE+11
-#define CANDLESHOP	UNIQUESHOP
-#define MAXRTYPE	UNIQUESHOP
+#define UNIQUESHOP	SHOPBASE+11	/* shops here & above not randomly gen'd. */
+#else
+#define UNIQUESHOP	SHOPBASE+10	/* shops here & above not randomly gen'd. */
 #endif
+#define CANDLESHOP	UNIQUESHOP
+#define JELLYSHOP	UNIQUESHOP+1
+#define ACIDSHOP	UNIQUESHOP+2
+#define PETSHOP		UNIQUESHOP+3
+#define CERAMICSHOP	UNIQUESHOP+4
+#define MAXRTYPE	CERAMICSHOP	/* maximum valid room type */
+
 /* NOTE: rtype is a char, so if go above 124 or so need to fix that*/
 
 /* Special type for search_special() */

--- a/src/mapglyph.c
+++ b/src/mapglyph.c
@@ -319,22 +319,22 @@ unsigned *ospecial;
 							
 						}
 						if (offset >= S_vwall && offset <= S_hcdoor) {
-							if (*in_rooms(x,y,POTIONSHOP))
+							if (*in_rooms(x,y,ACIDSHOP))
 								color = CLR_YELLOW;
-							else if (*in_rooms(x,y,ARMORSHOP))
+							else if (*in_rooms(x,y,CERAMICSHOP))
 								color = CLR_BROWN;
-							else if (*in_rooms(x,y,TOOLSHOP))
+							else if (*in_rooms(x,y,PETSHOP))
 								color = CLR_BROWN;
-							else if (*in_rooms(x,y,FOODSHOP))
+							else if (*in_rooms(x,y,JELLYSHOP))
 								color = CLR_BROWN;
 						} else if (offset == S_drkroom || offset == S_litroom) {
-							if (*in_rooms(x,y,POTIONSHOP))
+							if (*in_rooms(x,y,ACIDSHOP))
 								color = (offset == S_drkroom) ? CLR_BROWN : CLR_YELLOW;
-							else if (*in_rooms(x,y,ARMORSHOP))
+							else if (*in_rooms(x,y,CERAMICSHOP))
 								color = (offset == S_drkroom) ? CLR_BLACK : CLR_BROWN;
-							else if (*in_rooms(x,y,TOOLSHOP))
+							else if (*in_rooms(x,y,PETSHOP))
 								color = (offset == S_drkroom) ? CLR_BLACK : CLR_BROWN;
-							else if (*in_rooms(x,y,FOODSHOP))
+							else if (*in_rooms(x,y,JELLYSHOP))
 								color = (offset == S_drkroom) ? CLR_BLACK : CLR_BROWN;
 						}
 					}

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -2247,13 +2247,13 @@ mkcamp(type)
 		
 		flood_fill_rm(x, y, nroom+ROOMOFFSET, TRUE, TRUE);
 		if(type == VALAVI_CAMP)
-			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, ARMORSHOP, TRUE);
+			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, CERAMICSHOP, TRUE);
 		else if(type == FORMIAN_CAMP1)
-			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, TOOLSHOP, TRUE);
+			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, PETSHOP, TRUE);
 		else if(type == FORMIAN_CAMP2)
-			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, POTIONSHOP, TRUE);
+			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, ACIDSHOP, TRUE);
 		else if(type == THRIAE_CAMP)
-			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, FOODSHOP, TRUE);
+			add_room(x-r+1, y-r+1, x+r-1, y+r-1, TRUE, JELLYSHOP, TRUE);
 		rooms[nroom - 1].irregular = TRUE;
 		
 		pathto = rn2(pathto);
@@ -3853,8 +3853,10 @@ mkshop()
 				mkisland();
 				return;
 			}
-			for(i=0; shtypes[i].name; i++)
-				if(*ep == def_oc_syms[(int)shtypes[i].symb])
+			/* note: shops >= UNIQUESHOP don't have valid class symbols, nor are generated randomly */
+			for(i=0; shtypes[i].name && i < (UNIQUESHOP - SHOPBASE); i++)
+				if(shtypes[i].iprobs[0].itype >= 0)
+				if(*ep == def_oc_syms[(int)shtypes[i].iprobs[0].itype])
 				    goto gottype;
 			if(*ep == 'g' || *ep == 'G')
 				i = 0;
@@ -3901,8 +3903,8 @@ gottype:
 	    /* big rooms cannot be wand or book shops,
 	     * - so make them general stores
 	     */
-	    if(isbig(sroom) && (shtypes[i].symb == WAND_CLASS
-				|| shtypes[i].symb == SPBOOK_CLASS)) i = 0;
+	    if(isbig(sroom) && (shtypes[i].shoptype == WANDSHOP
+				|| shtypes[i].shoptype == BOOKSHOP)) i = 0;
 	}
 	sroom->rtype = SHOPBASE + i;
 

--- a/src/shk.c
+++ b/src/shk.c
@@ -79,7 +79,6 @@ static void FDECL(shk_weapon_works, (char *, struct monst *));
 static void FDECL(shk_armor_works, (char *, struct monst *));
 static void FDECL(shk_charge, (char *, struct monst *));
 static boolean FDECL(shk_obj_match, (struct obj *, struct monst *));
-/*static int FDECL(shk_class_match, (long class, struct monst *shkp));*/
 static boolean FDECL(shk_offer_price, (char *, long, struct monst *));
 static void FDECL(shk_smooth_charge, (int *, int, int));
 #endif
@@ -1897,7 +1896,7 @@ shk_other_services()
   	/* Weapon appraisals.  Weapon & general stores can do this. */
 		/* Disabled due to being potentially misleading */
 /*	if ((ESHK(shkp)->services & (SHK_UNCURSE)) &&
-			(shk_class_match(WEAPON_CLASS, shkp))) {
+			(ESHK(shkp)->shoptype == WEAPONSHOP || ESHK(shkp)->shoptype == GENERALSHOP)) {
 		any.a_int = 3;
 		add_menu(tmpwin, NO_GLYPH, &any , 'a', 0, ATR_NONE,
 				"Appraise", MENU_UNSELECTED);
@@ -1905,7 +1904,7 @@ shk_other_services()
 */
   	/* Weapon-works!  Only a weapon store. */
 	if ((ESHK(shkp)->services & (SHK_SPECIAL_A|SHK_SPECIAL_B|SHK_SPECIAL_C))
-			&& (shk_class_match(WEAPON_CLASS, shkp) == SHK_MATCH)
+			&& (ESHK(shkp)->shoptype == WEAPONSHOP)
 	) {
 		any.a_int = 4;
 		if (ESHK(shkp)->services & (SHK_SPECIAL_A|SHK_SPECIAL_B))
@@ -1918,7 +1917,7 @@ shk_other_services()
   
   	/* Armor-works */
 	if ((ESHK(shkp)->services & (SHK_SPECIAL_A|SHK_SPECIAL_B))
-			 && (shk_class_match(ARMOR_CLASS, shkp) == SHK_MATCH)
+			 &&(ESHK(shkp)->shoptype == ARMORSHOP)
 	) {
 		any.a_int = 5;
 		add_menu(tmpwin, NO_GLYPH, &any , 'r', 0, ATR_NONE,
@@ -1927,10 +1926,11 @@ shk_other_services()
   
   	/* Charging: / ( = */
 	if ((ESHK(shkp)->services & (SHK_SPECIAL_A|SHK_SPECIAL_B)) &&
-			((shk_class_match(WAND_CLASS, shkp) == SHK_MATCH) ||
-			(shk_class_match(TOOL_CLASS, shkp) == SHK_MATCH) ||
-			(shk_class_match(SPBOOK_CLASS, shkp) == SHK_MATCH) ||
-			(shk_class_match(RING_CLASS, shkp) == SHK_MATCH))
+			((ESHK(shkp)->shoptype == WANDSHOP) ||
+			(ESHK(shkp)->shoptype == TOOLSHOP) ||
+			(ESHK(shkp)->shoptype == CANDLESHOP) ||
+			(ESHK(shkp)->shoptype == BOOKSHOP) ||
+			(ESHK(shkp)->shoptype == RINGSHOP))
 	) {
 		any.a_int = 6;
 		add_menu(tmpwin, NO_GLYPH, &any , 'c', 0, ATR_NONE,
@@ -4994,7 +4994,7 @@ shk_appraisal(slang, shkp)
 		verbalize("This weapon needs to be identified first!");
 		return;
 	} else */
-	if (shk_class_match(WEAPON_CLASS, shkp) == SHK_MATCH)
+	if (ESHK(shkp)->shoptype == WEAPONSHOP)
 	{
 		verbalize("Ok, %s, let's see what we have here.", slang);
 		guesswork = FALSE;
@@ -5409,13 +5409,13 @@ shk_charge(slang, shkp)
 	char invlet;            /* Inventory letter             */
 
 	/* What type of shop are we? */
-	if (shk_class_match(WAND_CLASS, shkp) == SHK_MATCH)
+	if (ESHK(shkp)->shoptype == WANDSHOP)
 		obj = getobj(wand_types, "charge");
-	else if (shk_class_match(TOOL_CLASS, shkp) == SHK_MATCH)
+	else if (ESHK(shkp)->shoptype == TOOLSHOP || ESHK(shkp)->shoptype == CANDLESHOP)
 		obj = getobj(tool_types, "charge");
-	else if (shk_class_match(RING_CLASS, shkp) == SHK_MATCH)
+	else if (ESHK(shkp)->shoptype == RINGSHOP)
 		obj = getobj(ring_types, "charge");
-	else if (shk_class_match(SPBOOK_CLASS, shkp) == SHK_MATCH)
+	else if (ESHK(shkp)->shoptype == BOOKSHOP)
 		obj = getobj(spbook_types, "charge");
 	if (!obj) return;
 

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -199,39 +199,39 @@ static const char * const shkmusic[] = {
 
 const struct shclass shtypes[] = {
 #ifdef BARD
-	{"general store", RANDOM_CLASS, 41,
+	{"general store", GENERALSHOP, 41,
 #else
-	{"general store", RANDOM_CLASS, 44,
+	{"general store", GENERALSHOP, 44,
 #endif
 	    D_SHOP, {{100, RANDOM_CLASS}, {0, 0}, {0, 0}}, shkgeneral},
-	{"used armor dealership", ARMOR_CLASS, 14,
+	{"used armor dealership", ARMORSHOP, 14,
 	    D_SHOP, {{90, ARMOR_CLASS}, {10, WEAPON_CLASS}, {0, 0}},
 	     shkarmors},
-	{"second-hand bookstore", SCROLL_CLASS, 10, D_SHOP,
+	{"second-hand bookstore", SCROLLSHOP, 10, D_SHOP,
 	    {{90, SCROLL_CLASS}, {10, SPBOOK_CLASS}, {0, 0}}, shkbooks},
-	{"liquor emporium", POTION_CLASS, 10, D_SHOP,
+	{"liquor emporium", POTIONSHOP, 10, D_SHOP,
 	    {{100, POTION_CLASS}, {0, 0}, {0, 0}}, shkliquors},
-	{"antique weapons outlet", WEAPON_CLASS, 5, D_SHOP,
+	{"antique weapons outlet", WEAPONSHOP, 5, D_SHOP,
 	    {{90, WEAPON_CLASS}, {10, ARMOR_CLASS}, {0, 0}}, shkweapons},
-	{"delicatessen", FOOD_CLASS, 5, D_SHOP,
+	{"delicatessen", FOODSHOP, 5, D_SHOP,
 	    {{83, FOOD_CLASS}, {5, -POT_FRUIT_JUICE}, {4, -POT_BOOZE},
 	     {5, -POT_WATER}, {3, -ICE_BOX}}, shkfoods},
-	{"jewelers", RING_CLASS, 3, D_SHOP,
+	{"jewelers", RINGSHOP, 3, D_SHOP,
 	    {{85, RING_CLASS}, {10, GEM_CLASS}, {5, AMULET_CLASS}, {0, 0}},
 	    shkrings},
-	{"quality apparel and accessories", WAND_CLASS, 3, D_SHOP,
+	{"quality apparel and accessories", WANDSHOP, 3, D_SHOP,
 	    {{90, WAND_CLASS}, {5, -GLOVES}, {5, -ELVEN_CLOAK}, {0, 0}},
 	     shkwands},
-	{"hardware store", TOOL_CLASS, 3, D_SHOP,
+	{"hardware store", TOOLSHOP, 3, D_SHOP,
 	    {{100, TOOL_CLASS}, {0, 0}, {0, 0}}, shktools},
 	/* Actually shktools is ignored; the code specifically chooses a
 	 * random implementor name (along with candle shops having
 	 * random shopkeepers)
 	 */
-	{"rare books", SPBOOK_CLASS, 3, D_SHOP,
+	{"rare books", BOOKSHOP, 3, D_SHOP,
 	    {{90, SPBOOK_CLASS}, {10, SCROLL_CLASS}, {0, 0}}, shkbooks},
 #ifdef BARD
-	{"music shop", TOOL_CLASS, 3, D_SHOP,
+	{"music shop", MUSICSHOP, 3, D_SHOP,
 	    {{32, -FLUTE}, {32, -HARP}, {32, -DRUM}, 
 	     {2, -MAGIC_HARP}, {2, -MAGIC_FLUTE}},
 	     shkmusic},
@@ -240,33 +240,26 @@ const struct shclass shtypes[] = {
 	 * probability of zero.  They are only created via the special level
 	 * loader.
 	 */
-	{"lighting store", TOOL_CLASS, 0, D_SHOP,
+	{"lighting store", CANDLESHOP, 0, D_SHOP,
 	    {{32, -WAX_CANDLE}, {50, -TALLOW_CANDLE},
 	     {5, -LANTERN}, {10, -OIL_LAMP}, {3, -MAGIC_LAMP}}, shklight},
-	{(char *)0, 0, 0, 0, {{0, 0}, {0, 0}, {0, 0}}, 0}
-};
-
-#define JELLY_SHOP 0
-#define ACID_SHOP 1
-#define PET_SHOP 2
-#define CERAMIC_SHOP 3
-const struct shclass special_shtypes[] = {
-	{"hive outpost", FOOD_CLASS, 0, D_SHOP, 
+	/* Arcadian outposts */
+	{"hive outpost", JELLYSHOP, 0, D_SHOP, 
 	    {{12, -LUMP_OF_ROYAL_JELLY}, {12, -LUMP_OF_SOLDIER_S_JELLY}, 
 		 {12, -LUMP_OF_DANCER_S_JELLY},
 	     {12, -LUMP_OF_PHILOSOPHER_S_JELLY}, {12, -LUMP_OF_PRIESTESS_S_JELLY}, 
 		 {12, -LUMP_OF_RHETOR_S_JELLY}, 
 		 {14, -HONEYCOMB}, {14, -POT_GAIN_ABILITY}},
 	shkfoods},
-	{"nest outpost", POTION_CLASS, 10, D_SHOP,
+	{"nest outpost", ACIDSHOP, 0, D_SHOP,
 	    {{40, -POT_ACID}, {40, -POT_OIL}, 
 		 {20, -POT_BOOZE}},
 	shkliquors},
-	{"garrison outpost", TOOL_CLASS, 10, D_SHOP,
+	{"garrison outpost", PETSHOP, 0, D_SHOP,
 	    {{95, -FIGURINE}, {5, -LEASH}},
 	shktools},
-	{"mound outpost", ARMOR_CLASS, 10, D_SHOP,
-	    {{40, ARMOR_CLASS}, {20, -SHEPHERD_S_CROOK}, 
+	{"mound outpost", CERAMICSHOP, 0, D_SHOP,
+	    {{40, ARMOR_CLASS}, {20, -SHEPHERD_S_CROOK}, /* note: uses custom list for armor_class */
 		 {20, -SLIME_MOLD}, {20, -FIGURINE}
 		},
 	shkarmors},
@@ -326,94 +319,65 @@ int sx, sy;
 	struct obj *curobj = 0;
 
 	if (rn2(100) < depth(&u.uz) && !(Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz) && Is_qstart(&u.uz)) &&
-		!MON_AT(sx, sy) && (ptr = mkclass(S_MIMIC,Inhell ? G_HELL : G_NOHELL)) &&
-		(mtmp = makemon(ptr,sx,sy,NO_MM_FLAGS)) != 0) {
-	    /* note: makemon will set the mimic symbol to a shop item */
-	    if (rn2(10) >= depth(&u.uz)) {
-		mtmp->m_ap_type = M_AP_OBJECT;
-		mtmp->mappearance = STRANGE_OBJECT;
-	    }
-	} else if(In_law(&u.uz ) && (shp->symb == POTION_CLASS || shp->symb == FOOD_CLASS || shp->symb == TOOL_CLASS || shp->symb == ARMOR_CLASS)){
-		if(shp->symb == POTION_CLASS){
-			atype = get_special_shop_item(JELLY_SHOP);
-			if (atype < 0)
-				curobj = mksobj_at(-atype, sx, sy, TRUE, TRUE);
-			else
-				curobj = mkobj_at(atype, sx, sy, TRUE);
-			
-			if(curobj){
-				curobj->shopOwned = TRUE;
+		!MON_AT(sx, sy) && (ptr = mkclass(S_MIMIC, Inhell ? G_HELL : G_NOHELL)) &&
+		(mtmp = makemon(ptr, sx, sy, NO_MM_FLAGS)) != 0) {
+		/* note: makemon will set the mimic symbol to a shop item */
+		if (rn2(10) >= depth(&u.uz)) {
+			mtmp->m_ap_type = M_AP_OBJECT;
+			mtmp->mappearance = STRANGE_OBJECT;
+		}
+	}
+	else {
+		atype = get_shop_item(shp - shtypes);
+		if (atype < 0){
+			curobj = mksobj_at(-atype, sx, sy, TRUE, TRUE);
+		}
+		else {
+			curobj = mkobj_at(atype, sx, sy, TRUE);
+		}
+
+		if (curobj){
+			curobj->shopOwned = TRUE;
+
+			/* special cases below... */
+			if (shp->shoptype == PETSHOP && curobj->otyp == FIGURINE){
+				curobj->corpsenm = rn2(100) < 40 ? PM_MYRMIDON_HOPLITE :
+					rn2(60) < 30 ? PM_MYRMIDON_LOCHIAS :
+					rn2(30) < 10 ? PM_MYRMIDON_YPOLOCHAGOS :
+					rn2(20) < 5 ? PM_MYRMIDON_LOCHAGOS :
+					PM_FORMIAN_CRUSHER;
+				bless(curobj);
 			}
-		} else if(shp->symb == FOOD_CLASS){
-			atype = get_special_shop_item(ACID_SHOP);
-			if (atype < 0)
-				curobj = mksobj_at(-atype, sx, sy, TRUE, TRUE);
-			else
-				curobj = mkobj_at(atype, sx, sy, TRUE);
-			
-			if(curobj){
-				curobj->shopOwned = TRUE;
-			}
-		} else if(shp->symb == TOOL_CLASS){
-			atype = get_special_shop_item(PET_SHOP);
-			if (atype < 0)
-				curobj = mksobj_at(-atype, sx, sy, TRUE, TRUE);
-			else
-				curobj = mkobj_at(atype, sx, sy, TRUE);
-			
-			if(curobj){
-				curobj->shopOwned = TRUE;
-				if(curobj->otyp == FIGURINE){
-					curobj->corpsenm = rn2(100) < 40 ? PM_MYRMIDON_HOPLITE : 
-										rn2(60) < 30 ? PM_MYRMIDON_LOCHIAS :
-										rn2(30) < 10 ? PM_MYRMIDON_YPOLOCHAGOS : 
-										rn2(20) < 5 ? PM_MYRMIDON_LOCHAGOS :
-										PM_FORMIAN_CRUSHER;
-					bless(curobj);
-				}
-			}
-		} else if(shp->symb == ARMOR_CLASS){
-			atype = get_special_shop_item(CERAMIC_SHOP);
-			if (atype < 0){
-				curobj = mksobj_at(-atype, sx, sy, TRUE, TRUE);
-			} else {
-				if(atype != ARMOR_CLASS)
-					curobj = mkobj_at(atype, sx, sy, TRUE);
-				else {
-					curobj = mksobj_at(valavi_armors[rn2(SIZE(valavi_armors))], sx, sy, TRUE, TRUE);
-					if(curobj){
-						if(curobj->obj_material == IRON || curobj->obj_material == GOLD)
-							curobj->obj_material = MINERAL;
-						else if(curobj->obj_material == CLOTH)
-							curobj->oproperties = OPROP_WOOL;
-						
-						if(curobj->otyp == PLATE_MAIL)
-							curobj->oproperties = OPROP_WOOL;
+			if (shp->shoptype == CERAMICSHOP) {
+				if (curobj->oclass == ARMOR_CLASS && !curobj->oartifact) {
+					/* we actually want to completely replace that object. */
+					struct obj * newobj = mksobj_at(valavi_armors[rn2(SIZE(valavi_armors))], sx, sy, TRUE, TRUE);
+					newobj->shopOwned = TRUE;
+					if (newobj) {
+						if (is_metallic(newobj) && !newobj->oartifact)
+							set_material(newobj, MINERAL);
+						else if (newobj->obj_material == CLOTH)
+							newobj->oproperties = OPROP_WOOL;
+
+						if (newobj->otyp == PLATE_MAIL)
+							newobj->oproperties = OPROP_WOOL;
+
+						/* replace curobj with newobj */
+						delobj(curobj);
+						/* assign the new object to the curobj pointer */
+						curobj = newobj;
 					}
 				}
-			}
-			
-			if(curobj){
-				curobj->shopOwned = TRUE;
-				if(curobj->otyp == SLIME_MOLD){
-					if(rn2(2)) curobj->spe = fruitadd("lump of wood");
+				else if (curobj->otyp == SLIME_MOLD){
+					if (rn2(2)) curobj->spe = fruitadd("lump of wood");
 					else curobj->spe = fruitadd("mutton roast");
 				}
-				if(curobj->otyp == FIGURINE){
-					curobj->corpsenm = !rn2(3) ? PM_LAMB : rn2(2) ? PM_SHEEP : PM_DIRE_SHEEP; 
+				else if (curobj->otyp == FIGURINE){
+					curobj->corpsenm = !rn2(3) ? PM_LAMB : rn2(2) ? PM_SHEEP : PM_DIRE_SHEEP;
 					bless(curobj);
 				}
 			}
-		}
-	} else {
-	    atype = get_shop_item(shp - shtypes);
-	    if (atype < 0)
-			curobj = mksobj_at(-atype, sx, sy, TRUE, TRUE);
-	    else
-			curobj = mkobj_at(atype, sx, sy, TRUE);
-		
-		if(curobj){
-			curobj->shopOwned = TRUE;
+			/*end special cases*/
 		}
 	}
 }
@@ -574,13 +538,13 @@ struct mkroom	*sroom;
 	if(In_outlands(&u.uz) && !Is_gatetown(&u.uz))
 		newcham(shk, &mons[PM_PLUMACH_RILMANI], FALSE, FALSE);
 	else if(In_law(&u.uz)){
-		if((shk_class_match(FOOD_CLASS, shk)) == SHK_MATCH)
+		if (ESHK(shk)->shoptype == JELLYSHOP)
 			newcham(shk, &mons[PM_FORMIAN_TASKMASTER], FALSE, FALSE);
-		else if((shk_class_match(POTION_CLASS, shk)) == SHK_MATCH)
+		else if (ESHK(shk)->shoptype == ACIDSHOP)
 			newcham(shk, &mons[PM_THRIAE], FALSE, FALSE);
-		else if((shk_class_match(TOOL_CLASS, shk)) == SHK_MATCH)
+		else if (ESHK(shk)->shoptype == PETSHOP)
 			newcham(shk, &mons[PM_FORMIAN_TASKMASTER], FALSE, FALSE);
-		else if((shk_class_match(ARMOR_CLASS, shk)) == SHK_MATCH)
+		else if (ESHK(shk)->shoptype == CERAMICSHOP)
 			newcham(shk, &mons[PM_VALAVI], FALSE, FALSE);
 	}
 	
@@ -679,19 +643,20 @@ struct monst *shk;
 
 	if (!rn2(3)) ESHK(shk)->services |= SHK_UNCURSE;
 
-	if (!rn2(3) && shk_class_match(WEAPON_CLASS, shk))
+	if (!rn2(3) && (ESHK(shk)->shoptype == WEAPONSHOP || ESHK(shk)->shoptype == GENERALSHOP))
 		ESHK(shk)->services |= SHK_APPRAISE;
 
-	if ((shk_class_match(WEAPON_CLASS, shk) == SHK_MATCH) ||
-	(shk_class_match(ARMOR_CLASS, shk) == SHK_MATCH) ||
-	(shk_class_match(WAND_CLASS, shk) == SHK_MATCH) ||
-	(shk_class_match(TOOL_CLASS, shk) == SHK_MATCH) ||
-	(shk_class_match(SPBOOK_CLASS, shk) == SHK_MATCH) ||
-	(shk_class_match(RING_CLASS, shk) == SHK_MATCH)) {
+	if ((ESHK(shk)->shoptype == WEAPONSHOP) ||
+		(ESHK(shk)->shoptype == ARMORSHOP) ||
+		(ESHK(shk)->shoptype == WANDSHOP) ||
+		(ESHK(shk)->shoptype == TOOLSHOP) ||
+		(ESHK(shk)->shoptype == CANDLESHOP) ||
+		(ESHK(shk)->shoptype == BOOKSHOP) ||
+		(ESHK(shk)->shoptype == RINGSHOP)) {
 		if (!rn2(4/*5*/)) ESHK(shk)->services |= SHK_SPECIAL_A;
 		if (!rn2(4/*5*/)) ESHK(shk)->services |= SHK_SPECIAL_B;
 	}
-	if (!rn2(4/*5*/) && (shk_class_match(WEAPON_CLASS, shk) == SHK_MATCH))
+	if (!rn2(4/*5*/) && (ESHK(shk)->shoptype == WEAPONSHOP))
 	 ESHK(shk)->services |= SHK_SPECIAL_C;
 
 	return;
@@ -712,7 +677,7 @@ struct obj *obj;
 	
 	if(obj->ostolen || ESHK(shkp)->pbanned) return FALSE;
 
-    if (shp->symb == RANDOM_CLASS) return TRUE;
+    if (shp->shoptype == GENERALSHOP) return TRUE;
     else for (i = 0; i < SIZE(shtypes[0].iprobs) && shp->iprobs[i].iprob; i++){
 		if (shp->iprobs[i].itype < 0 ?
 			shp->iprobs[i].itype == - obj->otyp :
@@ -738,21 +703,6 @@ get_shop_item(type)
 int type;
 {
 	const struct shclass *shp = shtypes+type;
-	register int i,j;
-
-	/* select an appropriate object type at random */
-	for(j = rnd(100), i = 0; (j -= shp->iprobs[i].iprob) > 0; i++)
-		continue;
-
-	return shp->iprobs[i].itype;
-}
-
-/* positive value: class; negative value: specific object type */
-int
-get_special_shop_item(type)
-int type;
-{
-	const struct shclass *shp = &(special_shtypes[type]);
 	register int i,j;
 
 	/* select an appropriate object type at random */


### PR DESCRIPTION
Added to the shoplist proper.
Changes the symb in the shop structure to shoptyp; places where a symbol is actually needed can be done by accessing the first item index of the shop, which is klunky, but far more often we want to know exactly what shop we are working with.