### PR TITLE
Necro staff tweaks

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -319,7 +319,7 @@ A("Xiuhcoatl",	ATLATL,			0,			0,/*Needs encyc entry*/
 	LORDLY,	A_LAWFUL, PM_ARCHEOLOGIST, NON_PM, 4000L, 
 	0,0,0), 
 
-A("Staff of Necromancy", 		QUARTERSTAFF, 			0,			0,/*invoke for skeletons, life draining */
+A("Staff of Necromancy", 		QUARTERSTAFF, 			BONE,			0,/*invoke for skeletons, life draining */
 	(SPFX_RESTR|SPFX_INHER|SPFX_ATTK),0,
 	0 /*Monster Symbol*/, 0 /*MM*/, 0 /*MT*/, 0 /*MB*/, 0 /*MG*/, 0 /*MA*/, 0 /*MV*/,
 	DRLI(5,0),	COLD(0,0),	NO_CARY, /*Needs encyc entry*/

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -5262,7 +5262,7 @@ arti_invoke(obj)
 
 	case SATURN:
 		{
-			if ( !(uwep && uwep == obj) ) {
+			if (!(uwep && uwep == obj)) {
 				You_feel("that you should be wielding %s.", the(xname(obj)));
 				obj->age = 0;
 				break;
@@ -5334,7 +5334,7 @@ arti_invoke(obj)
 	break;
  	case PLUTO:
 		{
-			if ( !(uwep && uwep == obj) ) {
+			if (!(uwep && uwep == obj)) {
 				You_feel("that you should be wielding %s.", the(xname(obj)));
 				obj->age = 0;
 				break;
@@ -5416,7 +5416,7 @@ arti_invoke(obj)
 	break;
 	case WATER:
 		{
-			if ( !(uwep && uwep == obj) ) {
+			if (!(uwep && uwep == obj)) {
 				You_feel("that you should be wielding %s.", the(xname(obj)));
 				obj->age = 0;
 				break;
@@ -5455,7 +5455,7 @@ arti_invoke(obj)
 	break;
  	case SPEED_BANKAI:
 		{
-			if ( !(uwep && uwep == obj) ) {
+			if ( !(uwep && uwep == obj)) {
 				You_feel("that you should be wielding %s.", the(xname(obj)));
 				obj->age = 0;
 				break;
@@ -6359,7 +6359,7 @@ arti_invoke(obj)
 			}
 		break;
 		case DEATH_TCH:
-			if (uwep && uwep != obj){
+			if ((!uwep && uwep == obj)){
 				You_feel("that you should be wielding %s.", the(xname(obj)));;
 				obj->age = monstermoves;
 				return(0);
@@ -6386,7 +6386,7 @@ arti_invoke(obj)
 		break;
 		case SKELETAL_MINION:
 		{
-			if (uwep && uwep != obj){
+			if ((!uwep && uwep == obj)){
 				You_feel("that you should be wielding %s.", the(xname(obj)));;
 				obj->age = monstermoves;
 				return(0);
@@ -7389,7 +7389,7 @@ arti_invoke(obj)
           } else You_feel("like you should be wearing %s.", The(xname(obj)));
         } break;
         case TOWEL_ITEMS:{
-          if(uwep == obj){
+          if(uwep && uwep == obj){
             struct obj *otmp;
             switch(rn2(5)){
               case 0:
@@ -7448,7 +7448,7 @@ arti_invoke(obj)
           /* TODO */
         } break;
         case LIFE_DEATH:{
-          if(uwep == obj){
+          if(uwep && uwep == obj){
             if(!getdir((char *)0))
               break;
             switch(obj->ovar1){

--- a/src/invent.c
+++ b/src/invent.c
@@ -1213,7 +1213,8 @@ register const char *let,*word;
 			 otmp->oartifact == ART_ITLACHIAYAQUE || 
 			 otmp->oartifact == ART_ROD_OF_SEVEN_PARTS ||
 			 otmp->oartifact == ART_BOW_OF_SKADI ||
-			 otmp->oartifact == ART_PEN_OF_THE_VOID
+			 otmp->oartifact == ART_PEN_OF_THE_VOID ||
+			 otmp->oartifact == ART_STAFF_OF_NECROMANCY
 			) && !strcmp(word, "read")
 		){
 			bp[foo++] = otmp->invlet;

--- a/src/read.c
+++ b/src/read.c
@@ -227,6 +227,35 @@ doread()
 				if (i == MAXSPELL) impossible("Too many spells memorized!");
 				return 1;
 			}
+		
+		} else if(scroll->oartifact == ART_STAFF_OF_NECROMANCY){
+			if (Blind) {
+				You_cant("see the staff!");
+				return 0;
+			} else {
+				int i;
+				You("read the forbidden secrets of time and decay!");
+				for (i = 0; i < MAXSPELL; i++)  {
+					if (spellid(i) == SPE_DRAIN_LIFE)  {
+						if (spellknow(i) <= 1000) {
+							Your("knowledge of Drain Life is keener.");
+							spl_book[i].sp_know = 20000;
+							exercise(A_WIS,TRUE);       /* extra study */
+						} else { /* 1000 < spellknow(i) <= MAX_SPELL_STUDY */
+							You("know Drain Life quite well already.");
+						}
+						break;
+					} else if (spellid(i) == NO_SPELL)  {
+						spl_book[i].sp_id = SPE_DRAIN_LIFE;
+						spl_book[i].sp_lev = objects[SPE_DRAIN_LIFE].oc_level;
+						spl_book[i].sp_know = 20000;
+						You("learn to cast Drain Life!");
+						break;
+					}
+				}
+				if (i == MAXSPELL) impossible("Too many spells memorized!");
+				return 1;
+			}
 		} else if(scroll->otyp == LIGHTSABER){
 			if (Blind) {
 				You_cant("see it!");
@@ -239,7 +268,7 @@ doread()
 			pline(silly_thing_to, "read");
 			return(0);
 		}
-    } else if(scroll->oartifact && scroll->oartifact == ART_ENCYCLOPEDIA_GALACTICA){
+	} else if(scroll->oartifact && scroll->oartifact == ART_ENCYCLOPEDIA_GALACTICA){
       const char *line;
       char buf[BUFSZ];
 

--- a/src/spell.c
+++ b/src/spell.c
@@ -5240,6 +5240,11 @@ int spell;
 			splcaster -= urole.spelarmr * cast_bon / 3;
 		}
 
+		/* if (uwep->otyp == ART_STAFF_OF_NECROMANCY && spellid(spell) == SPE_DRAIN_LIFE) {
+			// Bonus to drain life
+			splcaster -= urole.spelarmr;
+		} The staff is already +4 to all attack spells, a bonus to drain life is probably overkill */
+
 		if (uwep->otyp == SHEPHERD_S_CROOK) {	// a tool for leading and manipulating things
 			cast_bon = 0;
 			if (spell_skilltype(spellid(spell)) == P_ENCHANTMENT_SPELL)

--- a/src/zap.c
+++ b/src/zap.c
@@ -418,7 +418,9 @@ struct obj *otmp;
 		} else {
 			levlost = 1;
 			dmg = rnd(8);
-			if (uwep && uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN){
+			if (uwep && (uwep->oartifact == ART_DEATH_SPEAR_OF_VHAERUN || 
+						uwep->oartifact == ART_STAFF_OF_NECROMANCY)
+			){
 				dmg += d((u.ulevel+1)/3, 4);
 				levlost += (u.ulevel+1)/6;
 			}


### PR DESCRIPTION
* Staff of Necromancy now made of bone
* Staff of Necromancy & Death-spear of Vhaerun can no longer be invoked bare-handed (thanks Nero)
* Reading the Staff teaches the drain life spell, and like the Death-spear, drain life deals an extra (lvl/3)d4 damage when the staff is wielded

Note - I didn't notice this before, but since the staff of necromancy is also an artifact quarterstaff, it grants a large bonus to fail rates (spelamr * 4/3) for any attack spells.