### PR TITLE
Half-dragons get appropriate DSM boosts

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -744,26 +744,6 @@ struct weapon_dice {
 													Dragon_shield_to_pm(uarms) == &mons[PM_GREEN_DRAGON]\
 												))\
 											))
-#define is_ancestral_dragon_gear	(Race_If(PM_HALF_DRAGON) &&
-(((flags.HDbreath == AD_COLD) && (
-	(uarm && uarm->otyp == WHITE_DRAGON_SCALES || uarm->otyp == WHITE_DRAGON_SCALE_MAIL) ||
-	(uarms && uarms->otyp == WHITE_DRAGON_SCALE_SHIELD))) ||
-((flags.HDbreath == AD_FIRE) && (
-	(uarm && uarm->otyp == RED_DRAGON_SCALES || uarm->otyp == RED_DRAGON_SCALE_MAIL) ||
-	(uarms && uarms->otyp == RED_DRAGON_SCALE_SHIELD))) ||
-((flags.HDbreath == AD_SLEE) && (
-	(uarm && uarm->otyp == ORANGE_DRAGON_SCALES || uarm->otyp == ORANGE_DRAGON_SCALE_MAIL) ||
-	(uarms && uarms->otyp == ORANGE_DRAGON_SCALE_SHIELD))) ||
-((flags.HDbreath == AD_ELEC) && (
-	(uarm && uarm->otyp == BLUE_DRAGON_SCALES || uarm->otyp == BLUE_DRAGON_SCALE_MAIL) ||
-	(uarms && uarms->otyp == BLUE_DRAGON_SCALE_SHIELD))) ||
-((flags.HDbreath == AD_DRST) && (
-	(uarm && uarm->otyp == GREEN_DRAGON_SCALES || uarm->otyp == GREEN_DRAGON_SCALE_MAIL) ||
-	(uarms && uarms->otyp == GREEN_DRAGON_SCALE_SHIELD))) ||
-((flags.HDbreath == AD_ACID) && (
-	(uarm && uarm->otyp == YELLOW_DRAGON_SCALES || uarm->otyp == YELLOW_DRAGON_SCALE_MAIL) ||
-	(uarms && uarms->otyp == YELLOW_DRAGON_SCALE_SHIELD)))))
-	
 /* Elven gear */
 #define is_elven_weapon(otmp)	((otmp)->otyp == ELVEN_ARROW\
 				|| (otmp)->otyp == ELVEN_SPEAR\

--- a/include/obj.h
+++ b/include/obj.h
@@ -731,6 +731,7 @@ struct weapon_dice {
 													Dragon_shield_to_pm(uarms) == &mons[PM_BLACK_DRAGON] ||\
 													Dragon_shield_to_pm(uarms) == &mons[PM_BLUE_DRAGON] ||\
 													Dragon_shield_to_pm(uarms) == &mons[PM_RED_DRAGON] ||\
+													Dragon_shield_to_pm(uarms) == &mons[PM_WHITE_DRAGON] ||\
 													Dragon_shield_to_pm(uarms) == &mons[PM_GRAY_DRAGON] ||\
 													Dragon_shield_to_pm(uarms) == &mons[PM_ORANGE_DRAGON]\
 												)) ||\
@@ -743,7 +744,26 @@ struct weapon_dice {
 													Dragon_shield_to_pm(uarms) == &mons[PM_GREEN_DRAGON]\
 												))\
 											))
-
+#define is_ancestral_dragon_gear	(Race_If(PM_HALF_DRAGON) &&
+(((flags.HDbreath == AD_COLD) && (
+	(uarm && uarm->otyp == WHITE_DRAGON_SCALES || uarm->otyp == WHITE_DRAGON_SCALE_MAIL) ||
+	(uarms && uarms->otyp == WHITE_DRAGON_SCALE_SHIELD))) ||
+((flags.HDbreath == AD_FIRE) && (
+	(uarm && uarm->otyp == RED_DRAGON_SCALES || uarm->otyp == RED_DRAGON_SCALE_MAIL) ||
+	(uarms && uarms->otyp == RED_DRAGON_SCALE_SHIELD))) ||
+((flags.HDbreath == AD_SLEE) && (
+	(uarm && uarm->otyp == ORANGE_DRAGON_SCALES || uarm->otyp == ORANGE_DRAGON_SCALE_MAIL) ||
+	(uarms && uarms->otyp == ORANGE_DRAGON_SCALE_SHIELD))) ||
+((flags.HDbreath == AD_ELEC) && (
+	(uarm && uarm->otyp == BLUE_DRAGON_SCALES || uarm->otyp == BLUE_DRAGON_SCALE_MAIL) ||
+	(uarms && uarms->otyp == BLUE_DRAGON_SCALE_SHIELD))) ||
+((flags.HDbreath == AD_DRST) && (
+	(uarm && uarm->otyp == GREEN_DRAGON_SCALES || uarm->otyp == GREEN_DRAGON_SCALE_MAIL) ||
+	(uarms && uarms->otyp == GREEN_DRAGON_SCALE_SHIELD))) ||
+((flags.HDbreath == AD_ACID) && (
+	(uarm && uarm->otyp == YELLOW_DRAGON_SCALES || uarm->otyp == YELLOW_DRAGON_SCALE_MAIL) ||
+	(uarms && uarms->otyp == YELLOW_DRAGON_SCALE_SHIELD)))))
+	
 /* Elven gear */
 #define is_elven_weapon(otmp)	((otmp)->otyp == ELVEN_ARROW\
 				|| (otmp)->otyp == ELVEN_SPEAR\

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -502,7 +502,25 @@ domonability()
 		Have_same_dragon_armor_and_shield &&
 		uarm->age < monstermoves && uarms->age < monstermoves
 	){
-		if !(is_ancestral_dragon_gear)
+		if (!((Race_if(PM_HALF_DRAGON) &&
+			(((flags.HDbreath == AD_COLD) && (
+				(uarm && (uarm->otyp == WHITE_DRAGON_SCALES || uarm->otyp == WHITE_DRAGON_SCALE_MAIL)) ||
+				(uarms && uarms->otyp == WHITE_DRAGON_SCALE_SHIELD))) ||
+			((flags.HDbreath == AD_FIRE) && (
+				(uarm && (uarm->otyp == RED_DRAGON_SCALES || uarm->otyp == RED_DRAGON_SCALE_MAIL)) ||
+				(uarms && uarms->otyp == RED_DRAGON_SCALE_SHIELD))) ||
+			((flags.HDbreath == AD_SLEE) && (
+				(uarm && (uarm->otyp == ORANGE_DRAGON_SCALES || uarm->otyp == ORANGE_DRAGON_SCALE_MAIL)) ||
+				(uarms && uarms->otyp == ORANGE_DRAGON_SCALE_SHIELD))) ||
+			((flags.HDbreath == AD_ELEC) && (
+				(uarm && (uarm->otyp == BLUE_DRAGON_SCALES || uarm->otyp == BLUE_DRAGON_SCALE_MAIL)) ||
+				(uarms && uarms->otyp == BLUE_DRAGON_SCALE_SHIELD))) ||
+			((flags.HDbreath == AD_DRST) && (
+				(uarm && (uarm->otyp == GREEN_DRAGON_SCALES || uarm->otyp == GREEN_DRAGON_SCALE_MAIL)) ||
+				(uarms && uarms->otyp == GREEN_DRAGON_SCALE_SHIELD))) ||
+			((flags.HDbreath == AD_ACID) && (
+				(uarm && (uarm->otyp == YELLOW_DRAGON_SCALES || uarm->otyp == YELLOW_DRAGON_SCALE_MAIL)) ||
+				(uarms && uarms->otyp == YELLOW_DRAGON_SCALE_SHIELD))))))){
 			Sprintf(buf, "Armor's Breath Weapon");
 			any.a_int = MATTK_DSCALE;	/* must be non-zero */
 			incntlet = 'a';

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -502,13 +502,15 @@ domonability()
 		Have_same_dragon_armor_and_shield &&
 		uarm->age < monstermoves && uarms->age < monstermoves
 	){
-		Sprintf(buf, "Armor's Breath Weapon");
-		any.a_int = MATTK_DSCALE;	/* must be non-zero */
-		incntlet = 'a';
-		add_menu(tmpwin, NO_GLYPH, &any,
-			incntlet, 0, ATR_NONE, buf,
-			MENU_UNSELECTED);
-		atleastone = TRUE;
+		if !(is_ancestral_dragon_gear)
+			Sprintf(buf, "Armor's Breath Weapon");
+			any.a_int = MATTK_DSCALE;	/* must be non-zero */
+			incntlet = 'a';
+			add_menu(tmpwin, NO_GLYPH, &any,
+				incntlet, 0, ATR_NONE, buf,
+				MENU_UNSELECTED);
+			atleastone = TRUE;
+		}
 	}
 	if(is_were(youracedata)){
 		Sprintf(buf, "Summon Aid");

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -883,77 +883,78 @@ dobreathe(mdat)
 	if (!mattk)
 	    impossible("bad breath attack?");	/* mouthwash needed... */
 	else{
-		int type = mattk->adtyp, multiplier = 1;
+		int type = mattk->adtyp;
+		double multiplier = 1.0;
 		if(type == AD_HDRG){
 			type = flags.HDbreath;
-			if(type == AD_SLEE) multiplier = 4;
+			if(type == AD_SLEE) multiplier = 4.0;
 		}
 		if(Race_if(PM_HALF_DRAGON)){
 			// give Half-dragons a +0.5 bonus per armor piece that matches their default breath
 			if (flags.HDbreath == AD_FIRE){
 				if (uarm){
-					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_RED_DRAGON)
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == &mons[PM_RED_DRAGON])
 						multiplier += 0.5;
-					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_RED_DRAGON)
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == &mons[PM_RED_DRAGON])
 						multiplier += 0.5;
 				} 
 				if (uarms){
-					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_RED_DRAGON)
+					if (Is_dragon_shield(uarms) && Dragon_shield_to_pm(uarms) == &mons[PM_RED_DRAGON])
 						multiplier += 0.5;
 				}
 			} else if (flags.HDbreath == AD_COLD){
 				if (uarm){
-					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_WHITE_DRAGON)
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == &mons[PM_WHITE_DRAGON])
 						multiplier += 0.5;
-					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_WHITE_DRAGON)
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == &mons[PM_WHITE_DRAGON])
 						multiplier += 0.5;
 				} 
 				if (uarms){
-					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_WHITE_DRAGON)
+					if (Is_dragon_shield(uarms) && Dragon_shield_to_pm(uarms) == &mons[PM_WHITE_DRAGON])
 						multiplier += 0.5;
 				}
 			} else if (flags.HDbreath == AD_ELEC){
 				if (uarm){
-					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_BLUE_DRAGON)
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == &mons[PM_BLUE_DRAGON])
 						multiplier += 0.5;
-					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_BLUE_DRAGON)
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == &mons[PM_BLUE_DRAGON])
 						multiplier += 0.5;
 				} 
 				if (uarms){
-					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_BLUE_DRAGON)
+					if (Is_dragon_shield(uarms) && Dragon_shield_to_pm(uarms) == &mons[PM_BLUE_DRAGON])
 						multiplier += 0.5;
 				}
 			} else if (flags.HDbreath == AD_DRST){
 				if (uarm){
-					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_GREEN_DRAGON)
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == &mons[PM_GREEN_DRAGON])
 						multiplier += 0.5;
-					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_GREEN_DRAGON)
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == &mons[PM_GREEN_DRAGON])
 						multiplier += 0.5;
 				} 
 				if (uarms){
-					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_GREEN_DRAGON)
+					if (Is_dragon_shield(uarms) && Dragon_shield_to_pm(uarms) == &mons[PM_GREEN_DRAGON])
 						multiplier += 0.5;
 				}
 			} else if (flags.HDbreath == AD_SLEE){
 				if (uarm){
-					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_ORANGE_DRAGON)
-						multiplier += 0.5;
-					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_ORANGE_DRAGON)
-						multiplier += 0.5;
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == &mons[PM_ORANGE_DRAGON])
+						multiplier += 2.0;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == &mons[PM_ORANGE_DRAGON])
+						multiplier += 2.0;
 				} 
 				if (uarms){
-					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_ORANGE_DRAGON)
-						multiplier += 0.5;
+					if (Is_dragon_shield(uarms) && Dragon_shield_to_pm(uarms) == &mons[PM_ORANGE_DRAGON])
+						multiplier += 2.0;
 				}
 			} else if (flags.HDbreath == AD_ACID){
 				if (uarm){
-					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_YELLOW_DRAGON)
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == &mons[PM_YELLOW_DRAGON])
 						multiplier += 0.5;
-					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_YELLOW_DRAGON)
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == &mons[PM_YELLOW_DRAGON])
 						multiplier += 0.5;
 				} 
 				if (uarms){
-					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_YELLOW_DRAGON)
+					if (Is_dragon_shield(uarms) && Dragon_shield_to_pm(uarms) == &mons[PM_YELLOW_DRAGON])
 						multiplier += 0.5;
 				}
 			}
@@ -962,24 +963,24 @@ dobreathe(mdat)
 			// Chromatic/Platinum dragon gear is never going to naturally apply
 			// Because it's black/silver, so give it appropriate buffs here 
 						
-			if (((uarm && uarm->oartifact == CHROMATIC_DRAGON_SCALES) ||
-				 (uarms && uarms->oartifact == CHROMATIC_DRAGON_SCALES)) && 
+			if (((uarm && uarm->oartifact == ART_CHROMATIC_DRAGON_SCALES) ||
+				 (uarms && uarms->oartifact == ART_CHROMATIC_DRAGON_SCALES)) && 
 				(flags.HDbreath == AD_FIRE || flags.HDbreath == AD_COLD || 
 				 flags.HDbreath == AD_ELEC || flags.HDbreath == AD_DRST ||
-				 flags.HDbreath == AD_ACID)
+				 flags.HDbreath == AD_ACID))
 			
 				multiplier += 0.5;
-			if (uarm && uarm->oartifact == DRAGON_PLATE && 
+			if (uarm && uarm->oartifact == ART_DRAGON_PLATE && 
 				(flags.HDbreath == AD_FIRE || flags.HDbreath == AD_COLD || 
-				 flags.HDbreath == AD_ELEC || flags.HDbreath == AD_SLEE)
+				 flags.HDbreath == AD_ELEC || flags.HDbreath == AD_SLEE))
 			
-				multiplier += 0.5;
+				multiplier += (flags.HDbreath == AD_SLEE)?2.0:0.5;
 		}
 		if(carrying_art(ART_DRAGON_S_HEART_STONE))
 			multiplier *= 2;
 		if(is_true_dragon(mdat) || (Race_if(PM_HALF_DRAGON) && u.ulevel >= 14)) flags.drgn_brth = 1;
 	    buzz(type, FOOD_CLASS, TRUE, (int)mattk->damn + (u.ulevel/2),
-			u.ux, u.uy, u.dx, u.dy,0, mattk->damd ? (d((int)mattk->damn + (u.ulevel/2), (int)mattk->damd)*multiplier) : 0);
+			u.ux, u.uy, u.dx, u.dy,0, mattk->damd ? ((int)(d((int)mattk->damn + (u.ulevel/2), (int)mattk->damd)*multiplier)) : 0);
 		flags.drgn_brth = 0;
 	}
 	return(1);

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -888,6 +888,93 @@ dobreathe(mdat)
 			type = flags.HDbreath;
 			if(type == AD_SLEE) multiplier = 4;
 		}
+		if(Race_if(PM_HALF_DRAGON)){
+			// give Half-dragons a +0.5 bonus per armor piece that matches their default breath
+			if (flags.HDbreath == AD_FIRE){
+				if (uarm){
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_RED_DRAGON)
+						multiplier += 0.5;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_RED_DRAGON)
+						multiplier += 0.5;
+				} 
+				if (uarms){
+					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_RED_DRAGON)
+						multiplier += 0.5;
+				}
+			} else if (flags.HDbreath == AD_COLD){
+				if (uarm){
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_WHITE_DRAGON)
+						multiplier += 0.5;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_WHITE_DRAGON)
+						multiplier += 0.5;
+				} 
+				if (uarms){
+					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_WHITE_DRAGON)
+						multiplier += 0.5;
+				}
+			} else if (flags.HDbreath == AD_ELEC){
+				if (uarm){
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_BLUE_DRAGON)
+						multiplier += 0.5;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_BLUE_DRAGON)
+						multiplier += 0.5;
+				} 
+				if (uarms){
+					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_BLUE_DRAGON)
+						multiplier += 0.5;
+				}
+			} else if (flags.HDbreath == AD_DRST){
+				if (uarm){
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_GREEN_DRAGON)
+						multiplier += 0.5;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_GREEN_DRAGON)
+						multiplier += 0.5;
+				} 
+				if (uarms){
+					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_GREEN_DRAGON)
+						multiplier += 0.5;
+				}
+			} else if (flags.HDbreath == AD_SLEE){
+				if (uarm){
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_ORANGE_DRAGON)
+						multiplier += 0.5;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_ORANGE_DRAGON)
+						multiplier += 0.5;
+				} 
+				if (uarms){
+					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_ORANGE_DRAGON)
+						multiplier += 0.5;
+				}
+			} else if (flags.HDbreath == AD_ACID){
+				if (uarm){
+					if (Is_dragon_scales(uarm) && Dragon_scales_to_pm(uarm) == PM_YELLOW_DRAGON)
+						multiplier += 0.5;
+					if (Is_dragon_mail(uarm) && Dragon_mail_to_pm(uarm) == PM_YELLOW_DRAGON)
+						multiplier += 0.5;
+				} 
+				if (uarms){
+					if (Is_dragon_shield(uarm) && Dragon_shield_to_pm(uarm) == PM_YELLOW_DRAGON)
+						multiplier += 0.5;
+				}
+			}
+			
+			
+			// Chromatic/Platinum dragon gear is never going to naturally apply
+			// Because it's black/silver, so give it appropriate buffs here 
+						
+			if (((uarm && uarm->oartifact == CHROMATIC_DRAGON_SCALES) ||
+				 (uarms && uarms->oartifact == CHROMATIC_DRAGON_SCALES)) && 
+				(flags.HDbreath == AD_FIRE || flags.HDbreath == AD_COLD || 
+				 flags.HDbreath == AD_ELEC || flags.HDbreath == AD_DRST ||
+				 flags.HDbreath == AD_ACID)
+			
+				multiplier += 0.5;
+			if (uarm && uarm->oartifact == DRAGON_PLATE && 
+				(flags.HDbreath == AD_FIRE || flags.HDbreath == AD_COLD || 
+				 flags.HDbreath == AD_ELEC || flags.HDbreath == AD_SLEE)
+			
+				multiplier += 0.5;
+		}
 		if(carrying_art(ART_DRAGON_S_HEART_STONE))
 			multiplier *= 2;
 		if(is_true_dragon(mdat) || (Race_if(PM_HALF_DRAGON) && u.ulevel >= 14)) flags.drgn_brth = 1;


### PR DESCRIPTION
The previous behavior was to just show 2 breath prompts in #monster, one labeled "armor's breath attack" and one just labeled "breath attack". When appropriate, this will only show one "breath attack" ability as an option.

As a half-dragon, wearing the appropriate dragon scale armor (or shield) will boost your breath attack. Each armor piece adds 0.5x (max 2x damage for shield and scales/mail).

The chromatic dragon scales will give a bonus to fire, cold, shock, acid, and poison breath (anything but sleep basically), and the platinum dragon plate will give a bonus to fire, cold, shock, sleep (not acid or poison). This lines up with the resistances they grant. I didn't bother implementing this for black, silver, or gray since I don't forsee those being valid half-dragon breaths anytime soon.

Without any boost, half-dragon breath was equal to magic missiles. With a full 2x multiplier, it's equal to magic missiles with double spell damage (avg 56/max 96 normal, avg 112/max 192 at level 30 each).

Note - the dragon's heart-stone will give a flat 2x modifier that _stacks_ with this, for a theoretical max multiplier of 4x. This comes out to 4*16d6, avg 224 damage / max 384 damage.