### PR TITLE
Fix the Pen of the Void

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1993,6 +1993,7 @@ static const char * const mb_verb[2][4] = {
 #define MB_INDEX_CANCEL		3
 
 /* called when someone is being hit by the pen of the void */
+/* called when someone is being hit by the pen of the void */
 STATIC_OVL boolean
 voidPen_hit(magr, mdef, pen, dmgptr, dieroll, vis, hittee)
 struct monst *magr, *mdef;	/* attacker and defender */
@@ -2010,8 +2011,67 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 	int berithdamage = 0;
 	
 	buf[0] = '\0';
+		
+	if(u.voidChime){
+		pline("The ringing blade hits %s.", hittee);
+		vis = FALSE;
+	}
 	
-	if(pen->ovar1&SEAL_BERITH){
+	if (u.specialSealsActive&SEAL_COSMOS || u.specialSealsActive&SEAL_LIVING_CRYSTAL || u.specialSealsActive&SEAL_TWO_TREES){
+		*dmgptr += (mdef->data->maligntyp == A_CHAOTIC)? d(2*dnum,4) : ((mdef->data->maligntyp == A_NEUTRAL) ? d(dnum, 4) : 0);
+	} else if (u.specialSealsActive&SEAL_MISKA){
+		*dmgptr += (mdef->data->maligntyp == A_LAWFUL)? d(2*dnum,4) : ((mdef->data->maligntyp == A_NEUTRAL) ? d(dnum, 4) : 0);
+	} else if (u.specialSealsActive&SEAL_NUDZIRATH){
+		*dmgptr += (mdef->data->maligntyp != A_NEUTRAL)? d(dnum,6) : 0;
+	} else if (u.specialSealsActive&SEAL_ALIGNMENT_THING){
+		if(rn2(3)) dmgptr += d(rnd(2)*dnum,4);
+	} else if (u.specialSealsActive&SEAL_UNKNOWN_GOD){
+		*dmgptr -= pen->spe;
+	}
+	
+	if (pen->ovar1&SEAL_AHAZU && dieroll < 5){
+	    *dmgptr += d(dnum,4);
+		if(vis) {
+			pline("The blade's shadow catches on %s.", hittee);
+			and = TRUE;
+		}
+		mdef->movement -= 3;
+	}
+	if (pen->ovar1&SEAL_AMON) {
+	    if (vis){ 
+			Sprintf(buf, "fiery");
+			and = TRUE;
+		}
+	    if (!rn2(4)) (void) destroy_mitem(mdef, POTION_CLASS, AD_FIRE);
+	    if (!rn2(4)) (void) destroy_mitem(mdef, SCROLL_CLASS, AD_FIRE);
+	    if (!rn2(7)) (void) destroy_mitem(mdef, SPBOOK_CLASS, AD_FIRE);
+	    if (youdefend && Slimed) burn_away_slime();
+		if(youdefend ? !Fire_resistance : !resists_fire(mdef)){
+			*dmgptr += d(dnum,4);
+		}
+	} // triggers narrow_voidPen_hit - fire res
+	if (pen->ovar1&SEAL_ASTAROTH) {
+	    if (vis){ 
+			and ? Strcat(buf, " and crackling") : Sprintf(buf, "crackling");
+			and = TRUE;
+		}
+	    if (!rn2(5)) (void) destroy_mitem(mdef, RING_CLASS, AD_ELEC);
+	    if (!rn2(5)) (void) destroy_mitem(mdef, WAND_CLASS, AD_ELEC);
+		if(youdefend ? !Shock_resistance : !resists_elec(mdef)){
+			*dmgptr += d(dnum,4);
+		}
+	} // nvPh - shock res
+	if (pen->ovar1&SEAL_BALAM) {
+	    if (vis){ 
+			and ? Strcat(buf, " yet freezing") : Sprintf(buf, "freezing");
+			and = TRUE;
+		}
+	    if (!rn2(4)) (void) destroy_mitem(mdef, POTION_CLASS, AD_COLD);
+		if(youdefend ? !Cold_resistance : !resists_cold(mdef)){
+			*dmgptr += d(dnum,4);
+		}
+	} // nvPh - cold res
+	if (pen->ovar1&SEAL_BERITH){
 		berithdamage = d(dnum,4);
 #ifndef GOLDOBJ
 		if (!youattack || u.ugold >= berithdamage)
@@ -2029,52 +2089,52 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		} else {
 			berithdamage = 0;
 		}
-	}
-	
-	if(u.voidChime){
-		pline("The ringing blade hits %s.", hittee);
-	} else {
-	if (pen->ovar1&SEAL_AMON) {
-	    if (vis){ 
-			Sprintf(buf, "fiery");
+		
+		if(vis && berithdamage > 0){
+			if(pen->ovar1&SEAL_AMON) and ? Strcat(buf, " and blood-crusted") : Sprintf(buf, "blood-crusted");
+			else and ? Strcat(buf, " and blood-soaked") : Sprintf(buf, "blood-soaked");
 			and = TRUE;
 		}
-	    if (!rn2(4)) (void) destroy_mitem(mdef, POTION_CLASS, AD_FIRE);
-	    if (!rn2(4)) (void) destroy_mitem(mdef, SCROLL_CLASS, AD_FIRE);
-	    if (!rn2(7)) (void) destroy_mitem(mdef, SPBOOK_CLASS, AD_FIRE);
-	    if (youdefend && Slimed) burn_away_slime();
-		if(youdefend ? !Fire_resistance : !resists_fire(mdef)){
+	}
+	if (pen->ovar1&SEAL_BUER){
+		if(youattack) healup(d(dnum,4), 0, FALSE, FALSE);
+		else magr->mhp = min(magr->mhp + d(dnum,4),magr->mhpmax);
+	}
+	if (pen->ovar1&SEAL_CHUPOCLOPS && dieroll < 3){
+		struct trap *ttmp2 = maketrap(mdef->mx, mdef->my, WEB);
+	    *dmgptr += d(dnum,4);
+		if (ttmp2){
+			if(youdefend){
+				pline_The("webbing sticks to you. You're caught!");
+				dotrap(ttmp2, NOWEBMSG);
+#ifdef STEED
+				if (u.usteed && u.utrap) {
+				/* you, not steed, are trapped */
+				dismount_steed(DISMOUNT_FELL);
+				}
+#endif
+			}
+			else mintrap(mdef);
+		}
+	}
+	if (pen->ovar1&SEAL_DANTALION){
+		if(youdefend || !mindless_mon(mdef))
+			*dmgptr += d(dnum,4);
+		if(dieroll < 3){
+			if(youdefend) aggravate();
+			else probe_monster(mdef);
+		}
+	} // nvPh - !mindless
+	if (pen->ovar1&SEAL_ECHIDNA) {
+	    if (vis){ 
+			and ? Strcat(buf, " and sizzling") : Sprintf(buf, "sizzling");
+			and = TRUE;
+		}
+	    if (!rn2(2)) (void) destroy_mitem(mdef, POTION_CLASS, AD_FIRE);
+		if(youdefend ? !Acid_resistance : !resists_acid(mdef)){
 			*dmgptr += d(dnum,4);
 		}
-	}
-	if (pen->ovar1&SEAL_BALAM) {
-	    if (vis){ 
-			and ? Strcat(buf, " yet freezing") : Sprintf(buf, "freezing");
-			and = TRUE;
-		}
-	    if (!rn2(4)) (void) destroy_mitem(mdef, POTION_CLASS, AD_COLD);
-		if(youdefend ? !Cold_resistance : !resists_cold(mdef)){
-			*dmgptr += d(dnum,4);
-		}
-	}
-	if (pen->ovar1&SEAL_ASTAROTH) {
-	    if (vis){ 
-			and ? Strcat(buf, " and crackling") : Sprintf(buf, "crackling");
-			and = TRUE;
-		}
-	    if (!rn2(5)) (void) destroy_mitem(mdef, RING_CLASS, AD_ELEC);
-	    if (!rn2(5)) (void) destroy_mitem(mdef, WAND_CLASS, AD_ELEC);
-		if(youdefend ? !Shock_resistance : !resists_elec(mdef)){
-			*dmgptr += d(dnum,4);
-		}
-	}
-	if(pen->ovar1&SEAL_BERITH && berithdamage > 0){
-		if(vis){
-			if(pen->ovar1&SEAL_AMON) and ? Strcat(buf, " blood-crusted") : Sprintf(buf, "blood-crusted");
-			else and ? Strcat(buf, " blood-soaked") : Sprintf(buf, "blood-soaked");
-			and = TRUE;
-		}
-	}
+	} // nvPh - acid res
 	if (pen->ovar1&SEAL_ENKI) {
 	    if (vis){ 
 			if(pen->ovar1&SEAL_AMON) and ? Strcat(buf, " and steaming") : Sprintf(buf, "steaming");
@@ -2133,7 +2193,33 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 				}
 			}
 		}
-	}
+	} // nvPh - water res
+	if (pen->ovar1&SEAL_FAFNIR){
+		if (vis){
+			and ? Strcat(buf, " and ruinous") : Sprintf(buf, "ruinous");
+			and = TRUE;
+		}
+		if(youdefend ? is_golem(youracedata) : is_golem(mdef->data)){
+			*dmgptr += d(2*dnum,4);
+		} else if(youdefend ? nonliving(youracedata) : nonliving_mon(mdef)){
+			*dmgptr += d(dnum,4);
+		}
+	} // nvPh - golem/nonliving
+	if (pen->ovar1&SEAL_HUGINN_MUNINN){
+		if(youdefend){
+			if(!Blind){
+				make_blinded(Blinded+1L,FALSE);
+				*dmgptr += d(dnum,4);
+			}
+		}
+		else if(!youdefend){
+			if(mdef->mcansee && haseyes(mdef->data)){
+				*dmgptr += d(dnum,4);
+				mdef->mcansee = 0;
+				mdef->mblinded = 1;
+			}
+		}
+	} // nvPh - blind
 	if (pen->ovar1&SEAL_IRIS) {
 	    if (vis){ 
 			if(pen->ovar1&SEAL_ENKI) and ? Strcat(buf, " yet thirsty") : Sprintf(buf, "thirsty");
@@ -2143,81 +2229,22 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving_mon(mdef) || is_anhydrous(mdef->data))){
 			*dmgptr += d(dnum,4);
 		}
-	}
-	if (pen->ovar1&SEAL_ECHIDNA) {
-	    if (vis){ 
-			and ? Strcat(buf, " and sizzling") : Sprintf(buf, "sizzling");
-			and = TRUE;
-		}
-	    if (!rn2(2)) (void) destroy_mitem(mdef, POTION_CLASS, AD_FIRE);
-		if(youdefend ? !Acid_resistance : !resists_acid(mdef)){
-			*dmgptr += d(dnum,4);
-		}
-	}
-	
-	if(vis && (and || (pen->ovar1&SEAL_FAFNIR))){
-		pline("The %s%s blade hits %s.", !(pen->ovar1&SEAL_FAFNIR) ? "" : and ? "ruinous " : "ruinous", buf, hittee);
-		and = TRUE;
-		if(youdefend ? is_golem(youracedata) : is_golem(mdef->data)){
-			*dmgptr += d(2*dnum,4);
-		} else if(youdefend ? nonliving(youracedata) : nonliving_mon(mdef)){
-			*dmgptr += d(dnum,4);
-		}
-	}
-	}
-	if(pen->ovar1&SEAL_AHAZU && dieroll < 5){
-	    *dmgptr += d(dnum,4);
-		if(vis) pline("The blade's shadow catches on %s.", hittee);
-		mdef->movement -= 3;
-		and = TRUE;
-	}
-	if(pen->ovar1&SEAL_BUER){
-		if(youattack) healup(d(dnum,4), 0, FALSE, FALSE);
-		else magr->mhp = min(magr->mhp + d(dnum,4),magr->mhpmax);
-	}
-	if(pen->ovar1&SEAL_CHUPOCLOPS && dieroll < 3){
-		struct trap *ttmp2 = maketrap(mdef->mx, mdef->my, WEB);
-	    *dmgptr += d(dnum,4);
-		if (ttmp2){
-			if(youdefend){
-				pline_The("webbing sticks to you. You're caught!");
-				dotrap(ttmp2, NOWEBMSG);
-#ifdef STEED
-				if (u.usteed && u.utrap) {
-				/* you, not steed, are trapped */
-				dismount_steed(DISMOUNT_FELL);
-				}
-#endif
-			}
-			else mintrap(mdef);
-		}
-	}
-	if(pen->ovar1&SEAL_DANTALION){
-	    if(youdefend || !mindless_mon(mdef))
-			*dmgptr += d(dnum,4);
-		if(dieroll < 3){
-			if(youdefend) aggravate();
-			else probe_monster(mdef);
-		}
-	}
-	if(pen->ovar1&SEAL_SHIRO){
-		struct obj *otmp;
-		otmp = mksobj((mvitals[PM_ACERERAK].died > 0) ? BOULDER : ROCK, TRUE, FALSE);
-		otmp->blessed = 0;
-		otmp->cursed = 0;
-		set_destroy_thrown(1); //state variable referenced in drop_throw
-			m_throw(magr, magr->mx, magr->my, mdef->mx-magr->mx, mdef->my-magr->my, 1, otmp,TRUE);
-		set_destroy_thrown(0);  //state variable referenced in drop_throw
-		if(mdef->mhp <= 0) return vis;//Monster was killed by throw and we should stop.
-	}
-	if(pen->ovar1&SEAL_MOTHER && dieroll <= dnum){
-		if(youdefend) nomul(5,"held by the pen of the void");
+	} // nvPh - hydrous
+	if (pen->ovar1&SEAL_MOTHER && dieroll <= dnum){
+		if(youdefend) nomul(5,"held by the Pen of the Void");
 	    else if(mdef->mcanmove || mdef->mfrozen){
 			mdef->mcanmove = 0;
 			mdef->mfrozen = max(mdef->mfrozen, 5);
 		}
 	}
-	if(pen->ovar1&SEAL_ORTHOS && dieroll < 3){
+	if (pen->ovar1&SEAL_NABERIUS){
+		if(youdefend && (Upolyd ? u.mh < .25*u.mhmax : u.uhp < .25*u.uhpmax)) *dmgptr += d(dnum,4);
+		else if(!youdefend){
+			if(mdef->mflee) *dmgptr += d(dnum,4);
+			if(mdef->mpeaceful) *dmgptr += d(dnum,4);
+		}
+	} // nvPh - peaceful/fleeing
+	if (pen->ovar1&SEAL_ORTHOS && dieroll < 3){
 	    *dmgptr += d(2*dnum,8);
 		if(youdefend){
 			You("are addled by the gusting winds!");
@@ -2230,7 +2257,13 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		}
 		and = TRUE;
 	}
-	if(pen->ovar1&SEAL_OTIAX){
+	if (pen->ovar1&SEAL_OSE){
+		if(youdefend && (Blind_telepat || !rn2(5))) *dmgptr += d(dnum,15);
+		else if(!youdefend && !mindless_mon(mdef) && (mon_resistance(mdef,TELEPAT) || !rn2(5))) *dmgptr += d(dnum,15);
+	} // nvPh - telepathy
+	if (pen->ovar1&SEAL_OTIAX){
+		char bufO[BUFSZ];
+		bufO[0] = '\0';
 	    *dmgptr += d(1,dnum);
 		if(youattack){
 			if(dieroll == 1){
@@ -2276,14 +2309,14 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 			}
 		} else if(youdefend){
 			if(!(u.sealsActive&SEAL_ANDROMALIUS)){
-				buf[0] = '\0';
-				switch(steal(magr, buf, FALSE, FALSE)){
+				bufO[0] = '\0';
+				switch(steal(magr, bufO, FALSE, FALSE)){
 				  case -1:
 					return vis;
 				  case 0:
 				  break;
 				  default:
-					pline("%s steals %s.", Monnam(magr), buf);
+					pline("%s steals %s.", Monnam(magr), bufO);
 				  break;
 				}
 			}
@@ -2317,8 +2350,8 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 					Strcpy(onambuf, doname(otmp));
 				(void) add_to_minv(magr, otmp);
 				if (vis) {
-					Strcpy(buf, Monnam(magr));
-					pline("%s steals %s from %s!", buf,
+					Strcpy(bufO, Monnam(magr));
+					pline("%s steals %s from %s!", bufO,
 						onambuf, mdefnambuf);
 				}
 				possibly_unwield(mdef, FALSE);
@@ -2329,11 +2362,21 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 			}
 		}
 	}
-	if(pen->ovar1&SEAL_PAIMON){
+	if (pen->ovar1&SEAL_PAIMON){
 		if(youattack) u.uen = min(u.uen+dnum,u.uenmax);
 		else magr->mspec_used = max(magr->mspec_used - dnum,0);
-	}
-	if(pen->ovar1&SEAL_SIMURGH){
+	} // nvPh - !cancelled
+	if (pen->ovar1&SEAL_SHIRO){
+		struct obj *otmp;
+		otmp = mksobj((mvitals[PM_ACERERAK].died > 0) ? BOULDER : ROCK, TRUE, FALSE);
+		otmp->blessed = 0;
+		otmp->cursed = 0;
+		set_destroy_thrown(1); //state variable referenced in drop_throw
+			m_throw(magr, magr->mx, magr->my, mdef->mx-magr->mx, mdef->my-magr->my, 1, otmp,TRUE);
+		set_destroy_thrown(0);  //state variable referenced in drop_throw
+		if(mdef->mhp <= 0) return vis;//Monster was killed by throw and we should stop.
+	} // nvPh potential - invisible?
+	if (pen->ovar1&SEAL_SIMURGH){
 		if(youdefend && !Blind){
 			You("are dazzled by prismatic feathers!");
 			make_stunned((HStun + 5), FALSE);
@@ -2346,8 +2389,8 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 			if(mvitals[PM_ACERERAK].died > 0) *dmgptr += d(2,4);
 		}
 		and = TRUE;
-	}
-	if(pen->ovar1&SEAL_TENEBROUS && dieroll <= dnum){
+	} // nvPh - blind
+	if (pen->ovar1&SEAL_TENEBROUS && dieroll <= dnum){
 		if(youdefend && !Drain_resistance){
 			if (Blind)
 				You_feel("an unholy blade drain your life!");
@@ -2374,8 +2417,10 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 			}
 		}
 		and = TRUE;
-	}
-	return vis&&and;
+	} // nvPh - drain res
+	
+	pline("The %s blade hits %s.", buf, hittee);	
+	return (and || vis); // vis should be redundant, but it's not a bad idea since riker can be a dumb bitch
 }
 
 /* called when someone is being hit by the pen of the void */
@@ -2386,13 +2431,29 @@ struct obj *pen;	/* Pen of the Void */
 {
 	boolean youdefend = mdef == &youmonst;
 	
-	
-	// if(pen->ovar1&SEAL_BERITH){
-		// //Requires knowing the attacker
-	// }
+	/*
+	if (u.specialSealsActive&SEAL_COSMOS || u.specialSealsActive&SEAL_LIVING_CRYSTAL || u.specialSealsActive&SEAL_TWO_TREES) {
+		if(!youdefend && (mdef->data->maligntyp == A_CHAOTIC)) return TRUE;
+	}
+	else if (u.specialSealsActive&SEAL_MISKA) {
+		if(!youdefend && (mdef->data->maligntyp == A_LAWFUL)) return TRUE;
+	}
+	else if (u.specialSealsActive&SEAL_NUDZIRATH) {
+		if(!youdefend && (mdef->data->maligntyp != A_NEUTRAL) && !rn2(2)) return TRUE;
+	}
+	else if (u.specialSealsActive&SEAL_ALIGNMENT_THING) {
+		if(!youdefend && !rn2(3)) return TRUE;
+	}
+	*/
+	// I went ahead and implemented these, not sure if they're balanced so commented out - riker	
 	
 	if (pen->ovar1&SEAL_AMON) {
 		if(youdefend ? !Fire_resistance : !resists_fire(mdef)){
+			return TRUE;
+		}
+	}
+	if (pen->ovar1&SEAL_ASTAROTH) {
+		if(youdefend ? !Shock_resistance : !resists_elec(mdef)){
 			return TRUE;
 		}
 	}
@@ -2401,10 +2462,9 @@ struct obj *pen;	/* Pen of the Void */
 			return TRUE;
 		}
 	}
-	if (pen->ovar1&SEAL_ASTAROTH) {
-		if(youdefend ? !Shock_resistance : !resists_elec(mdef)){
+	if (pen->ovar1&SEAL_DANTALION){
+	    if(youdefend || !mindless_mon(mdef))
 			return TRUE;
-		}
 	}
 	if (pen->ovar1&SEAL_ENKI) {
 		if(youdefend){
@@ -2451,30 +2511,19 @@ struct obj *pen;	/* Pen of the Void */
 			}
 		}
 	}
-	if (pen->ovar1&SEAL_IRIS) {
-		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving_mon(mdef) || is_anhydrous(mdef->data))){
-			return TRUE;
-		}
-	}
 	if (pen->ovar1&SEAL_ECHIDNA) {
 		if(youdefend ? !Acid_resistance : !resists_acid(mdef)){
 			return TRUE;
 		}
 	}
-	
-	if(pen->ovar1&SEAL_FAFNIR){
+	if (pen->ovar1&SEAL_FAFNIR){
 		if(youdefend ? is_golem(youracedata) : is_golem(mdef->data)){
 			return TRUE;
 		} else if(youdefend ? nonliving(youracedata) : nonliving_mon(mdef)){
 			return TRUE;
 		}
 	}
-	
-	if(pen->ovar1&SEAL_DANTALION){
-	    if(youdefend || !mindless_mon(mdef))
-			return TRUE;
-	}
-	if(pen->ovar1&SEAL_SIMURGH){
+	if (pen->ovar1&SEAL_HUGINN_MUNINN){
 		if(youdefend && !Blind){
 			return TRUE;
 		}
@@ -2482,7 +2531,44 @@ struct obj *pen;	/* Pen of the Void */
 			return TRUE;
 		}
 	}
-	if(pen->ovar1&SEAL_TENEBROUS){
+	if (pen->ovar1&SEAL_IRIS) {
+		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving_mon(mdef) || is_anhydrous(mdef->data))){
+			return TRUE;
+		}
+	}
+	if (pen->ovar1&SEAL_NABERIUS){
+		if(youdefend && (Upolyd ? u.mh < .25*u.mhmax : u.uhp < .25*u.uhpmax)){
+			return TRUE;
+		}
+		else if(mdef->mflee || mdef->mpeaceful){
+			return TRUE;
+		}
+	}
+	if (pen->ovar1&SEAL_OSE){
+		if(youdefend && Blind_telepat){
+			return TRUE;
+		}
+		else if(!mindless_mon(mdef) && mon_resistance(mdef,TELEPAT)){
+			return TRUE;
+		}
+	}
+	if (pen->ovar1&SEAL_PAIMON){
+		if(youdefend && (u.uen < u.uenmax/4)){
+			return TRUE;
+		}
+		else if(mdef->mcan){
+			return TRUE;
+		}
+	}
+	if (pen->ovar1&SEAL_SIMURGH){
+		if(youdefend && !Blind){
+			return TRUE;
+		}
+		else if(mdef->mcansee && haseyes(mdef->data)){
+			return TRUE;
+		}
+	}
+	if (pen->ovar1&SEAL_TENEBROUS){
 		if(youdefend && !Drain_resistance){
 			return TRUE;
 		}
@@ -2490,6 +2576,7 @@ struct obj *pen;	/* Pen of the Void */
 			return TRUE;
 		}
 	}
+
 	return FALSE;
 }
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -146,7 +146,6 @@ STATIC_DCL boolean FDECL(can_advance, (int, BOOLEAN_P));
 STATIC_DCL boolean FDECL(could_advance, (int));
 STATIC_DCL boolean FDECL(peaked_skill, (int));
 STATIC_DCL int FDECL(slots_required, (int));
-STATIC_DCL int FDECL(pendamage, (struct obj *,struct monst *));
 
 #ifdef OVL1
 
@@ -1064,9 +1063,6 @@ int spec;
 		static int warnedotyp = 0;
 		static struct permonst *warnedptr = 0;
 		
-		if(otmp->oartifact == ART_PEN_OF_THE_VOID){
-			tmp += pendamage(otmp, mon);
-		}
 		if(otmp->oartifact == ART_ROD_OF_SEVEN_PARTS 
 			&& !otmp->blessed && !otmp->cursed
 			&& mon
@@ -1261,92 +1257,6 @@ int spec;
 	return(tmp);
 }
 
-STATIC_OVL
-int
-pendamage(pen, mon)
-struct obj *pen;
-struct monst *mon;
-{
-	boolean youdef = mon == &youmonst;
-	int dmg = 0;
-	int dnum = (Role_if(PM_EXILE) && quest_status.killed_nemesis) ? 2 : 1;
-	
-	if(u.specialSealsActive&SEAL_COSMOS || u.specialSealsActive&SEAL_LIVING_CRYSTAL || u.specialSealsActive&SEAL_TWO_TREES){
-		if(mon->data->maligntyp == A_CHAOTIC) dmg += d(2*dnum,4);
-		else if(mon->data->maligntyp == A_NEUTRAL) dmg += d(dnum,4);
-	} else if(u.specialSealsActive&SEAL_MISKA){
-		if(mon->data->maligntyp == A_LAWFUL) dmg += d(2*dnum,4);
-		else if(mon->data->maligntyp == A_NEUTRAL) dmg += d(dnum,4);
-	} else if(u.specialSealsActive&SEAL_NUDZIRATH){
-		if(mon->data->maligntyp != A_NEUTRAL) dmg += d(dnum,6);
-	} else if(u.specialSealsActive&SEAL_ALIGNMENT_THING){
-		if(rn2(3)) dmg += d(rnd(2)*dnum,4);
-	} else if(u.specialSealsActive&SEAL_UNKNOWN_GOD){
-		dmg -= pen->spe;
-	}
-	
-	if(pen->ovar1&SEAL_AMON){
-		if(youdef && !Fire_resistance) dmg += d(dnum,4);
-		else if(!youdef && !resists_fire(mon)) dmg += d(resists_cold(mon) ? 2*dnum : dnum,4);
-	}
-	if(pen->ovar1&SEAL_ASTAROTH){
-		if(youdef && !Shock_resistance) dmg += d(dnum,4);
-		else if(!youdef && !resists_elec(mon)) dmg += d(dnum,4);
-	}
-	if(pen->ovar1&SEAL_BALAM){
-		if(youdef && !Cold_resistance) dmg += d(dnum,4);
-		else if(!youdef && !resists_cold(mon)) dmg += d(resists_fire(mon) ? 2*dnum : dnum,4);
-	}
-	if(pen->ovar1&SEAL_ECHIDNA){
-		if(youdef && !Acid_resistance) dmg += d(dnum,4);
-		else if(!youdef && !resists_acid(mon)) dmg += d(dnum,4);
-	}
-	if(pen->ovar1&SEAL_FAFNIR){
-		if(youdef){
-			if(is_golem(youracedata)) dmg += d(2*dnum,4);
-			else if(nonliving(youracedata)) dmg += d(dnum,4);
-		}
-		else {
-			if(is_golem(mon->data)) dmg += d(2*dnum,4);
-			else if(nonliving_mon(mon)) dmg += d(dnum,4);
-		}
-	}
-	if(pen->ovar1&SEAL_IRIS){
-		if(youdef && !(nonliving(youracedata) || is_anhydrous(youracedata))) dmg += d(dnum,4);
-		else if(!youdef && !(nonliving_mon(mon) || is_anhydrous(mon->data))) dmg += d(dnum,4);
-	}
-	if(pen->ovar1&SEAL_ENKI){
-		if(youdef && !(nonliving(youracedata) || amphibious(youracedata))) dmg += d(dnum,4);
-		else if(!youdef && !(nonliving_mon(mon) || amphibious_mon(mon))) dmg += d(dnum,4);
-	}
-	if(pen->ovar1&SEAL_OSE){
-		if(youdef && (Blind_telepat || !rn2(5))) dmg += d(dnum,15);
-		else if(!youdef && !mindless_mon(mon) && (mon_resistance(mon,TELEPAT) || !rn2(5))) dmg += d(dnum,15);
-	}
-	if(pen->ovar1&SEAL_NABERIUS){
-		if(youdef && (Upolyd ? u.mh < .25*u.mhmax : u.uhp < .25*u.uhpmax)) dmg += d(dnum,4);
-		else if(!youdef){
-			if(mon->mflee) dmg += d(dnum,4);
-			if(mon->mpeaceful) dmg += d(dnum,4);
-		}
-	}
-	if(pen->ovar1&SEAL_HUGINN_MUNINN){
-		if(youdef){
-			if(!Blind){
-				make_blinded(Blinded+1L,FALSE);
-				dmg += d(dnum,4);
-			}
-		}
-		else if(!youdef){
-			if(mon->mcansee && haseyes(mon->data)){
-				dmg += d(dnum,4);
-				mon->mcansee = 0;
-				mon->mblinded = 1;
-			}
-		}
-	}
-	return dmg;
-}
 
 #endif /* OVLB */
 #ifdef OVL0


### PR DESCRIPTION
Damage was broken, as was messaging. To quote the commit msg for the first commit:

```
long story short this should make all pen damage thingies (22 of the 31 spirits of the near void, and the alignment spirits) process when artifact_hit is run. there's 9 spirits that don't have damage-based thingies (ymir's poison, jack's light) so they're scattered in appropriate places elsewhere

in addition, narrow_voidPen_hit now has around 4 more exceptions (ose - telepathy, h&m - !blind, paimon - !cancelled, naberius - fleeing/peaceful)
```