### PR TITLE
Fix Treasury of Proteus angering shopkeepers

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -1785,7 +1785,7 @@ no_unwear:
 	    addinv_core2(otmp);
 	}
 
-	if ((!carried(otmp) || obj->unpaid) &&
+	if ((!(carried(otmp) || (otmp->where == OBJ_CONTAINED && carried(otmp->ocontainer))) || obj->unpaid) &&
 		get_obj_location(otmp, &ox, &oy, BURIED_TOO|CONTAINED_TOO) &&
 		costly_spot(ox, oy)) {
 	    register struct monst *shkp =


### PR DESCRIPTION
Note: only checks a single level of ocontainer. Nesting containers would cause the bug to return. This is currently fine, because the Treasury is too large to be put into a bag.