### PR TITLE
Generalize the clear_path attack requirement

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -924,9 +924,6 @@ int tary;
 			/* don't make attacks that will kill oneself */
 			if (be_safe && !safe_attack(magr, mdef, attk, (struct obj *)0, pa, pd))
 				continue;
-			/* requires a clear path */
-			if (!clear_path(x(magr), y(magr), tarx, tary))
-				continue;
 			/* must be in range */
 			if (distmin(x(magr), y(magr), tarx, tary) > 
 				((aatyp == AT_5SBT || aatyp == AT_5SQR) ? 5 : 2))

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -45,6 +45,10 @@ boolean active;
 	if (cantmove(magr))
 		return FALSE;
 
+	/* agr has no line of sight to def */
+	if (!clear_path(x(magr), y(magr), tarx, tary))
+		return FALSE;
+
 	/* madness only prevents your active attempts to hit things */
 	if (youagr && active && madness_cant_attack(mdef))
 		return FALSE;


### PR DESCRIPTION
Prevents polearms through walls
I don't think there were any cases where this was desirable.