### PR TITLE
New gloves: The Grappler's Grasp

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1048,6 +1048,19 @@ A("Hammerfeet",						KICKING_BOOTS,		(const char *)0,
 	NOINVOKE, (ARTI_PLUSSEV)
 	),
 
+/*Needs encyc entry*/
+/* has a chance to make a bonus AT_HUGS attack on targets when hitting */
+/* by extension, protects you from being grabbed */
+A("The Grappler's Grasp",			GAUNTLETS_OF_POWER,	(const char *)0,
+	2500L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	A_NONE, NON_PM, NON_PM, TIER_C, NOFLAG,
+	NO_MONS(),
+	ATTK(AD_PHYS, 1, 6), NOFLAG,
+	PROP0(), NOFLAG,
+	PROP0(), NOFLAG,
+	NOINVOKE, (ARTI_PLUSSEV)
+	),
+
 A("The Shield of the Resolute Heart",	GAUNTLETS_OF_DEXTERITY,			(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_NONE, NON_PM, NON_PM, TIER_B, NOFLAG,

--- a/include/extern.h
+++ b/include/extern.h
@@ -1505,7 +1505,7 @@ E boolean FDECL(can_blnd, (struct monst *,struct monst *,UCHAR_P,struct obj *));
 E boolean FDECL(ranged_attk, (struct permonst *));
 E boolean FDECL(passes_bars, (struct monst *));
 E boolean FDECL(can_track, (struct permonst *));
-E boolean FDECL(sticks, (struct permonst *));
+E boolean FDECL(sticks, (struct monst *));
 E int FDECL(num_horns, (struct permonst *));
 /* E boolean FDECL(canseemon, (struct monst *)); */
 E struct attack *FDECL(dmgtype_fromattack, (struct permonst *,int,int));

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -22,6 +22,7 @@ STATIC_DCL struct artifact artilist[];
 
 extern boolean notonhead;	/* for long worms */
 extern boolean lifehunt_sneak_attacking;
+extern struct attack grapple;
 
 #define get_artifact(o) \
 		(((o)&&(o)->oartifact) ? &artilist[(o)->oartifact] : 0)
@@ -327,6 +328,7 @@ struct obj * otmp;
 		switch (otmp->oartifact)
 		{
 		case ART_PREMIUM_HEART:
+		case ART_GRAPPLER_S_GRASP:
 		case ART_GRANDMASTER_S_ROBE:
 			artival += artival / 2;
 			break;
@@ -2602,7 +2604,7 @@ char *type;			/* blade, staff, etc */
 	    } else {
 		nomul(-3, "being scared stiff");
 		nomovemsg = "";
-		if (magr && magr == u.ustuck && sticks(youracedata)) {
+		if (magr && magr == u.ustuck && sticks(&youmonst)) {
 		    u.ustuck = (struct monst *)0;
 		    You("release %s!", mon_nam(magr));
 		}
@@ -3136,6 +3138,19 @@ boolean * messaged;
 		int dsize = spiritDsize();
 		explode(x(magr), y(magr), AD_PHYS, WEAPON_CLASS, d(5, dsize), EXPL_DARK, 1); //Obsidian Glass
 		explode(x(mdef), y(mdef), AD_PHYS, WEAPON_CLASS, d(5, dsize), EXPL_DARK, 1); //Obsidian Glass
+	}
+
+	/* The Grappler's Grasp has a chance to begin grapples.  */
+	if (oartifact == ART_GRAPPLER_S_GRASP) {
+		/* cannot begin a grapple -- Damage is done by adding an AT_HUGS to your attack chain, NOT here. */
+		if ((youagr || youdef) && !u.ustuck)
+		{
+			int newres = xmeleehurty(magr, mdef, &grapple, &grapple, otmp, (youagr || youdef), 0, dieroll, -1, FALSE);
+
+			/* quick return in case we grabbed a cockatrice or something */
+			if (newres & (MM_AGR_DIED | MM_AGR_STOP))
+				return newres;
+		}
 	}
 
 	/* The defender was killed, by the player, by the artifact's special external damage sources */

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2335,7 +2335,7 @@ int final;	/* 0 => still in progress; 1 => over, survived; 2 => dead */
 	    you_are(buf);
 	} else if (u.ustuck) {
 	    Sprintf(buf, "%s %s",
-		    (Upolyd && sticks(youracedata)) ? "holding" : "held by",
+		    (sticks(&youmonst) ? "holding" : "held by"),
 		    a_monnam(u.ustuck));
 	    you_are(buf);
 	}
@@ -3095,7 +3095,7 @@ int final;
 	    dump(youwere, buf);
 	} else if (u.ustuck) {
 	    Sprintf(buf, "%s %s",
-		    (Upolyd && sticks(youracedata)) ? "holding" : "held by",
+		    (sticks(&youmonst) ? "holding" : "held by"),
 		    a_monnam(u.ustuck));
 	    dump(youwere, buf);
 	}

--- a/src/dog.c
+++ b/src/dog.c
@@ -1227,7 +1227,7 @@ int enhanced;
 	if (mtmp == u.ustuck) {
 	    if (u.uswallow)
 		expels(mtmp, mtmp->data, TRUE);
-	    else if (!(sticks(youracedata)))
+	    else if (!(sticks(&youmonst)))
 		unstuck(mtmp);
 	}
 

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -1011,7 +1011,7 @@ register int after;	/* this is extra fast monster movement */
 	    // }
 	}
 	if (!Conflict && !mtmp->mconf &&
-	    mtmp == u.ustuck && !sticks(youracedata)) {
+	    mtmp == u.ustuck && !sticks(&youmonst)) {
 	    unstuck(mtmp);	/* swallowed case handled above */
 	    You("get released!");
 	}

--- a/src/hack.c
+++ b/src/hack.c
@@ -1080,7 +1080,7 @@ domove()
 		    if (distu(u.ustuck->mx, u.ustuck->my) > 2) {
 			/* perhaps it fled (or was teleported or ... ) */
 			u.ustuck = 0;
-		    } else if (sticks(youracedata)) {
+		    } else if (sticks(&youmonst)) {
 			/* When polymorphed into a sticking monster,
 			 * u.ustuck means it's stuck to you, not you to it.
 			 */

--- a/src/mon.c
+++ b/src/mon.c
@@ -6521,7 +6521,7 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
 				/* update swallow glyphs for new monster */
 				swallowed(0);
 			}
-		} else if (!sticks(mdat) && !sticks(youracedata))
+		} else if (!sticks(mtmp) && !sticks(&youmonst))
 			unstuck(mtmp);
 	}
 

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -509,11 +509,19 @@ can_track(ptr)		/* returns TRUE if monster can track well */
 #ifdef OVL1
 
 boolean
-sticks(ptr)	/* creature sticks other creatures it hits */
-	register struct permonst *ptr;
+sticks(mtmp)	/* creature sticks other creatures it hits */
+struct monst * mtmp;
 {
-	return((boolean)(dmgtype(ptr,AD_STCK) || dmgtype(ptr,AD_WRAP) ||
-		attacktype(ptr,AT_HUGS)));
+	register struct permonst * ptr = (mtmp == &youmonst) ? youracedata : mtmp->data;
+	/* monsters that can intrinsically do so */
+	if (dmgtype(ptr, AD_STCK) || dmgtype(ptr, AD_WRAP) || attacktype(ptr, AT_HUGS))
+		return TRUE;
+	/* or if wearing the Grappler's Grasp */
+	struct obj * gloves = ((mtmp == &youmonst) ? uarmg : which_armor(mtmp, W_ARMG));
+	if (gloves && gloves->oartifact == ART_GRAPPLER_S_GRASP)
+		return TRUE;
+
+	return FALSE;
 }
 
 /* number of horns this type of monster has on its head */

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -778,7 +778,7 @@ boolean fleemsg;
 	if (u.ustuck == mtmp) {
 	    if (u.uswallow)
 		expels(mtmp, mtmp->data, TRUE);
-	    else if (!sticks(youracedata)) {
+	    else if (!sticks(&youmonst)) {
 		unstuck(mtmp);	/* monster lets go when fleeing */
 		You("get released!");
 	    }
@@ -1822,7 +1822,7 @@ boolean
 itsstuck(mtmp)
 register struct monst *mtmp;
 {
-	if (sticks(youracedata) && mtmp==u.ustuck && !u.uswallow) {
+	if (sticks(&youmonst) && mtmp==u.ustuck && !u.uswallow) {
 		pline("%s cannot escape from you!", Monnam(mtmp));
 		return(TRUE);
 	}

--- a/src/pager.c
+++ b/src/pager.c
@@ -211,7 +211,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 		Strcat(buf, "praying ");
 		
 	    if (u.ustuck == mtmp)
-		Strcat(buf, (sticks(youracedata)) ?
+		Strcat(buf, (sticks(&youmonst)) ?
 			", being held" : ", holding you");
 	    if (mtmp->mleashed)
 		Strcat(buf, ", leashed to you");

--- a/src/pline.c
+++ b/src/pline.c
@@ -505,7 +505,7 @@ register struct monst *mtmp;
 	if (mtmp->mundetected)	  Strcat(info, ", concealed");
 	if (mtmp->minvis)	  Strcat(info, ", invisible");
 	if (mtmp == u.ustuck)	  Strcat(info,
-			(sticks(youracedata)) ? ", held by you" :
+			(sticks(&youmonst)) ? ", held by you" :
 				u.uswallow ? (is_animal(u.ustuck->data) ?
 				", swallowed you" :
 				", engulfed you") :
@@ -580,7 +580,7 @@ ustatusline()
 	if (u.uundetected)	Strcat(info, ", concealed");
 	if (Invis)		Strcat(info, ", invisible");
 	if (u.ustuck) {
-	    if (sticks(youracedata))
+	    if (sticks(&youmonst))
 		Strcat(info, ", holding ");
 	    else
 		Strcat(info, ", held by ");

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -89,7 +89,7 @@ STATIC_OVL void
 polyman(fmt, arg)
 const char *fmt, *arg;
 {
-	boolean sticky = sticks(youmonst.data) && u.ustuck && !u.uswallow,
+	boolean sticky = sticks(&youmonst) && u.ustuck && !u.uswallow,
 		was_mimicking = (youmonst.m_ap_type == M_AP_OBJECT);
 	boolean could_pass_walls = Passes_walls;
 	boolean was_blind = !!Blind;
@@ -399,7 +399,7 @@ int
 polymon(mntmp)	/* returns 1 if polymorph successful */
 int	mntmp;
 {
-	boolean sticky = sticks(youmonst.data) && u.ustuck && !u.uswallow,
+	boolean sticky = sticks(&youmonst) && u.ustuck && !u.uswallow,
 		was_blind = !!Blind, dochange = FALSE;
 	boolean could_pass_walls = Passes_walls;
 	int mlvl;
@@ -584,8 +584,8 @@ int	mntmp;
 	}
 	newsym(u.ux,u.uy);		/* Change symbol */
 
-	if (!sticky && !u.uswallow && u.ustuck && sticks(youmonst.data)) u.ustuck = 0;
-	else if (sticky && !sticks(youmonst.data)) uunstick();
+	if (!sticky && !u.uswallow && u.ustuck && sticks(&youmonst)) u.ustuck = 0;
+	else if (sticky && !sticks(&youmonst)) uunstick();
 #ifdef STEED
 	if (u.usteed) {
 	    if (touch_petrifies(u.usteed->data) &&

--- a/src/trap.c
+++ b/src/trap.c
@@ -2768,7 +2768,7 @@ long hmask, emask;     /* might cancel timeout */
 	/* check for falling into pool - added by GAN 10/20/86 */
 	if(!Flying) {
 		if (!u.uswallow && u.ustuck) {
-			if (sticks(youracedata))
+			if (sticks(&youmonst))
 				You("aren't able to maintain your hold on %s.",
 					mon_nam(u.ustuck));
 			else
@@ -3724,7 +3724,7 @@ dountrap()	/* disarm a trap */
 	if (((nohands(youracedata) || !freehand()) && !(webmaker(youracedata) || u.sealsActive&SEAL_CHUPOCLOPS || (uarm && uarm->oartifact==ART_SPIDERSILK))) || !youracedata->mmove) {
 	    pline("And just how do you expect to do that?");
 	    return 0;
-	} else if (u.ustuck && sticks(youracedata)) {
+	} else if (u.ustuck && sticks(&youmonst)) {
 	    pline("You'll have to let go of %s first.", mon_nam(u.ustuck));
 	    return 0;
 	}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -49,6 +49,7 @@ static const int Soresu_counterattack[] = { 10, 15, 25 };
 /* Misc attacks */
 static struct attack noattack = { 0, 0, 0, 0 };
 static struct attack basicattack  = { AT_WEAP, AD_PHYS, 1, 4 };
+struct attack grapple = { AT_HUGS, AD_PHYS, 0, 6 };	/* for grappler's grasp */
 
 /* getvis()
  * 
@@ -1464,6 +1465,7 @@ int * subout;					/* records what attacks have been subbed out */
 #define SUBOUT_MAINWEPB	0x0080	/* Bonus attack caused by the wielded *mainhand* weapon */
 #define SUBOUT_XWEP		0x0100	/* when giving additional attacks, whether or not to use AT_XWEP or AT_WEAP this call */
 #define SUBOUT_GOATSPWN	0x0200	/* Goat spawn: seduction */
+#define SUBOUT_GRAPPLE	0x0400	/* Grappler's Grasp crushing damage */
 int * tohitmod;					/* some attacks are made with decreased accuracy */
 {
 	struct attack * attk;
@@ -1818,6 +1820,16 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 			attk->damd = 8;
 			/* this is applied to all acceptable attacks; no subout marker is necessary */
 		}	
+	}
+
+	/* creatures wearing the Grappler's Grasp and currently grappling something get a hug attack if they don't have one already */
+	if (is_null_attk(attk) && !by_the_book && !dmgtype(pa, AT_HUGS) && !(*subout&SUBOUT_GRAPPLE)) {
+		struct obj * otmp = (youagr ? uarmg : which_armor(magr, W_ARMG));
+		if (otmp && otmp->oartifact == ART_GRAPPLER_S_GRASP) {
+			*attk = grapple;
+			attk->damn = youagr ? ((P_SKILL(P_BARE_HANDED_COMBAT) + 1) / 2 + martial_bonus()) : 2;
+			*subout |= SUBOUT_GRAPPLE;
+		}
 	}
 
 	/* players can get a whole host of spirit attacks */
@@ -3883,7 +3895,7 @@ boolean ranged;
 	{
 		/* are grabs possible? */
 		if ((youagr || youdef)
-			&& !sticks(pd)
+			&& !sticks(mdef)
 			)
 		{
 			/* if we aren't already stuck, try to grab them */
@@ -4629,7 +4641,7 @@ boolean ranged;
 			&& !(result & MM_AGR_DIED)
 			&& (youagr || youdef)					/* the player must be involved in a sticking situation (gameplay limitation) */
 			&& !u.ustuck							/* can't already be stuck */
-			&& !(sticks(pa) && sticks(pd)))			/* creatures can't grab other grabbers (gameplay limitation)  */
+			&& !(sticks(magr) && sticks(mdef)))		/* creatures can't grab other grabbers (gameplay limitation)  */
 		{
 			if (pa == &mons[PM_TOVE])
 				pline("%s %s much too slithy to stick to %s!",
@@ -5547,7 +5559,7 @@ boolean ranged;
 		/* attempt to stick */
 		if ((youagr || youdef)					/* the player must be involved in a sticking situation (gameplay limitation) */
 			&& !u.ustuck						/* can't already be stuck */
-			&& !(sticks(pa) && sticks(pd))		/* grabbers can't grab other grabbers (gameplay limitation)  */
+			&& !(sticks(magr) && sticks(mdef))	/* grabbers can't grab other grabbers (gameplay limitation)  */
 			){
 			if (pd == &mons[PM_TOVE])
 			{
@@ -7048,7 +7060,7 @@ boolean ranged;
 		 * or if either creature could be the one doing the grabbing,
 		 * substitute simple physical damage */
 		if (!(youagr || youdef)
-			|| (sticks(pd))){
+			|| (sticks(mdef))){
 			/* make physical attack */
 			alt_attk.adtyp = AD_PHYS;
 			return xmeleehurty(magr, mdef, &alt_attk, originalattk, weapon, dohitmsg, dmg, dieroll, vis, ranged);

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -883,7 +883,7 @@ slept_monst(mon)
 struct monst *mon;
 {
 	if ((mon->msleeping || !mon->mcanmove) && mon == u.ustuck &&
-		!sticks(youracedata) && !u.uswallow) {
+		!sticks(&youmonst) && !u.uswallow) {
 		pline("%s grip relaxes.", s_suffix(Monnam(mon)));
 		unstuck(mon);
 	}


### PR DESCRIPTION
NOTE: This is created after (and so dependent on) the new artifact structure.

When you hit with an unarmed attack, you grab the defender and deal Nd6 crushing damage per turn.
Crushing damage is based on your unarmed skill, and is increased by 1 if you know martial arts.
Unskilled/Basic -> N = 1;  Skilled/Expert -> N = 2;  Master/Grandmaster -> N = 3..

You are immune to being grabbed while wearing these gauntlets, in the same way you are when polymorphed into a creature that makes grab attacks.