### PR TITLE
Shadowsteel no longer evaporates while invisible, more Spidersilk changes

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2014,6 +2014,9 @@ struct obj * otmp;
 	case ART_AEGIS:
 		def += 3;//3 total, Same as Cloak of protection
 		break;
+	case ART_SPIDERSILK:
+		def += 2;//offsetting the cloth material
+		break;
 	}
 
 	return def;
@@ -2097,6 +2100,9 @@ struct obj * otmp;
 		break;
 	case ART_AEGIS:
 		def += 1;//3 total, Same as Cloak of protection
+		break;
+	case ART_SPIDERSILK:
+		def += 2;//offsetting the cloth material
 		break;
 	// case ART_CLAWS_OF_THE_REVENANCER:
 		// def += 5;

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -916,6 +916,8 @@ boolean adjective;
 		/* overly fancy clothing */
 		else if (obj->otyp == GENTLEMAN_S_SUIT || obj->otyp == GENTLEWOMAN_S_DRESS)
 			return "silk";
+		else if (obj->oartifact == ART_SPIDERSILK)
+			return "spidersilk";
 		else
 			return "cloth";
 	case LEATHER:

--- a/src/worn.c
+++ b/src/worn.c
@@ -1616,6 +1616,12 @@ long timeout;
 				objects[uarmc->otyp].a_can - uarmc->ovar1 :
 				objects[uarmc->otyp].a_can;
 		}
+		
+		if (Invis){
+			start_timer(1, TIMER_OBJECT, LIGHT_DAMAGE, (genericptr_t)obj);
+			return;
+		}
+		
 		if((levl[u.ux][u.uy].lit == 0 && 
 			!(viz_array[u.uy][u.ux]&TEMP_LIT1 && !(viz_array[u.uy][u.ux]&TEMP_DRK1)))
 		  || (levl[u.ux][u.uy].lit && 
@@ -1714,6 +1720,10 @@ long timeout;
 			armpro = armor->otyp == DROVEN_CLOAK ? 
 				objects[armor->otyp].a_can - armor->ovar1 :
 				objects[armor->otyp].a_can;
+		}
+		if (obj->ocarry->perminvis || obj->ocarry->minvis){
+			start_timer(1, TIMER_OBJECT, LIGHT_DAMAGE, (genericptr_t)obj);
+			return;
 		}
 		if((levl[obj->ocarry->mx][obj->ocarry->my].lit == 0 && 
 				!(viz_array[obj->ocarry->my][obj->ocarry->mx]&TEMP_LIT1 && !(viz_array[obj->ocarry->my][obj->ocarry->mx]&TEMP_DRK1)))


### PR DESCRIPTION
This protects shadowsteel worn or carried from being afflicted by light if the bearer (you or a monster) is invisible, however fixed shadowsteel will not regenerate while you're invisible and in darkness (or just plain invisible). The justification for this that it needs to be submerged in shadow to heal.

Also, Spidersilk now grants an extra 2 AC/DR to compensate for the lack of protection that cloth gives, and shows as being made of "spidersilk" instead of "cloth" in the more info menu as well as when unidentified ("Made of spidersilk.", "a spidersilk droven chain mail named Spidersilk").