### PR TITLE
Migo should fire their mist projector at a 1/5 rate, not 4/5.

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -10638,8 +10638,8 @@ int vis;
 		/* MONSTER GENERATING GAZES, MVU ONLY */
 
 	case AD_MIST:  // mi-go mist projector
-		/* 4/5 chance to succeed */
-		if (maybe_not && !rn2(5))
+		/* 1/5 chance to succeed */
+		if (maybe_not && rn2(5))
 			return MM_MISS;
 		else {
 			int i = 0;


### PR DESCRIPTION
I blame the old weird way of saying 1/5 chance of success, `if(rn2(20)>15)`.