### PR TITLE
Overhaul trap ammo (stolen from xnethack)

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2597,6 +2597,7 @@ E boolean FDECL(burnarmor,(struct monst *));
 E boolean FDECL(rust_dmg, (struct obj *,const char *,int,BOOLEAN_P,struct monst *));
 E void FDECL(grease_protect, (struct obj *,const char *,struct monst *));
 E struct trap *FDECL(maketrap, (int,int,int));
+E void FDECL(set_trap_ammo, (struct trap *, struct obj *));
 E void FDECL(fall_through, (BOOLEAN_P));
 E struct monst *FDECL(animate_statue, (struct obj *,XCHAR_P,XCHAR_P,int,int *));
 E struct monst *FDECL(activate_statue_trap,
@@ -2623,6 +2624,7 @@ E boolean NDECL(drown);
 E int NDECL(dodeepswim);
 E void FDECL(drain_en, (int));
 E int NDECL(dountrap);
+E void FDECL(remove_trap_ammo, (struct trap *));
 E int FDECL(untrap, (struct obj *));
 E boolean FDECL(chest_trap, (struct obj *,int,BOOLEAN_P));
 E void FDECL(deltrap, (struct trap *));

--- a/include/obj.h
+++ b/include/obj.h
@@ -68,7 +68,8 @@ struct obj {
 #define OBJ_BURIED	6		/* object buried */
 #define OBJ_ONBILL	7		/* object on shk bill */
 #define OBJ_MAGIC_CHEST	8		/* object in shared magic chest */
-#define NOBJ_STATES	9
+#define OBJ_INTRAP 9    /* object is trap ammo */
+#define NOBJ_STATES	10
 	xchar timed;		/* # of fuses (timers) attached to this obj */
 
 	Bitfield(cursed,1);

--- a/include/trap.h
+++ b/include/trap.h
@@ -44,7 +44,7 @@ extern struct trap *ftrap;
 #define dealloc_trap(trap) free((genericptr_t) (trap))
 
 /* what vl to use */
-#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || (ttyp) == FALLING_ROCK_TRAP ||\
+#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || (ttyp) == ROCKTRAP ||\
 								(ttyp) == BEAR_TRAP || (ttyp) == LANDMINE || (ttyp) == FIRE_TRAP)
 #define trapv_launch(ttyp)	((ttyp) == ROLLING_BOULDER_TRAP)
 #define trapv_statue(ttyp)	((ttyp) == STATUE_TRAP)

--- a/include/trap.h
+++ b/include/trap.h
@@ -33,7 +33,7 @@ struct trap {
 				 easy to make a monster peaceful if you could
 				 set a trap for it and then untrap it. */
 	union vlaunchinfo vl;
-#define ammo           vl.v_ammo
+#define launch_ammo    vl.v_ammo
 #define launch_otyp	   vl.v_launch_otyp
 #define launch2		   vl.v_launch2
 #define statueid       vl.v_statue_oid
@@ -42,6 +42,11 @@ struct trap {
 extern struct trap *ftrap;
 #define newtrap()	(struct trap *) alloc(sizeof(struct trap))
 #define dealloc_trap(trap) free((genericptr_t) (trap))
+
+/* what vl to use */
+#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || (ttyp) == BEAR_TRAP || (ttyp) == LANDMINE)
+#define trapv_launch(ttyp)	((ttyp) == ROLLING_BOULDER_TRAP)
+#define trapv_statue(ttyp)	((ttyp) == STATUE_TRAP)
 
 /* reasons for statue animation */
 #define ANIMATE_NORMAL	0

--- a/include/trap.h
+++ b/include/trap.h
@@ -7,19 +7,9 @@
 #ifndef TRAP_H
 #define TRAP_H
 
-struct trap_loaded_obj {
-	unsigned short o_pois : 8;		/* poison type(s) */
-	unsigned short o_mat : 5;		/* object material */
-	unsigned short o_blessed : 1;	/* blessed */
-	unsigned short o_cursed : 1;	/* cursed */
-	unsigned short o_pm_one : 1;	/* +1 if non-cursed, -1 if cursed */
-	// no remaining bits -- if more are needed, cannibalize o_pois and assume only 1 poison type?
-};
-
 union vlaunchinfo {
-	/* 16 bits */
-	/* arrow/dart */
-	struct trap_loaded_obj v_loaded_obj;	/* bitfield struct to make projectiles consistent from launcher traps */
+	/* ??? bits - max(<sizeof(pointer)>, 16bits). */
+	struct obj* v_ammo;	/* quivered object associated with this trap - rocks/darts/arrows/beartraps/landmines. */
 	/* rolling boulder */
 	short v_launch_otyp;	/* type of object to be triggered */
 	coord v_launch2;	/* secondary launch point (for boulders) */
@@ -43,11 +33,7 @@ struct trap {
 				 easy to make a monster peaceful if you could
 				 set a trap for it and then untrap it. */
 	union vlaunchinfo vl;
-#define launch_pois    vl.v_loaded_obj.o_pois
-#define launch_mat     vl.v_loaded_obj.o_mat
-#define launch_blessed vl.v_loaded_obj.o_blessed
-#define launch_cursed  vl.v_loaded_obj.o_cursed
-#define launch_enchant vl.v_loaded_obj.o_pm_one
+#define ammo           vl.v_ammo
 #define launch_otyp	   vl.v_launch_otyp
 #define launch2		   vl.v_launch2
 #define statueid       vl.v_statue_oid

--- a/include/trap.h
+++ b/include/trap.h
@@ -44,7 +44,8 @@ extern struct trap *ftrap;
 #define dealloc_trap(trap) free((genericptr_t) (trap))
 
 /* what vl to use */
-#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || (ttyp) == BEAR_TRAP || (ttyp) == LANDMINE)
+#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || \
+								(ttyp) == BEAR_TRAP || (ttyp) == LANDMINE || (ttyp) == FIRE_TRAP)
 #define trapv_launch(ttyp)	((ttyp) == ROLLING_BOULDER_TRAP)
 #define trapv_statue(ttyp)	((ttyp) == STATUE_TRAP)
 

--- a/include/trap.h
+++ b/include/trap.h
@@ -44,7 +44,7 @@ extern struct trap *ftrap;
 #define dealloc_trap(trap) free((genericptr_t) (trap))
 
 /* what vl to use */
-#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || \
+#define trapv_ammo(ttyp)	((ttyp) == DART_TRAP || (ttyp) == ARROW_TRAP || (ttyp) == FALLING_ROCK_TRAP ||\
 								(ttyp) == BEAR_TRAP || (ttyp) == LANDMINE || (ttyp) == FIRE_TRAP)
 #define trapv_launch(ttyp)	((ttyp) == ROLLING_BOULDER_TRAP)
 #define trapv_statue(ttyp)	((ttyp) == STATUE_TRAP)

--- a/src/apply.c
+++ b/src/apply.c
@@ -3421,6 +3421,7 @@ set_trap()
 	struct obj *otmp = trapinfo.tobj;
 	struct trap *ttmp;
 	int ttyp;
+	boolean obj_cursed = otmp->cursed;
 
 	if (!otmp || !carried(otmp) ||
 		u.ux != trapinfo.tx || u.uy != trapinfo.ty) {
@@ -3437,20 +3438,27 @@ set_trap()
 	    ttmp->tseen = 1;
 	    ttmp->madeby_u = 1;
 	    newsym(u.ux, u.uy); /* if our hero happens to be invisible */
+
+		/* Our object becomes the new ammo of the trap. */
+		if (otmp->quan > 1) {
+			otmp = splitobj(otmp, 1);
+		}
+		freeinv(otmp);
+		set_trap_ammo(ttmp, otmp);
+
 	    if (*in_rooms(u.ux,u.uy,SHOPBASE)) {
 		add_damage(u.ux, u.uy, 0L);		/* schedule removal */
 	    }
 	    if (!trapinfo.force_bungle)
 		You("finish arming %s.",
 			the(defsyms[trap_to_defsym(what_trap(ttyp))].explanation));
-	    if (((otmp->cursed || Fumbling) && (rnl(100) > 50)) || trapinfo.force_bungle)
+		if (((obj_cursed || Fumbling) && (rnl(100) > 50)) || trapinfo.force_bungle)
 		dotrap(ttmp,
 			(unsigned)(trapinfo.force_bungle ? FORCEBUNGLE : 0));
 	} else {
 	    /* this shouldn't happen */
 	    Your("trap setting attempt fails.");
 	}
-	useup(otmp);
 	reset_trapset();
 	return 0;
 }

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2827,6 +2827,13 @@ obj_extract_self(obj)
 	case OBJ_MAGIC_CHEST:
 	    extract_magic_chest_nobj(obj);
 	    break;
+	case OBJ_INTRAP:
+		/* The only place that we should be trying to extract an object inside a
+		* trap is from within the trap code, where we have a pointer to the
+		* trap that contains the object. We should never be trying to extract
+		* an object inside a trap without that context. */
+		panic("trying to extract object from trap with no trap info");
+		break;
 	default:
 	    panic("obj_extract_self");
 	    break;

--- a/src/restore.c
+++ b/src/restore.c
@@ -893,7 +893,7 @@ boolean ghostly;
 		/* trap->ammo will either be NULL or a stale pointer from the previous
 		* game. We don't read the stale pointer, other than to see whether an
 		* object chain follows this trap. */
-		if (trap->launch_ammo) {
+		if (trapv_ammo(trap->ttyp)) {
 			trap->launch_ammo = restobjchn(fd, ghostly, FALSE);
 		}
 		trap->ntrap = ftrap;

--- a/src/restore.c
+++ b/src/restore.c
@@ -893,8 +893,8 @@ boolean ghostly;
 		/* trap->ammo will either be NULL or a stale pointer from the previous
 		* game. We don't read the stale pointer, other than to see whether an
 		* object chain follows this trap. */
-		if (trap->ammo) {
-			trap->ammo = restobjchn(fd, ghostly, FALSE);
+		if (trap->launch_ammo) {
+			trap->launch_ammo = restobjchn(fd, ghostly, FALSE);
 		}
 		trap->ntrap = ftrap;
 		ftrap = trap;

--- a/src/restore.c
+++ b/src/restore.c
@@ -890,6 +890,12 @@ boolean ghostly;
 	while (trap = newtrap(),
 	       mread(fd, (genericptr_t)trap, sizeof(struct trap)),
 	       trap->tx != 0) {	/* need "!= 0" to work around DICE 3.0 bug */
+		/* trap->ammo will either be NULL or a stale pointer from the previous
+		* game. We don't read the stale pointer, other than to see whether an
+		* object chain follows this trap. */
+		if (trap->ammo) {
+			trap->ammo = restobjchn(fd, ghostly, FALSE);
+		}
 		trap->ntrap = ftrap;
 		ftrap = trap;
 	}

--- a/src/save.c
+++ b/src/save.c
@@ -969,8 +969,8 @@ register struct trap *trap;
 	    trap2 = trap->ntrap;
 	    if (perform_bwrite(mode))
 		bwrite(fd, (genericptr_t) trap, sizeof(struct trap));
-		if (trap->ammo)
-			saveobjchn(fd, trap->ammo, mode);
+		if (trap->launch_ammo)
+			saveobjchn(fd, trap->launch_ammo, mode);
 	    if (release_data(mode))
 		dealloc_trap(trap);
 	    trap = trap2;

--- a/src/save.c
+++ b/src/save.c
@@ -969,7 +969,7 @@ register struct trap *trap;
 	    trap2 = trap->ntrap;
 	    if (perform_bwrite(mode))
 		bwrite(fd, (genericptr_t) trap, sizeof(struct trap));
-		if (trap->launch_ammo)
+		if (trapv_ammo(trap->ttyp))
 			saveobjchn(fd, trap->launch_ammo, mode);
 	    if (release_data(mode))
 		dealloc_trap(trap);

--- a/src/save.c
+++ b/src/save.c
@@ -969,6 +969,8 @@ register struct trap *trap;
 	    trap2 = trap->ntrap;
 	    if (perform_bwrite(mode))
 		bwrite(fd, (genericptr_t) trap, sizeof(struct trap));
+		if (trap->ammo)
+			saveobjchn(fd, trap->ammo, mode);
 	    if (release_data(mode))
 		dealloc_trap(trap);
 	    trap = trap2;

--- a/src/trap.c
+++ b/src/trap.c
@@ -4855,7 +4855,7 @@ register struct trap *trap;
 		if (!ttmp) return;
 		ttmp->ntrap = trap->ntrap;
 	}
-	while (trap->launch_ammo) {
+	while (trapv_ammo(trap->ttyp) && trap->launch_ammo) {
 		impossible("deleting trap containing ammo?");
 		struct obj* otmp = trap->launch_ammo;
 		extract_nobj(otmp, &trap->launch_ammo);

--- a/src/trap.c
+++ b/src/trap.c
@@ -346,6 +346,11 @@ register int x, y, typ;
 			otmp->quan = rnd(3);
 			set_trap_ammo(ttmp, otmp);
 			break;
+		case ROCKTRAP:
+			otmp = mksobj(ROCK, TRUE, FALSE);
+			otmp->quan = 5 + rnd(10);
+			set_trap_ammo(ttmp, otmp);
+			break;
 	    case RUST_TRAP:
 		if (!rn2(4)) {
 		    del_engr_at(x, y);
@@ -823,7 +828,7 @@ unsigned trflags;
 		break;
 
 	    case ROCKTRAP:
-		if (trap->once && trap->tseen && !rn2(15)) {
+		if (!(otmp = trap->launch_ammo)) {
 		    pline("A trap door in %s opens, but nothing falls out!",
 			  the(ceiling(u.ux,u.uy)));
 		    deltrap(trap);
@@ -831,11 +836,11 @@ unsigned trflags;
 		} else {
 		    int dmg = d(2,6); /* should be std ROCK dmg? */
 
-		    trap->once = 1;
+			if (trap->launch_ammo->quan > 1) {
+				otmp = splitobj(trap->launch_ammo, 1);
+			}
+			extract_nobj(otmp, &trap->launch_ammo);
 		    seetrap(trap);
-		    otmp = mksobj_at(ROCK, u.ux, u.uy, TRUE, FALSE);
-		    otmp->quan = 1L;
-		    otmp->owt = weight(otmp);
 
 		    pline("A trap door in %s opens and %s falls on your %s!",
 			  the(ceiling(u.ux,u.uy)),
@@ -864,6 +869,7 @@ unsigned trflags;
 		    }
 
 		    if (!Blind) otmp->dknown = 1;
+			place_object(otmp, u.ux, u.uy);
 		    stackobj(otmp);
 		    newsym(u.ux,u.uy);	/* map the rock */
 
@@ -2038,7 +2044,7 @@ register struct monst *mtmp;
 				trapkilled = TRUE;
 			break;
 		case ROCKTRAP:
-			if (trap->once && trap->tseen && !rn2(15)) {
+			if (!(otmp = trap->launch_ammo)) {
 			    if (in_sight && see_it)
 				pline("A trap door above %s opens, but nothing falls out!",
 				      mon_nam(mtmp));
@@ -2046,10 +2052,10 @@ register struct monst *mtmp;
 			    newsym(mtmp->mx, mtmp->my);
 			    break;
 			}
-			trap->once = 1;
-			otmp = mksobj(ROCK, TRUE, FALSE);
-			otmp->quan = 1L;
-			otmp->owt = weight(otmp);
+			if (trap->launch_ammo->quan > 1) {
+				otmp = splitobj(trap->launch_ammo, 1);
+			}
+			extract_nobj(otmp, &trap->launch_ammo);
 			if (in_sight) seetrap(trap);
 			if (thitm(0, mtmp, otmp, d(2, 6), FALSE))
 			    trapkilled = TRUE;

--- a/src/trap.c
+++ b/src/trap.c
@@ -4867,6 +4867,12 @@ register struct trap *trap;
 		if (!ttmp) return;
 		ttmp->ntrap = trap->ntrap;
 	}
+	while (trap->ammo) {
+		impossible("deleting trap containing ammo?");
+		struct obj* otmp = trap->ammo;
+		extract_nobj(otmp, &trap->ammo);
+		obfree(otmp, (struct obj *) 0);
+	}
 	dealloc_trap(trap);
 }
 

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -13207,13 +13207,21 @@ boolean killerset;				/* if TRUE, use the already-set killer if the player dies 
 	/* poison */
 	if (poisons_resisted || poisons_majoreff || poisons_minoreff || poisons_wipedoff) {
 		otmp = poisonedobj;
-		if (youdef && attk) {/* SCOPECREEP: get below scopecreep working so that the player can be poisoned by a poisoned object that isn't from an attack hitting them */
-			/* using poisoned() from mon.c */
+		if (youdef) {
 			char buf[BUFSZ];
-			Sprintf(buf, "%s %s", s_suffix(Monnam(magr)), mpoisons_subj(magr, attk));
+			if (attk && magr) {
+				/* using poisoned() from mon.c */
+				Sprintf(buf, "%s %s", s_suffix(Monnam(magr)), mpoisons_subj(magr, attk));
+			}
+			else if (otmp) {
+				Sprintf(buf, "%s", The(xname(otmp)));
+			}
+			else {
+				impossible("no name to poison you with");
+			}
 			/* SCOPECREEP: the "fatal" field (30) is inconsistent. Preferrably, this should use the same major/minor effect system set up in this function */
 			/* also, this spams messages when recursed */
-			poisoned(buf, A_CON, pa->mname, 30, (poisons_majoreff | poisons_minoreff));
+			poisoned(buf, A_CON, (magr ? pa->mname : xname(otmp)), 30, (poisons_majoreff | poisons_minoreff));
 		}
 		else {
 			int i, n;


### PR DESCRIPTION
Actually creates an object and attaches it to the trap.
I didn't do it this way at first because I was scared of save/restore object chains 😄 

Also:
Makes fire traps limited
Fixes crash with poisoned trap ammo