### PR TITLE
Block certain races from getting bad gifts

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -324,10 +324,11 @@ aligntyp alignment;	/* target alignment, or A_NONE */
 				goto make_artif;	/* 'a' points to the desired one */
 			} else if (by_align && a->race != NON_PM && race_hostile(&mons[a->race])){
 				continue;	/* skip enemies' equipment */
-			} else if (by_align && a->race == PM_DROW && (
-				artifact_light(&artilist[m]) || m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD || 
-				(&artilist[m]->material == IRON && (u.ulevel < 7 || !rn2(2)) 
-			)))
+			} else if (by_align && a->race == PM_DROW && !(
+				artifact_light(oname(otmp, (&artilist[m])->name)) || m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD) && 
+				(!((artilist[m].material == IRON || (artilist[m].material == 0 && oname(otmp, (&artilist[m])->name)->obj_material == IRON))) && 
+				(u.ulevel < 7 || !rn2(2)))
+			)
 			{ 
 				continue;	// drow will never get a light-giving artifact, since that's annoying
 							// they're also blocked from iron while under level 7, and have a 1/3 of a chance otherwise

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -324,10 +324,13 @@ aligntyp alignment;	/* target alignment, or A_NONE */
 				goto make_artif;	/* 'a' points to the desired one */
 			} else if (by_align && a->race != NON_PM && race_hostile(&mons[a->race])){
 				continue;	/* skip enemies' equipment */
-			} else if (by_align && a->race == PM_DROW && !(
-				artifact_light(oname(otmp, (&artilist[m])->name)) || m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD) && 
-				(!((artilist[m].material == IRON || (artilist[m].material == 0 && oname(otmp, (&artilist[m])->name)->obj_material == IRON))) && 
-				(u.ulevel < 7 || !rn2(2)))
+			} else if (by_align && a->race == PM_DROW && 
+				!(artifact_light(oname(otmp, (&artilist[m])->name)) || m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD) && 
+				(
+					!(artilist[m].material == IRON || 
+						(artilist[m].material == 0 && oname(otmp, (&artilist[m])->name)->obj_material == IRON)
+					) &&  (u.ulevel < 7 || !rn2(2))
+				)
 			)
 			{ 
 				continue;	// drow will never get a light-giving artifact, since that's annoying

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -324,17 +324,23 @@ aligntyp alignment;	/* target alignment, or A_NONE */
 				goto make_artif;	/* 'a' points to the desired one */
 			} else if (by_align && a->race != NON_PM && race_hostile(&mons[a->race])){
 				continue;	/* skip enemies' equipment */
-			} else if (by_align && a->race == PM_DROW && 
-				!(artifact_light(oname(otmp, (&artilist[m])->name)) || m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD) && 
-				(
-					!(artilist[m].material == IRON || 
-						(artilist[m].material == 0 && oname(otmp, (&artilist[m])->name)->obj_material == IRON)
-					) &&  (u.ulevel < 7 || !rn2(2))
-				)
-			)
-			{ 
-				continue;	// drow will never get a light-giving artifact, since that's annoying
-							// they're also blocked from iron while under level 7, and have a 1/3 of a chance otherwise
+			} else if (by_align && hates_iron(youracedata) &&  
+				((artilist[m].material == IRON || 
+					(artilist[m].material == 0 && objects[(int)((&artilist[m])->otyp)].oc_material == IRON)
+				) && (u.ugifts < 2 || !rn2(2)))
+			){ 
+				continue; // no iron gifts if you're an elf/drow - game-able by selfpoly but eh
+							
+			} else if (by_align && hates_silver(youracedata) &&  
+				((artilist[m].material == SILVER || 
+					(artilist[m].material == 0 && objects[(int)((&artilist[m])->otyp)].oc_material == SILVER)
+				) && (u.ugifts < 2 || !rn2(2)))
+			){ 
+				continue; // no silver gifts if you're an vampire - game-able by selfpoly still
+							
+			} else if (by_align && Race_if(PM_DROW) && (m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD)){
+				continue; // no light-giving artis for drow (artifact_light should be unnecessary)
+			
 			} else if(by_align && Role_if(PM_PIRATE)) 
 				continue; /* pirates are not gifted artifacts */
 			else if(by_align && Role_if(PM_MONK) && !is_monk_safe_artifact(m) && (!(u.uconduct.weaphit) || rn2(20)))

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -324,6 +324,13 @@ aligntyp alignment;	/* target alignment, or A_NONE */
 				goto make_artif;	/* 'a' points to the desired one */
 			} else if (by_align && a->race != NON_PM && race_hostile(&mons[a->race])){
 				continue;	/* skip enemies' equipment */
+			} else if (by_align && a->race == PM_DROW && (
+				artifact_light(&artilist[m]) || m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD || 
+				(&artilist[m]->material == IRON && (u.ulevel < 7 || !rn2(2)) 
+			)))
+			{ 
+				continue;	// drow will never get a light-giving artifact, since that's annoying
+							// they're also blocked from iron while under level 7, and have a 1/3 of a chance otherwise
 			} else if(by_align && Role_if(PM_PIRATE)) 
 				continue; /* pirates are not gifted artifacts */
 			else if(by_align && Role_if(PM_MONK) && !is_monk_safe_artifact(m) && (!(u.uconduct.weaphit) || rn2(20)))


### PR DESCRIPTION
For their first two gifts, vampires will never get a silver artifact and elves/drow will never get a iron artifact. This doesn't interfere with a first pantheon first gift (for priest, pirate, convicts, wizards), they'll still get their first gift like normal. 

Drow will also never get a light-giving artifact regardless of gift number. This is just the Arkenstone and the Holy Moonlight Sword, Atma weapon is excluded since it can be used with fossil dark. 

In theory, this will prevent players from getting bad artifacts early-game when they don't have gloves or aren't ready to take the regen penalty. In practice, it means elves & drow are gonna get a lot of unaligned gifts. (this could be fixed with a guaranteed first gift or more options though)

 