### PR TITLE
For some reason, this is necessary.

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -225,7 +225,7 @@ struct obj {
 #define OPROP_VORPW		0x0001000000000000
 #define OPROP_MORGW		0x0002000000000000
 #define OPROP_WRTHW		0x0004000000000000
-#define OPROP_W_MASK	~OPROP_DEF_MASK
+#define OPROP_W_MASK	0xffffffff00000000
 
   unsigned oeaten;	/* nutrition left in food, if partly eaten */
 	long age;		/* creation date */


### PR DESCRIPTION
Testing concluded the following:
0x00000000ffffffff == ~(0xffffffff00000000)
0xffffffff00000000 != ~(0x00000000ffffffff)

So let's not use '~' with long long integers.