### PR TITLE
Generalize always-on lightsources

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1103,6 +1103,7 @@ E void FDECL(obj_move_light_source, (struct obj *, struct obj *));
 E boolean NDECL(any_light_source);
 E void FDECL(snuff_light_source, (int, int));
 E boolean FDECL(obj_sheds_light, (struct obj *));
+E boolean FDECL(obj_eternal_light, (struct obj *));
 E boolean FDECL(obj_is_burning, (struct obj *));
 E boolean FDECL(litsaber, (struct obj *));
 E void FDECL(obj_split_light_source, (struct obj *, struct obj *));

--- a/src/invent.c
+++ b/src/invent.c
@@ -420,8 +420,8 @@ struct obj *obj;
 			attach_fig_transform_timeout(obj);
 		    }
 	}
-	/* relight artifacts */
-	if (arti_light(obj) && !obj->lamplit)
+	/* relight lightsources that should always be lit */
+	if (obj_eternal_light(obj) && !obj->lamplit)
 		begin_burn(obj, FALSE);
 }
 

--- a/src/light.c
+++ b/src/light.c
@@ -652,10 +652,20 @@ boolean
 obj_sheds_light(obj)
 struct obj *obj;
 {
-	return (
+	return (obj->lamplit && (						/* lamplit is sometimes off for even eternal lightsources */
 		obj_is_burning(obj) ||						/* standard lightsources that must be lit */
-		(arti_light(obj) && obj->lamplit) ||		/* artifact lightsource -- not lit when in something's stomach */
-		(artifact_light(obj) && obj->lamplit) ||	/* sometimes active artifact lightsource */
+		artifact_light(obj) ||						/* sometimes active artifact lightsource */
+		obj_eternal_light(obj)						/* object should always be shedding light (except when occluded) */
+		));
+}
+/* Return TRUE if object's light should in theory never go out */
+/* it is still temporarily extinguished when in a monster's stomach */
+boolean
+obj_eternal_light(obj)
+struct obj * obj;
+{
+	return (
+		arti_light(obj) ||							/* artifact lightsource */
 		obj->otyp == POT_STARLIGHT ||				/* always lit potion */
 		obj->otyp == CHUNK_OF_FOSSIL_DARK			/* always dark rock */
 		);

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2622,8 +2622,8 @@ int x, y;
     otmp->nobj = fobj;
     fobj = otmp;
     if (otmp->timed) obj_timer_checks(otmp, x, y, 0);
-	/* relight artifacts */
-	if (arti_light(otmp) && !otmp->lamplit)
+	/* relight lightsources that should always be lit */
+	if (obj_eternal_light(otmp) && !otmp->lamplit)
 		begin_burn(otmp, FALSE);
 }
 

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -2155,11 +2155,9 @@ begin_burn(obj, already_lit)
 
 	/* some things need to set lamplit on their own here */
 	if (obj->otyp == MAGIC_LAMP ||
-		obj->otyp == POT_STARLIGHT ||
-		obj->otyp == CHUNK_OF_FOSSIL_DARK ||
 		obj->otyp == CANDLE_OF_INVOCATION ||
 		artifact_light(obj) ||
-		arti_light(obj))
+		obj_eternal_light(obj))
 		obj->lamplit = TRUE;
 	/* lightsaber charge and Atma Weapon special */
 	if (obj->otyp == DOUBLE_LIGHTSABER ||


### PR DESCRIPTION
Fixes bug: Potions of starlight were extinguishing when dropped into a purple worm's stomach.