### PR TITLE
Correct fired-as-in-from-a-launcher vs fired-as-in-not-misthrown conf…

### DIFF
--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1166,7 +1166,7 @@ boolean * wepgone;				/* pointer to: TRUE if projectile has been destroyed */
 		if (mdef->mcanmove &&
 			(!is_animal(mdef->data)) &&
 			(!mindless_mon(mdef) || (mdef->data == &mons[PM_CROW_WINGED_HALF_DRAGON] && thrownobj->oartifact == ART_YORSHKA_S_SPEAR)) &&
-			!fired
+			!launcher
 			) {
 			if (vis) {
 				pline("%s catches %s.", Monnam(mdef), the(xname(thrownobj)));


### PR DESCRIPTION
…usion

Was causing pets to be hit when you threw weapons to them