### PR TITLE
Beartrap in shop setting message

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -3263,6 +3263,16 @@ struct obj *otmp;
 	You("begin setting %s %s.",
 	    shk_your(buf, otmp),
 	    defsyms[trap_to_defsym(what_trap(ttyp))].explanation);
+	
+	if (otmp->unpaid){
+		verbalize("You set it, you buy it!");
+		if (!rn2(3))
+			verbalize("If you hurt somebody, it's not my fault!");
+		bill_dummy_object(otmp);
+	} else {
+		verbalize("Don't hurt my customers!");
+	}
+	
 	set_occupation(set_trap, occutext, 0);
 	return;
 }


### PR DESCRIPTION
Gives a message now when you set a beartrap up in a shop if it's not yours, instead of just silently adding it to your bill. I also added a message if its yours just for completeness.

Note - it's a stupid idea to kept placing / setting traps, since you'll make money for every time you untrap it (and sell it back to the shopkeeper), but you'll pay the full cost when you place the shopkeeper's trap done, so it's a losing battle unless you've got 25 charisma, where you just break even.