### PR TITLE
No double space with empty pen

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2420,7 +2420,10 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		and = TRUE;
 	} // nvPh - drain res
 	
-	pline("The %s blade hits %s.", buf, hittee);	
+	
+	if (buf[0] != '\0')
+		pline("The %s blade hits %s.", buf, hittee);
+	
 	return (and || vis); // vis should be redundant, but it's not a bad idea since riker can be a dumb bitch
 }
 


### PR DESCRIPTION
since I think it's fine to just axe the "the blade hits the newt" anyway, it's not like it conveys any important information.

(previously it said `"The[  ]blade hits the newt"`)