### PR TITLE
Fix lifesaving relocating the player to water after drowning

### DIFF
--- a/include/youprop.h
+++ b/include/youprop.h
@@ -422,7 +422,7 @@
 #define EMagical_breathing	u.uprops[MAGICAL_BREATHING].extrinsic
 #define Amphibious		(HMagical_breathing || EMagical_breathing || \
 				 u.sealsActive&SEAL_ASTAROTH || \
-				 (u.divetimer > 0 && u.usubwater) || \
+				 (Swimming && u.divetimer > 0 && u.usubwater) || \
 				 amphibious(youracedata))
 	/* Get wet, may go under surface */
 


### PR DESCRIPTION
Fixes #300
However, drowning on the plane of water still doesn't place the player in an air bubble!