### PR TITLE
Magic chests bolt themselves to the floor when first unlocked

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2616,7 +2616,7 @@ E boolean NDECL(drown);
 E int NDECL(dodeepswim);
 E void FDECL(drain_en, (int));
 E int NDECL(dountrap);
-E int FDECL(untrap, (BOOLEAN_P));
+E int FDECL(untrap, (struct obj *));
 E boolean FDECL(chest_trap, (struct obj *,int,BOOLEAN_P));
 E void FDECL(deltrap, (struct trap *));
 E boolean FDECL(delfloortrap, (struct trap *));

--- a/include/obj.h
+++ b/include/obj.h
@@ -96,6 +96,7 @@ struct obj {
 #define ohaluengr obroken	/* engraving on ring isn't a ward */
 #define odebone obroken		/* corpse has been de-boned */
 	Bitfield(otrapped,1);	/* container is trapped */
+#define obolted otrapped	/* magic chest is permanently attached to floor */
 				/* or accidental tripped rolling boulder trap */
 
 	Bitfield(recharged,3);	/* number of times it's been recharged */

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -5069,7 +5069,7 @@ arti_invoke(obj)
 	    break;
 	  }
 	case UNTRAP: {
-	    if(!untrap(TRUE)) {
+	    if(!untrap(obj)) {
 		obj->age = 0; /* don't charge for changing their mind */
 		return 0;
 	    }

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -406,7 +406,8 @@ xchar x, y;
 	/* Mjollnir is magically too heavy to kick */
 	if(kickobj->oartifact == ART_MJOLLNIR || 
 		kickobj->oartifact == ART_SICKLE_MOON || 
-		kickobj->oartifact == ART_AXE_OF_THE_DWARVISH_LORDS) range = 1;
+		kickobj->oartifact == ART_AXE_OF_THE_DWARVISH_LORDS ||
+		(kickobj->otyp == MAGIC_CHEST && kickobj->obolted)) range = 1;
 
 	/* see if the object has a place to move into */
 	if(!ZAP_POS(levl[x+u.dx][y+u.dy].typ) || closed_door(x+u.dx, y+u.dy))
@@ -448,14 +449,15 @@ xchar x, y;
 
 	/* a box gets a chance of breaking open here */
 	if(Is_box(kickobj)) {
-		boolean otrp = kickobj->otrapped;
+		boolean otrp = (kickobj->otrapped && kickobj->otyp != MAGIC_CHEST);
 
 		if(range < 2) pline("THUD!");
 
 		container_impact_dmg(kickobj);
 
 		if (kickobj->olocked) {
-		    if (!rn2(5) || (martial() && !rn2(2))) {
+			/* magic chests cannot be kicked open */
+			if ((!rn2(5) || (martial() && !rn2(2))) && kickobj->otyp != MAGIC_CHEST) {
 			You("break open the lock!");
 			kickobj->olocked = 0;
 			kickobj->obroken = 1;
@@ -1430,6 +1432,8 @@ xchar x, y, dlev;
 		/* number of objects in the pile */
 		oct += obj->quan;
 		if(obj == uball || obj == uchain) continue;
+		/* bolted magic chests can't fall */
+		if(obj->otyp == MAGIC_CHEST && obj->obolted) continue;
 		/* boulders can fall too, but rarely & never due to rocks */
 		if((isrock && is_boulder(obj) ) ||
 		   rn2(is_boulder(obj) ? 30 : 3)) continue;

--- a/src/lock.c
+++ b/src/lock.c
@@ -149,10 +149,16 @@ picklock()	/* try to open/close a lock */
 	} else {
 	    if(xlock.box->otyp == MAGIC_CHEST){
 			xlock.box->olocked = 0;
+			xlock.box->obolted = 1;
+			xlock.box->owt = weight(xlock.box);
 			xlock.box->ovar1 = xlock.mgclcknm;
-		} else xlock.box->olocked = !xlock.box->olocked;
-	    if(xlock.box->otrapped)	
-		(void) chest_trap(xlock.box, FINGER, FALSE);
+			pline_The("chest bolts itself to the floor!");
+		}
+		else {
+			xlock.box->olocked = !xlock.box->olocked;
+			if (xlock.box->otrapped)
+				(void)chest_trap(xlock.box, FINGER, FALSE);
+		}
 	}
 	exercise(A_DEX, TRUE);
 	return((xlock.usedtime = 0));
@@ -197,6 +203,7 @@ forcelock()	/* try to force a locked chest */
 
 	if(xlock.picktyp == 3) u.otiaxAttack = moves;
 	if(rn2(100) >= xlock.chance) return(1);		/* still busy */
+	if(xlock.box->otyp == MAGIC_CHEST) return(1); /* you can't force a magic chest's lock, but you can certainly try */
 
 	You("succeed in forcing the lock.");
 	xlock.box->olocked = 0;
@@ -992,21 +999,22 @@ register struct obj *obj, *otmp;	/* obj *is* a box */
 	switch(otmp->otyp) {
 	case WAN_LOCKING:
 	case SPE_WIZARD_LOCK:
-	    if (!obj->olocked) {	/* lock it; fix if broken */
-		pline("Klunk!");
-		obj->olocked = 1;
-		obj->obroken = 0;
-		res = 1;
-	    } /* else already closed and locked */
+		if (!obj->olocked) {	/* lock it; fix if broken */
+			pline("Klunk!");
+			obj->olocked = 1;
+			obj->obroken = 0;
+			res = 1;
+		} /* else already closed and locked */
 	    break;
 	case WAN_OPENING:
 	case SPE_KNOCK:
-	    if (obj->olocked) {		/* unlock; couldn't be broken */
-		pline("Klick!");
-		obj->olocked = 0;
-		res = 1;
-	    } else			/* silently fix if broken */
-		obj->obroken = 0;
+		if (obj->olocked && !(obj->otyp == MAGIC_CHEST && !obj->obolted)) {		/* unlock; couldn't be broken */
+			pline("Klick!");
+			obj->olocked = 0;
+			res = 1;
+		}
+		else			/* silently fix if broken */
+			obj->obroken = 0;
 	    break;
 	case WAN_POLYMORPH:
 	case SPE_POLYMORPH:

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -816,6 +816,7 @@ boolean artif;
 					break;
 		case MAGIC_CHEST:
 			otmp->olocked = 1;
+			otmp->obolted = 0;
 		break;
 #ifdef TOURIST
 		case EXPENSIVE_CAMERA:
@@ -2187,7 +2188,8 @@ weight(obj)
 register struct obj *obj;
 {
 	int wt = objects[obj->otyp].oc_weight;
-	if(obj->oartifact == ART_ROD_OF_LORDLY_MIGHT) wt = objects[MACE].oc_weight;
+	if (obj->otyp == MAGIC_CHEST && obj->obolted) wt = 99999;	/* impossibly heavy */
+	else if(obj->oartifact == ART_ROD_OF_LORDLY_MIGHT) wt = objects[MACE].oc_weight;
 	else if(obj->oartifact == ART_ANNULUS) wt = objects[BELL_OF_OPENING].oc_weight;
 	else if(obj->oartifact == ART_SCEPTRE_OF_LOLTH) wt = 3*objects[MACE].oc_weight;
 	else if(obj->oartifact == ART_ROD_OF_THE_ELVISH_LORDS) wt = objects[ELVEN_MACE].oc_weight;

--- a/src/mon.c
+++ b/src/mon.c
@@ -2376,7 +2376,7 @@ meatobj(mtmp)		/* for gelatinous cubes */
 		/* in case it polymorphed or died */
 		if (ptr != &mons[PM_GELATINOUS_CUBE])
 		    return !ptr ? 2 : 1;
-	    } else if (otmp->oclass != ROCK_CLASS &&
+	    } else if (otmp->oclass != ROCK_CLASS && !(otmp->otyp == MAGIC_CHEST && otmp->obolted) &&
 				    otmp != uball && otmp != uchain) {
 		++ecount;
 		if (ecount == 1) {
@@ -2852,6 +2852,8 @@ struct obj *otmp;
 	    return FALSE;
 	if (otyp == CORPSE && is_rider(&mons[otmp->corpsenm]))
 	    return FALSE;
+	if (otyp == MAGIC_CHEST && otmp->obolted)
+		return FALSE;
 	if (otmp->obj_material == SILVER && hates_silver(mdat) &&
 		(otyp != BELL_OF_OPENING || !is_covetous(mdat)))
 	    return FALSE;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1407,6 +1407,10 @@ boolean telekinesis;	/* not picking it up directly by hand */
 		return 1;	/* tried to pick something up and failed, but
 				   don't want to terminate pickup loop yet   */
 	    }
+	} else if (obj->otyp == MAGIC_CHEST && obj->obolted) {
+		pline_The("chest is bolted down!");
+		return 1;	/* tried to pick something up and failed, but
+				   don't want to terminate pickup loop yet   */
 	}
 
 	if ((res = lift_object(obj, (struct obj *)0, &count, telekinesis)) <= 0)
@@ -2732,7 +2736,7 @@ register int held;
 	    pline("%s to be locked.", Tobjnam(obj, "seem"));
 	    if (held) You("must put it down to unlock.");
 	    return 0;
-	} else if (obj->otrapped) {
+	} else if (obj->otrapped && (obj->otyp != MAGIC_CHEST)) {
 	    if (held) You("open %s...", the(xname(obj)));
 	    (void) chest_trap(obj, HAND, FALSE);
 	    /* even if the trap fails, you've used up this turn */

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1488,6 +1488,8 @@ register struct obj *obj;
 	if (obj->otyp == CORPSE && is_rider(&mons[obj->corpsenm])) {
 	    if (revive_corpse(obj, REVIVE_MONSTER)) return;
 	}
+	if (obj->otyp == MAGIC_CHEST && obj->obolted)
+		return;
 
 	obj_extract_self(obj);
 	otx = obj->ox;

--- a/src/trap.c
+++ b/src/trap.c
@@ -3768,7 +3768,7 @@ dountrap()	/* disarm a trap */
 		 makeplural(body_part(HAND)));
 	    return 0;
 	}
-	return untrap(FALSE);
+	return untrap((struct obj *)0);
 }
 #endif /* OVLB */
 #ifdef OVL2
@@ -4311,8 +4311,8 @@ struct trap *ttmp;
 }
 
 int
-untrap(force)
-boolean force;
+untrap(tool)
+struct obj * tool;
 {
 	register struct obj *otmp;
 	register boolean confused = (Confusion > 0 || Hallucination > 0);
@@ -4323,6 +4323,7 @@ boolean force;
 	boolean trap_skipped = FALSE;
 	boolean box_here = FALSE;
 	boolean deal_with_floor_trap = FALSE;
+	boolean force = (tool && tool->oartifact);
 	char the_trap[BUFSZ], qbuf[QBUFSZ];
 	int containercnt = 0;
 
@@ -4516,7 +4517,7 @@ boolean force;
 					return(0);
 				}
 #endif
-				if (!force) {
+				if (!(tool && tool->oartifact == ART_MASTER_KEY_OF_THIEVERY)) {
 					pline("The bolts are seemingly magical and impossible to budge.");
 					return(0);
 				}

--- a/src/zap.c
+++ b/src/zap.c
@@ -1636,7 +1636,7 @@ poly_obj(obj, id)
 	    otmp->oerodeproof = obj->oerodeproof;
 
 	/* Keep chest/box traps and poisoned ammo if we may */
-	if (obj->otrapped && Is_box(otmp)) otmp->otrapped = TRUE;
+	if (obj->otrapped && Is_box(otmp) && otmp->otyp != MAGIC_CHEST) otmp->otrapped = TRUE;
 
 	if (obj->opoisoned && is_poisonable(otmp))
 		otmp->opoisoned = obj->opoisoned;


### PR DESCRIPTION
This way, you can choose to move a magic chest to your stash (or wherever it is you want it) before placing it, but you cannot carry one around with you as a chest of holding.

Once bolted down, they are very hard (impossible, hopefully) to move.
* Attempting to pick one up gives a message that the chest is bolted down.
* Being magically fixed in place, a bolted magic chest cannot be teleported away or kicked around.
* Gelatinous cubes don't engulf them, and other monsters won't pick them up.
* The chest won't fall from other items impacting it
* The chest is also set to weigh a ridiculous amount while bolted down.

The Master Key of Thievery's untrapping invoke is the only way to unbolt one.

Magic chests also cannot be opened by kicking or forcing the lock.