### PR TITLE
Fixes related to lightsaber schenanigans

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -246,7 +246,7 @@ int thrown;
 	m_shot.s = ammo_and_launcher(obj,launcher) ? TRUE : FALSE;
 	/* give a message if shooting more than one, or if player
 	   attempted to specify a count */
-	if(obj->oartifact == ART_FLUORITE_OCTAHEDRON){
+	if(obj->oartifact == ART_FLUORITE_OCTAHEDRON && obj->oclass == GEM_CLASS){
 		if(!ammo_and_launcher(obj,launcher)){
 			if(shotlimit && shotlimit < obj->quan) You("throw %d Fluorite %s.", shotlimit, shotlimit > 1 ? "Octahedra" : "Octahedron");
 			else if(obj->quan == 8) You("throw the Fluorite Octet.");

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -4867,6 +4867,17 @@ typfnd:
 		*wishreturn = WISH_DENIED;
 		return &zeroobj;
 	}
+	/* even more wishing abuse: if we tried to create an artifact but failed (it was already generated) we may need a new otyp */
+	if (isartifact && !otmp->oartifact) {
+		switch (otmp->otyp) {
+		case BEAMSWORD:
+			otmp = poly_obj(otmp, BROADSWORD);
+			break;
+		case UNIVERSAL_KEY:
+			otmp = poly_obj(otmp, SKELETON_KEY);
+			break;
+		}
+	}
 	
 	if (halfeaten && otmp->oclass == FOOD_CLASS) {
 		if (otmp->otyp == CORPSE)

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -417,8 +417,10 @@ int otyp;
 		{
 			ocaa = AT_EXPL;					// exploding
 			ocad = AD_LUCK;					// lucky
-			ocn = obj->quan;				// 1 die per octahedron
-			ocd = 8;						// They are eight-sided dice
+			if (obj->oclass == GEM_CLASS) {	// the following dice rules are not for a lightsaber
+				ocn = obj->quan;			// 1 die per octahedron
+				ocd = 8;					// They are eight-sided dice
+			}
 		}
 		else if (obj->oartifact == ART_GIANTSLAYER)
 		{

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -417,10 +417,8 @@ int otyp;
 		{
 			ocaa = AT_EXPL;					// exploding
 			ocad = AD_LUCK;					// lucky
-			if (obj->oclass == GEM_CLASS) {	// the following dice rules are not for a lightsaber
-				ocn = obj->quan;			// 1 die per octahedron
-				ocd = 8;					// They are eight-sided dice
-			}
+			ocn = obj->quan;				// 1 die per octahedron
+			ocd = 8;						// They are eight-sided dice
 		}
 		else if (obj->oartifact == ART_GIANTSLAYER)
 		{
@@ -590,8 +588,12 @@ int otyp;
 	if (obj && (otyp == LIGHTSABER || otyp == BEAMSWORD || otyp == DOUBLE_LIGHTSABER) && !litsaber(obj))
 	{
 		spe_mult = 1;
+		ocaa = AT_NONE;
+		ocad = AD_PHYS;
 		ocn = 1;
 		ocd = 2;
+		bonaa = AT_NONE;
+		bonad = AD_PHYS;
 		bonn = 0;
 		bond = 0;
 	}


### PR DESCRIPTION
You cannot wish for Atma Weapon multiple times to obtain a beamsword.
Putting the Fluorite Octet into a beamsword shouldn't reduce its die size to 8 (but it should still be lucky+exploding)

Fixes #293 