### PR TITLE
Black web allows 2wep with blank offhand

### DIFF
--- a/src/wield.c
+++ b/src/wield.c
@@ -515,6 +515,7 @@ test_twoweapon()
 	if (!could_twoweap(youmonst.data) && 
 		!(!Upolyd && Role_if(PM_ANACHRONONAUT)) && 
 		!(u.specialSealsActive&SEAL_MISKA) && 
+		!(u.specialSealsActive&SEAL_BLACK_WEB && !uswapwep) && 
 		!(!Upolyd && uwep && uswapwep && 
 			((artilist[uwep->oartifact].inv_prop == DANCE_DAGGER && artilist[uswapwep->oartifact].inv_prop == SING_SPEAR) ||
 			 (artilist[uswapwep->oartifact].inv_prop == DANCE_DAGGER && artilist[uwep->oartifact].inv_prop == SING_SPEAR))


### PR DESCRIPTION
Even if you can't normally two-weapon, you can two-weapon any one-handed weapon with a shadowblade or two-weapon. This obeys the standard two-weaponing rules, and does NOT let you two-weapon a blank main hand with an offhand weapon. The latter should rarely matter but if there's some item with a penalty for wielding it, it won't bypass that I guess.