### PR TITLE
Preemptively fix lightsource bugs

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -97,8 +97,7 @@ new_light_source(x, y, range, type, id)
 }
 
 /*
- * Delete a light source. This assumes only one light source is attached
- * to an object at a time.
+ * Delete all light sources attached to (type, id). There *should* only be one.
  */
 void
 del_light_source(type, id, silent)
@@ -108,6 +107,7 @@ del_light_source(type, id, silent)
 {
     light_source *curr, *prev;
     genericptr_t tmp_id;
+	boolean found_it = FALSE;
 
     /* need to be prepared for dealing a with light source which
        has only been partially restored during a level change
@@ -131,10 +131,12 @@ del_light_source(type, id, silent)
 
 	    free((genericptr_t)curr);
 	    vision_full_recalc = 1;
-	    return;
+		if (found_it && !silent)
+			impossible("multiple ls attached to type %d, id %d", type, curr->id);
+		found_it = TRUE;
 	}
     }
-    if(!silent) impossible("del_light_source: not found type=%d, id=0x%lx", type, (long)id);
+    if(!found_it && !silent) impossible("del_light_source: not found type=%d, id=0x%lx", type, (long)id);
 }
 
 /* Mark locations that are temporarily lit via mobile light sources. */

--- a/src/light.c
+++ b/src/light.c
@@ -57,6 +57,7 @@ extern char circle_start[];
 
 
 /* Create a new light source.  */
+/* If a lightsource is already attached to (type, id), replace it (with a warning) */
 void
 new_light_source(x, y, range, type, id)
     xchar x, y;
@@ -64,15 +65,26 @@ new_light_source(x, y, range, type, id)
     genericptr_t id;
 {
     light_source *ls;
+	boolean duplicate = FALSE;
 
     if (range > MAX_RADIUS || range < 0) {
 	impossible("new_light_source:  illegal range %d", range);
 	return;
     }
 
-    ls = (light_source *) alloc(sizeof(light_source));
-
-    ls->next = light_base;
+	/* check that this is a unique lightsource */
+	for (ls = light_base; ls; ls = ls->next) {
+		if (ls->type == type && ls->id == id) {
+			/* Duplicate */
+			duplicate = TRUE;
+			impossible("duplicate lightsource attempting to be created, type %d", type);
+			break;
+		}
+	}
+	if (!duplicate) {
+		ls = (light_source *)alloc(sizeof(light_source));
+	}
+	ls->next = light_base;
     ls->x = x;
     ls->y = y;
     ls->range = range;


### PR DESCRIPTION
Closes #415, I think.

There should only be 1 lightsource attached to any monster/object. With del_light_source properly closing all ls, though, it might also be acceptably not-crashy (but pointless) to have >1 ls on something.