### PR TITLE
Block glamdring from being whipped away

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -2321,11 +2321,11 @@ museamnesia:
 				/* this monster won't want to catch a cursed
 				   weapon; drop it at hero's feet instead */
 				where_to = 2;
-		    } /*else if (where_to == 3 && hates_holy_mon(mtmp) && obj->blessed) {
-				// this is commented out because that's a reasonably strong change, since
-				// then all you have to do is bless your weapon and you've got a much better chance of keeping it
+		    } else if (where_to == 3 && hates_holy_mon(mtmp) && obj->blessed) {
+				/* this monster won't want to catch a blessed
+				   weapon; drop it at hero's feet instead */
 				where_to = 2;
-		    }*/
+		    }
 		    
 		    
 		    freeinv(obj);

--- a/src/muse.c
+++ b/src/muse.c
@@ -2281,42 +2281,53 @@ museamnesia:
 		    hand = body_part(HAND);
 		    if (bimanual(obj,youracedata)) hand = makeplural(hand);
 
-		    if (vismon)
-			pline("%s flicks a whip towards your %s!",
-			      Monnam(mtmp), hand);
+		    if (vismon){
+				pline("%s flicks a whip towards your %s!", Monnam(mtmp), hand);
+			}
 		    if (obj->otyp == HEAVY_IRON_BALL) {
-			pline("%s fails to wrap around %s.",
-			      The_whip, the_weapon);
-			return 1;
+				pline("%s fails to wrap around %s.", The_whip, the_weapon);
+				return 1;
 		    }
-		    pline("%s wraps around %s you're wielding!",
-			  The_whip, the_weapon);
+		    
+		    if (obj->oartifact)
+		   		pline("%s wraps around your wielded %s!", The_whip, the_weapon);
+		    else
+		    	pline("%s wraps around %s you're wielding!", The_whip, the_weapon);
+		    
 		    if (welded(obj)) {
-			pline("%s welded to your %s%c",
-			      !is_plural(obj) ? "It is" : "They are",
-			      hand, !obj->bknown ? '!' : '.');
-			/* obj->bknown = 1; */ /* welded() takes care of this */
-			where_to = 0;
+				pline("%s welded to your %s%c", !is_plural(obj) ? "It is" : "They are",
+					hand, !obj->bknown ? '!' : '.');
+				/* obj->bknown = 1; */ /* welded() takes care of this */
+				where_to = 0;
 		    }
+		    
+		    if (obj->oartifact && obj->oartifact == ART_GLAMDRING){
+		    	pline("Glamdring resists being ripped out of your hands!");
+		    	where_to = 0;
+		    }
+		    
 		    if (!where_to) {
-			pline_The("whip slips free.");  /* not `The_whip' */
-			return 1;
-		    } else if (where_to == 3 && hates_silver(mtmp->data) &&
-			    (obj->obj_material == SILVER || arti_silvered(obj))) {
-			/* this monster won't want to catch a silver
-			   weapon; drop it at hero's feet instead */
-			where_to = 2;
-		    } else if (where_to == 3 && hates_iron(mtmp->data) &&
-			    obj->obj_material == IRON) {
-			/* this monster won't want to catch an iron
-			   weapon; drop it at hero's feet instead */
-			where_to = 2;
-		    } else if (where_to == 3 && hates_unholy_mon(mtmp) &&
-			    is_unholy(obj)) {
-			/* this monster won't want to catch a cursed
-			   weapon; drop it at hero's feet instead */
-			where_to = 2;
-		    }
+				pline_The("whip slips free.");  /* not `The_whip' */
+				return 1;
+		    } else if (where_to == 3 && hates_silver(mtmp->data) && (obj->obj_material == SILVER || arti_silvered(obj))) {
+				/* this monster won't want to catch a silver
+				   weapon; drop it at hero's feet instead */
+				where_to = 2;
+		    } else if (where_to == 3 && hates_iron(mtmp->data) && obj->obj_material == IRON) {
+				/* this monster won't want to catch an iron
+				   weapon; drop it at hero's feet instead */
+				where_to = 2;
+		    } else if (where_to == 3 && hates_unholy_mon(mtmp) && is_unholy(obj)) {
+				/* this monster won't want to catch a cursed
+				   weapon; drop it at hero's feet instead */
+				where_to = 2;
+		    } /*else if (where_to == 3 && hates_holy_mon(mtmp) && obj->blessed) {
+				// this is commented out because that's a reasonably strong change, since
+				// then all you have to do is bless your weapon and you've got a much better chance of keeping it
+				where_to = 2;
+		    }*/
+		    
+		    
 		    freeinv(obj);
 		    uwepgone();
 		    switch (where_to) {


### PR DESCRIPTION
It can't be disarmed already, now it can't be yoinked with a whip.

before (and unchanged), you cannot be disarmed of glamdring by a disarming strike. however, since those are only implemented for youagr... and you need to either be wielding Tobiume or a ranseur.... that's a really pointless change. in fact, that's actively detrimental - a monster with glamdring can't have it stolen like that, but it never matters for you!

after, a whip trying to steal glamdring will just fail ("Glamdring resists being ripped out of your hands!").