### PR TITLE
Extracting an object from a chain resets obj->nobj

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2865,6 +2865,7 @@ extract_nobj(obj, head_ptr)
 		panic("extract_nobj: object lost");
 	}
     obj->where = OBJ_FREE;
+	obj->nobj = (struct obj *)0;
 }
 
 


### PR DESCRIPTION
Do not require caller of extract_nobj() to (re)set obj->nobj.