### PR TITLE
Fix modor typo

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -164,9 +164,9 @@ E struct dgn_topology {		/* special dungeon levels for speed */
     d_level	d_mordor_1_level;
     d_level	d_mordor_2_level;
     d_level	d_spider_level;
-    d_level	d_modor_depths_1_level;
-    d_level	d_modor_depths_2_level;
-    d_level	d_modor_depths_3_level;
+    d_level	d_mordor_depths_1_level;
+    d_level	d_mordor_depths_2_level;
+    d_level	d_mordor_depths_3_level;
     d_level	d_borehole_1_level;
     d_level	d_borehole_2_level;
     d_level	d_borehole_3_level;
@@ -278,9 +278,9 @@ E struct dgn_topology {		/* special dungeon levels for speed */
 #define mordor_1_level		(dungeon_topology.d_mordor_1_level)
 #define mordor_2_level		(dungeon_topology.d_mordor_2_level)
 #define spider_level		(dungeon_topology.d_spider_level)
-#define modor_depths_1_level		(dungeon_topology.d_modor_depths_1_level)
-#define modor_depths_2_level		(dungeon_topology.d_modor_depths_2_level)
-#define modor_depths_3_level		(dungeon_topology.d_modor_depths_3_level)
+#define mordor_depths_1_level		(dungeon_topology.d_mordor_depths_1_level)
+#define mordor_depths_2_level		(dungeon_topology.d_mordor_depths_2_level)
+#define mordor_depths_3_level		(dungeon_topology.d_mordor_depths_3_level)
 #define borehole_1_level	(dungeon_topology.d_borehole_1_level)
 #define borehole_2_level	(dungeon_topology.d_borehole_2_level)
 #define borehole_3_level	(dungeon_topology.d_borehole_3_level)

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -746,9 +746,9 @@ struct level_map {
 	{ "mord1",&mordor_1_level },
 	{ "mord2",&mordor_2_level },
 	{ "spi1",&spider_level },
-	{ "mdpth1",&modor_depths_1_level },
-	{ "mdpth2",&modor_depths_2_level },
-	{ "mdpth3",&modor_depths_3_level },
+	{ "mdpth1",&mordor_depths_1_level },
+	{ "mdpth2",&mordor_depths_2_level },
+	{ "mdpth3",&mordor_depths_3_level },
 	{ "bore1",&borehole_1_level },
 	{ "bore2",&borehole_2_level },
 	{ "bore3",&borehole_3_level },
@@ -1591,9 +1591,9 @@ In_mordor_depths(lev)	/* are you on the chaotic quest? */
 d_level	*lev;
 {
 	return((boolean)(lev->dnum == chaos_dnum && chaos_dvariant == MORDOR && (
-		on_level(&u.uz, &modor_depths_1_level)
-		|| on_level(&u.uz, &modor_depths_2_level)
-		|| on_level(&u.uz, &modor_depths_3_level)
+		on_level(&u.uz, &mordor_depths_1_level)
+		|| on_level(&u.uz, &mordor_depths_2_level)
+		|| on_level(&u.uz, &mordor_depths_3_level)
 	)));
 }
 

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -573,7 +573,7 @@ fixup_special()
 			//Note: Post forest-conversion
 			place_chaos_forest_features();
 		}
-		if(on_level(&u.uz, &modor_depths_2_level)){
+		if(on_level(&u.uz, &mordor_depths_2_level)){
 			place_chaos_forest_features();
 			for (x = 1; x < COLNO - 1; x++)
 			for (y = 0; y < ROWNO - 1; y++){
@@ -581,7 +581,7 @@ fixup_special()
 			}
 			wallification(1, 0, COLNO - 1, ROWNO - 1);
 		}
-		if(on_level(&u.uz, &modor_depths_3_level)){
+		if(on_level(&u.uz, &mordor_depths_3_level)){
 			place_chaos_forest_features();
 		}
 	}

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -3919,9 +3919,9 @@ place_chaos_forest_features()
 		int i = 4 + d(4,4);
 		for(; i > 0; i--)
 			mkwraithclearing(0);
-	} else if(on_level(&u.uz, &modor_depths_2_level)){
+	} else if(on_level(&u.uz, &mordor_depths_2_level)){
 		mklavapool();
-	} else if(on_level(&u.uz, &modor_depths_3_level)){
+	} else if(on_level(&u.uz, &mordor_depths_3_level)){
 		int i = 20+ d(4,10);
 		for(; i > 0; i--)
 			mkstonepillars();

--- a/src/questpgr.c
+++ b/src/questpgr.c
@@ -889,10 +889,10 @@ chaos3_montype()
 			case 8: return mkclass(S_SPIDER, G_NOHELL|G_HELL);
 		}
 	} else if(
-		on_level(&u.uz, &modor_depths_1_level)
-		|| on_level(&u.uz, &modor_depths_2_level)
+		on_level(&u.uz, &mordor_depths_1_level)
+		|| on_level(&u.uz, &mordor_depths_2_level)
 	){
-		switch(rn2(on_level(&u.uz, &modor_depths_2_level) ? 30 : 20)){
+		switch(rn2(on_level(&u.uz, &mordor_depths_2_level) ? 30 : 20)){
 			case 1:
 			case 2:
 			case 3:
@@ -923,7 +923,7 @@ chaos3_montype()
 			case 28:
 			case 29: return &mons[PM_MORDOR_SHAMAN];
 		}
-	} else if(on_level(&u.uz, &modor_depths_3_level)){
+	} else if(on_level(&u.uz, &mordor_depths_3_level)){
 		switch(rn2(20)){
 			case 0:
 			case 1:


### PR DESCRIPTION
The mordor depths were titled as "modor" in include/decl.h. Fixes that and where referred to.