### PR TITLE
proofed corrodable items should be acid-coatable

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -2683,7 +2683,7 @@ dodip()
 			(potion->otyp == POT_BLOOD && acidic(&mons[potion->corpsenm]))) 
 		&& (!(obj->opoisoned & OPOISON_ACID) || obj->otyp == VIPERWHIP)
 	){
-		if(is_corrodeable(obj) && obj->oeroded2 < MAX_ERODE){
+		if(is_corrodeable(obj) && !obj->oerodeproof && obj->oeroded2 < MAX_ERODE){
 			int poofit = 1;
 			if(obj->greased)
 				poofit = 0;


### PR DESCRIPTION
honestly - I see no reason why you can't acid-coat items as you corrode them ala lethe, but I mean I guess the acid is consumed as it destroys the item, so the better question is why can lethe? but yeah