### PR TITLE
Allow basic wishing for "petrified" statues, which attaches a monster…

### DIFF
--- a/dat/gehennom.des
+++ b/dat/gehennom.des
@@ -3225,8 +3225,8 @@ MONSTER:'&',"balrog",place[3], asleep
 
 
 TRAP:"statue", place[4]
-CONTAINER:   '`', "statue" ,place[4], cursed, "Shaktari", 1
-OBJECT:')', "flail", contained, cursed, 3, "Sting of the Poison Queen"
+CONTAINER:'#', "cursed petrified statue of Shaktari", place[4]
+OBJECT:'#', "the cursed +3 Sting of the Poison Queen", contained
 MONSTER:'S',"python", place[4]
 MONSTER:'S',"cobra", place[4]
 MONSTER:'S',"python", place[4]

--- a/include/extern.h
+++ b/include/extern.h
@@ -1344,6 +1344,7 @@ E struct obj *FDECL(mkgold, (long,int,int));
 E struct obj *FDECL(mkcorpstat,
 		(int,struct monst *,struct permonst *,int,int,BOOLEAN_P));
 E struct obj *FDECL(obj_attach_mid, (struct obj *, unsigned));
+E struct obj *FDECL(save_mtraits, (struct obj *, struct monst *));
 E struct monst *FDECL(get_mtraits, (struct obj *, BOOLEAN_P));
 E struct obj *FDECL(mk_tt_object, (int,int,int));
 E struct obj *FDECL(mk_named_object,

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -11,7 +11,6 @@ STATIC_DCL void FDECL(handle_material_specials, (struct obj *, int, int));
 STATIC_DCL void FDECL(init_obj_material, (struct obj *));
 #ifdef OVL1
 STATIC_DCL void FDECL(container_weight, (struct obj *));
-STATIC_DCL struct obj *FDECL(save_mtraits, (struct obj *, struct monst *));
 #ifdef WIZARD
 STATIC_DCL const char *FDECL(where_name, (int));
 STATIC_DCL void FDECL(check_contained, (struct obj *,const char *));
@@ -2443,7 +2442,7 @@ unsigned mid;
     return otmp;
 }
 
-static struct obj *
+struct obj *
 save_mtraits(obj, mtmp)
 struct obj *obj;
 struct monst *mtmp;

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3135,7 +3135,7 @@ int wishflags;
 	boolean allow_artifact = !!(wishflags & WISH_ARTALLOW);
 	
 	int halfeaten, halfdrained, mntmp, contents;
-	int islit, unlabeled, ishistoric, isdiluted;
+	int islit, unlabeled, ishistoric, ispetrified, isdiluted;
 	struct fruit *f;
 	int ftype = current_fruit;
 	char fruitbuf[BUFSZ];
@@ -3395,6 +3395,8 @@ int wishflags;
 			halfeaten = 1;
 		} else if (!strncmpi(bp, "historic ", l=9)) {
 			ishistoric = 1;
+		} else if (!strncmpi(bp, "petrified ", l=10)) {
+			ispetrified = 1;
 		} else if (!strncmpi(bp, "diluted ", l=8)) {
 			isdiluted = 1;
 		} else if(!strncmpi(bp, "empty ", l=6)) {
@@ -4792,6 +4794,24 @@ typfnd:
 	/* set moon phase */
 	if(moonphase != -1 && otmp->otyp == MOON_AXE){
 		otmp->ovar1 = moonphase;
+	}
+
+	/* attach creature of the item's permonst type */
+	if(ispetrified && wizwish && otmp->corpsenm != NON_PM){
+		struct monst * mon;
+		struct obj * otmp2;
+		mon = makemon(&mons[otmp->corpsenm], 0, 0, NO_MINVENT);
+		otmp2 = save_mtraits(otmp, mon);
+		mongone(mon);
+		if (otmp2){
+			otmp = otmp2;
+		}
+		else {
+			//something went wrong
+			impossible("bad petrified statue?");
+			*wishreturn = WISH_FAILURE;
+			return &zeroobj;
+		}
 	}
 	
 	/* more wishing abuse: don't allow wishing for certain artifacts */


### PR DESCRIPTION
… to the statue

This creates a monster of the appropriate corpsenm to attach to the statue, which is needed for statue traps to generate a unique monster. This is NOT enough to specify a statue of a derived undead or tame creature.
Use this to attach the Shaktari monster to the statue in Demogorgon's lair. (https://github.com/Chris-plus-alphanumericgibberish/dNAO/projects/3#card-24874236, https://github.com/Chris-plus-alphanumericgibberish/dNAO/projects/3#card-24499719)

Also works for corpses, but is rather useless since only permonst ID can be specified.