### PR TITLE
Fix some issues with hidden monsters and mimics

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1454,6 +1454,7 @@ E void NDECL(wake_nearby);
 E void NDECL(wake_nearby_noisy);
 E void FDECL(wake_nearto, (int,int,int));
 E void FDECL(wake_nearto_noisy, (int,int,int));
+E void FDECL(seemimic_ambush, (struct monst *));
 E void FDECL(seemimic, (struct monst *));
 E void NDECL(rescham);
 E void NDECL(restartcham);

--- a/src/mon.c
+++ b/src/mon.c
@@ -6052,6 +6052,7 @@ int anger;
 {
 	mtmp->msleeping = 0;
 	mtmp->meating = 0;	/* assume there's no salvagable food left */
+	mtmp->mstrategy &= ~(STRAT_WAITMASK);
 	if(anger) setmangry(mtmp);
 	if(mtmp->m_ap_type) seemimic(mtmp);
 	else if (flags.forcefight && !flags.mon_moving && mtmp->mundetected) {
@@ -6195,6 +6196,44 @@ register int x, y, distance;
 		}
 	}
 }
+
+void
+seemimic_ambush(mtmp)
+struct monst *mtmp;
+{
+	unsigned old_app = mtmp->mappearance;
+	uchar old_ap_type = mtmp->m_ap_type;
+
+	seemimic(mtmp);
+
+	if (canseemon(mtmp) && !sensemon(mtmp)) {
+		const char * app;
+		switch (old_ap_type)
+		{
+		case M_AP_OBJECT:
+			if (old_app == STRANGE_OBJECT)
+				app = "strange object";
+			else
+				app = simple_typename(old_app);
+			break;
+		case M_AP_FURNITURE:
+			app = defsyms[old_app].explanation;
+			break;
+		case M_AP_MONSTER:
+			app = mons[old_app].mname;
+			break;
+		case M_AP_NOTHING:
+			app = m_monnam(mtmp);
+			break;
+		}
+		pline("That %s was actually %s!",
+			app,
+			a_monnam(mtmp)
+			);
+	}
+	return;
+}
+
 
 /* NOTE: we must check for mimicry before calling this routine */
 void

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -8,6 +8,23 @@ extern boolean notonhead;
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
+/* unhide creatures, possibly with message, before they make an attack */
+void
+xmakingattack(magr, mdef, tarx, tary)
+struct monst * magr;
+struct monst * mdef;
+int tarx;
+int tary;
+{
+	boolean youagr = (magr == &youmonst);
+	boolean youdef = (mdef == &youmonst);
+	struct permonst * pa = youagr ? youracedata : magr->data;
+	struct permonst * pd = youdef ? youracedata : mdef->data;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
 boolean
 magr_can_attack_mdef(magr, mdef, tarx, tary, active)


### PR DESCRIPTION
The code to say "Foo was hidden under the water" wasn't working.
Mimics reveal themselves when attacking or being attacked.
Wakeup() should also tell monsters to stop waiting for the player (meditating).
You should get a message for noticing a hidden monster appearing.
Together with #460, should fix #451.