### PR TITLE
Add callandor

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -595,6 +595,14 @@ A("Fuma-itto no Ken",		BROADSWORD,		0,			0, /*Needs encyc entry*/
  *  Nethack Samurai call broadswords "Ninja-to," which is the steriotypical ninja sword.
  *  Aparently, there was no such thing as an actual Ninja-to, it's something Hollywood made up!
  */
+
+A("Callandor", 		CRYSTAL_SWORD, 			0,			0,/*Crystal sword whose use comes with a price of your sanity */
+	(SPFX_RESTR|SPFX_EREGEN|SPFX_HSPDAM)	,0,
+	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/,
+	NO_ATTK,	NO_DFNS,	NO_CARY, /*Needs encyc entry*/
+	0, A_LAWFUL, NON_PM, NON_PM, 6660L, 
+	SPFX2_SPELLUP,0,0),
+
 A("Yoichi no yumi", YUMI, 					0,			0,/*Needs encyc entry*/
 	(SPFX_RESTR),0,
 	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/,

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -688,10 +688,10 @@ boolean while_carried;
 				if (spfx & SPFX_TCTRL) got_prop = TRUE;
 				break;
 			case ENERGY_REGENERATION:
-				if (spfx & SPFX_EREGEN) got_prop = TRUE;
+				if (spfx & SPFX_EREGEN && !(oartifact == ART_CALLANDOR && flags.initgend)) got_prop = TRUE;
 				break;
 			case HALF_SPDAM:
-				if (spfx & SPFX_HSPDAM) got_prop = TRUE;
+				if (spfx & SPFX_HSPDAM && !(oartifact == ART_CALLANDOR && flags.initgend)) got_prop = TRUE;
 				break;
 			case HALF_PHDAM:
 				if (spfx & SPFX_HPHDAM) got_prop = TRUE;
@@ -719,7 +719,7 @@ boolean while_carried;
 				if (spfx2 & SPFX2_STLTH) got_prop = TRUE;
 				break;
 			case SPELLBOOST:
-				if (spfx2 & SPFX2_SPELLUP) got_prop = TRUE;
+				if (spfx2 & SPFX2_SPELLUP && !(oartifact == ART_CALLANDOR && flags.initgend)) got_prop = TRUE;
 				break;
 			case POLYMORPH_CONTROL:
 				if (spfx3 & SPFX3_PCTRL) got_prop = TRUE;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -342,6 +342,9 @@ aligntyp alignment;	/* target alignment, or A_NONE */
 							
 			} else if (by_align && Race_if(PM_DROW) && (m == ART_ARKENSTONE || m == ART_HOLY_MOONLIGHT_SWORD)){
 				continue; // no light-giving artis for drow (artifact_light should be unnecessary)
+
+			} else if (by_align && m == ART_CALLANDOR && flags.initgend){
+				continue; // callandor is saidin only
 			
 			} else if(by_align && Role_if(PM_PIRATE)) 
 				continue; /* pirates are not gifted artifacts */

--- a/src/spell.c
+++ b/src/spell.c
@@ -4195,6 +4195,9 @@ boolean atme;
 		u.uen -= energy;
 		flags.botl = 1;
 		exercise(A_WIS, TRUE);
+		if (uwep && uwep->oartifact == ART_CALLANDOR && !flags.initgend && rn2(20)){
+			change_usanity(-rnd(spellev(spell)));
+		}
 		/* pseudo is a temporary "false" object containing the spell stats */
 		pseudo = mksobj(spellid(spell), FALSE, FALSE);
 		pseudo->blessed = pseudo->cursed = 0;

--- a/src/spell.c
+++ b/src/spell.c
@@ -5261,6 +5261,11 @@ int spell;
 			splcaster -= cast_bon;
 		}
 		
+		if(uwep && uwep->oartifact == ART_CALLANDOR && !flags.initgend){	// sa'angreal
+			cast_bon = 2;
+			splcaster -= urole.spelarmr * cast_bon / 3;
+		}
+		
 		if(Role_if(PM_WIZARD) && uwep->oclass == WAND_CLASS) {	// a tool of spellweaving
 			cast_bon = 1;
 			if (uwep->oartifact)


### PR DESCRIPTION
Callandor

* artifact crystal sword
* when wielded by a male character
   * grants energy regeneration, half spell damage, and boosts spells while wielded
    * on 1/20 of spell casts, subtracts rnd(spell_level) sanity

Reference to Callandor, a male sa'angreal from the Wheel of Time series. Notable that it amplified the taint, thus the the san loss, but also heavily boosted spells. Possibly could have a negative effect of some sort on your health as well after prolonged usage (ala tensa z?). 

I'm not really expecting this to be merged, just fyi. If you do that's cool, but it probably needs some more fine tuning.