### PR TITLE
Rewrite how derived creatures are handled

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -49,7 +49,7 @@
 #define mon_warning(mon) ((Warning && !(mon)->mpeaceful &&         \
          (distu((mon)->mx, (mon)->my) < 100) &&        \
          (((int) ((mon)->m_lev / 4)) >= flags.warnlevel))    \
-        || ((mon)->data == &mons[PM_GREAT_CTHULHU] && \
+        || ((mon)->mtyp == PM_GREAT_CTHULHU && \
 		    (distu((mon)->mx, (mon)->my) < 2*BOLT_LIM * 2*BOLT_LIM) \
 			) \
 		)

--- a/include/display.h
+++ b/include/display.h
@@ -368,12 +368,12 @@
 
 /* Not affected by hallucination.  Gives a generic body for CORPSE */
 #define objnum_to_glyph(onum)	((int) ((onum) << 4) + objects[onum].oc_color + GLYPH_OBJ_OFF)
-#define monnum_to_glyph(mnum)	((int) (mnum) + GLYPH_MON_OFF)
-#define detected_monnum_to_glyph(mnum)	((int) (mnum) + GLYPH_DETECT_OFF)
-#define ridden_monnum_to_glyph(mnum)	((int) (mnum) + GLYPH_RIDDEN_OFF)
-#define petnum_to_glyph(mnum)	((int) (mnum) + GLYPH_PET_OFF)
-#define peacenum_to_glyph(mnum)	((int) (mnum) + GLYPH_PEACE_OFF)
-#define zombienum_to_glyph(mnum)	((int) (mnum) + GLYPH_ZOMBIE_OFF)
+#define monnum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_MON_OFF)
+#define detected_monnum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_DETECT_OFF)
+#define ridden_monnum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_RIDDEN_OFF)
+#define petnum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_PET_OFF)
+#define peacenum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_PEACE_OFF)
+#define zombienum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_ZOMBIE_OFF)
 
 /* The hero's glyph when seen as a monster.
  */

--- a/include/extern.h
+++ b/include/extern.h
@@ -1481,7 +1481,7 @@ E void FDECL(insight_vanish,(struct monst *));
 
 /* ### mondata.c ### */
 
-E void FDECL(set_mon_data, (struct monst *,struct permonst *,int));
+E void FDECL(set_mon_data, (struct monst *,int,int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(attacktype, (struct permonst *,int));
 E boolean FDECL(noattacks, (struct permonst *));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1460,7 +1460,7 @@ E void NDECL(rescham);
 E void NDECL(restartcham);
 E void FDECL(restore_cham, (struct monst *));
 E void FDECL(mon_animal_list, (BOOLEAN_P));
-E int FDECL(newcham, (struct monst *,struct permonst *,BOOLEAN_P,BOOLEAN_P));
+E int FDECL(newcham, (struct monst *,int,BOOLEAN_P,BOOLEAN_P));
 E int FDECL(select_newcham_form, (struct monst *));
 E int FDECL(can_be_hatched, (int));
 E int FDECL(egg_type_from_parent, (int,BOOLEAN_P));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1482,7 +1482,7 @@ E void FDECL(insight_vanish,(struct monst *));
 /* ### mondata.c ### */
 
 E void NDECL(id_permonst);
-E void FDECL(set_mon_data, (struct monst *,int,int));
+E void FDECL(set_mon_data, (struct monst *,int));
 E void FDECL(set_faction, (struct monst *, int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(attacktype, (struct permonst *,int));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1483,6 +1483,7 @@ E void FDECL(insight_vanish,(struct monst *));
 
 E void NDECL(id_permonst);
 E void FDECL(set_mon_data, (struct monst *,int,int));
+E void FDECL(set_faction, (struct monst *, int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(attacktype, (struct permonst *,int));
 E boolean FDECL(noattacks, (struct permonst *));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1481,6 +1481,7 @@ E void FDECL(insight_vanish,(struct monst *));
 
 /* ### mondata.c ### */
 
+E void NDECL(id_permonst);
 E void FDECL(set_mon_data, (struct monst *,int,int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(attacktype, (struct permonst *,int));

--- a/include/hack.h
+++ b/include/hack.h
@@ -138,7 +138,7 @@ NEARDATA extern coord bhitpos;	/* place where throw or zap hits or stops */
 					(u.sealsActive&SEAL_PAIMON && is_magical((mon)->data)) || \
 					(u.sealsActive&SEAL_ANDROMALIUS && is_thief((mon)->data)) || \
 					(u.sealsActive&SEAL_TENEBROUS && !nonliving_mon(mon)) || \
-					(Upolyd && youmonst.data == &mons[PM_SHARK] && has_blood((mon)->data) && \
+					(Upolyd && youmonst.data->mtyp == PM_SHARK && has_blood((mon)->data) && \
 						(mon)->mhp < (mon)->mhpmax && is_pool(u.ux, u.uy, TRUE) && is_pool((mon)->mx, (mon)->my, TRUE)) || \
 					(u.specialSealsActive&SEAL_ACERERAK && is_undead_mon(mon)) || \
 					(uwep && uwep->oclass == WEAPON_CLASS && (uwep)->obj_material == WOOD && uwep->otyp != MOON_AXE &&\

--- a/include/monattk.h
+++ b/include/monattk.h
@@ -50,6 +50,14 @@
 #define AT_MARI		254	/* uses (i-2)th unwielded weapon in inventory */
 #define AT_MAGC		255	/* uses magic spell(s) */
 
+#define weapon_aatyp(aatyp)	( \
+	(aatyp) == AT_WEAP || \
+	(aatyp) == AT_XWEP || \
+	(aatyp) == AT_MARI || \
+	(aatyp) == AT_DEVA || \
+	(aatyp) == AT_HODS \
+	)
+
 /*	Add new damage types below.
  *
  *	Note that 1-10 correspond to the types of attack used in buzz().

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -255,7 +255,7 @@
 								 (ptr)->mtyp == PM_MASKED_QUEEN \
 								 )
 #define controlledwidegaze(ptr)		(is_angel(ptr) || is_auton(ptr))
-#define controlledwidegaze_mon(mon)		(controlledwidegaze((mon)->data))
+#define controlledwidegaze_mon(mon)		(controlledwidegaze((mon)->data) || (mon)->mfaction == ILLUMINATED)
 #define acidic(ptr)			(((ptr)->mflagsb & MB_ACID) != 0L)
 #define poisonous(ptr)		(((ptr)->mflagsb & MB_POIS) != 0L)
 #define freezing(ptr)		(((ptr)->mflagsb & MB_CHILL) != 0L)

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -41,7 +41,7 @@
 #define is_blind(mon)		(!((mon)->mcansee) || (darksight((mon)->data) && !(\
 													(!levl[(mon)->mx][(mon)->my].lit && !(viz_array[(mon)->my][(mon)->mx]&TEMP_LIT1 && !(viz_array[(mon)->my][(mon)->mx]&TEMP_DRK1)))\
 													|| (levl[(mon)->mx][(mon)->my].lit &&  (viz_array[(mon)->my][(mon)->mx]&TEMP_DRK1 && !(viz_array[(mon)->my][(mon)->mx]&TEMP_LIT1))))))
-#define is_deaf(mon)		(!((mon)->mcanhear) || (mon)->data == &mons[PM_ALABASTER_ELF] || (mon)->data == &mons[PM_ALABASTER_ELF_ELDER])
+#define is_deaf(mon)		(!((mon)->mcanhear) || (mon)->mtyp == PM_ALABASTER_ELF || (mon)->mtyp == PM_ALABASTER_ELF_ELDER)
 
 #define is_molochan(ptr)	((ptr)->maligntyp == A_NONE)
 #define is_voidalign(ptr)	((ptr)->maligntyp == A_VOID)
@@ -49,21 +49,21 @@
 #define is_neutral(ptr)		((ptr)->maligntyp == A_NEUTRAL)
 #define is_chaotic(ptr)		((ptr)->maligntyp < A_NEUTRAL && !is_molochan(ptr) && !is_voidalign(ptr))
 
-#define is_alabaster_mummy(ptr)	((ptr) == &mons[PM_ALABASTER_MUMMY])
+#define is_alabaster_mummy(ptr)	((ptr)->mtyp == PM_ALABASTER_MUMMY)
 
 #define is_lminion(mon)		(is_minion((mon)->data) && \
 				 (mon)->data->maligntyp > A_NEUTRAL && \
-				 ((mon)->data != &mons[PM_ANGEL] || \
+				 ((mon)->mtyp != PM_ANGEL || \
 				  EPRI(mon)->shralign > 0))
 
 #define is_nminion(mon)		(is_minion((mon)->data) && \
 				 (mon)->data->maligntyp == A_NEUTRAL && \
-				 ((mon)->data != &mons[PM_ANGEL] || \
+				 ((mon)->mtyp != PM_ANGEL || \
 				  EPRI(mon)->shralign == 0))
 
 #define is_cminion(mon)		(is_minion((mon)->data) && \
 				 (mon)->data->maligntyp < A_NEUTRAL && \
-				 ((mon)->data != &mons[PM_ANGEL] || \
+				 ((mon)->mtyp != PM_ANGEL || \
 				  EPRI(mon)->shralign < 0))
 
 #define notonline(ptr)			(((ptr)->mflagsm & MM_NOTONL) != 0L)
@@ -74,7 +74,10 @@
 #define species_displaces(ptr)	(((ptr)->mflagsg & MG_DISPLACEMENT) != 0L)
 #define species_floats(ptr)		(((ptr)->mflagsm & MM_FLOAT) != 0L)
 #define species_swims(ptr)		(((ptr)->mflagsm & MM_SWIM) != 0L)
-#define is_suicidal(ptr)		(is_fern_spore(ptr) || ptr == &mons[PM_FREEZING_SPHERE] || ptr == &mons[PM_FLAMING_SPHERE] || ptr == &mons[PM_SHOCKING_SPHERE])
+#define is_suicidal(ptr)		(is_fern_spore(ptr) || \
+					(ptr)->mtyp == PM_FREEZING_SPHERE || \
+					(ptr)->mtyp == PM_FLAMING_SPHERE || \
+					(ptr)->mtyp == PM_SHOCKING_SPHERE)
 #define breathless(ptr)			(((ptr)->mflagsm & MM_BREATHLESS) != 0L)
 #define breathless_mon(mon)		(breathless((mon)->data) || is_derived_undead_mon(mon) || mon_resistance((mon), MAGICAL_BREATHING))
 #define amphibious(ptr)			(((ptr)->mflagsm & (MM_AMPHIBIOUS | MM_BREATHLESS)) != 0L)
@@ -82,7 +85,7 @@
 #define species_passes_walls(ptr)	(((ptr)->mflagsm & MM_WALLWALK) != 0L)
 #define amorphous(ptr)			(((ptr)->mflagsm & MM_AMORPHOUS) != 0L)
 #define noncorporeal(ptr)		((ptr)->mlet == S_GHOST || (ptr)->mlet == S_SHADE)
-#define insubstantial(ptr)		((ptr)->mlet == S_SHADE || (ptr) == &mons[PM_SHARAB_KAMEREL])
+#define insubstantial(ptr)		((ptr)->mlet == S_SHADE || (ptr)->mtyp == PM_SHARAB_KAMEREL)
 #define tunnels(ptr)			(((ptr)->mflagsm & MM_TUNNEL) != 0L)
 #define needspick(ptr)			(((ptr)->mflagsm & MM_NEEDPICK) != 0L)
 #define hides_under(ptr)		(((ptr)->mflagst & MT_CONCEAL) != 0L)
@@ -94,9 +97,9 @@
 #define goodsmeller(ptr)		(((ptr)->mflagsv & MV_SCENT) != 0L)
 #define is_tracker(ptr)			(((ptr)->mflagsg & MG_TRACKER) != 0L)
 #define eyecount(ptr)			(!haseyes(ptr) ? 0 : \
-				 ((ptr) == &mons[PM_CYCLOPS] || \
-				  (ptr) == &mons[PM_MONOTON] || \
-				  (ptr) == &mons[PM_FLOATING_EYE]) ? 1 : 2)
+				 ((ptr)->mtyp == PM_CYCLOPS || \
+				  (ptr)->mtyp == PM_MONOTON || \
+				  (ptr)->mtyp == PM_FLOATING_EYE) ? 1 : 2)
 #define sensitive_ears(ptr)		(((ptr)->mflagsv & MV_ECHOLOCATE) != 0L)
 #define nohands(ptr)		(((ptr)->mflagsb & (MB_NOHANDS|MB_NOLIMBS)) != 0L)
 #define nolimbs(ptr)		(((ptr)->mflagsb & MB_NOLIMBS) == MB_NOLIMBS)
@@ -106,101 +109,106 @@
 #define has_head_mon(mon) ((mon)->mfaction == MISTWEAVER || has_head((mon)->data))
 #define has_horns(ptr)		(num_horns(ptr) > 0)
 #define is_whirly(ptr)		((ptr)->mlet == S_VORTEX || \
-				 (ptr) == &mons[PM_AIR_ELEMENTAL] ||\
-				 (ptr) == &mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES] ||\
-				 (ptr) == &mons[PM_DREADBLOSSOM_SWARM])
-#define has_passthrough_displacement(ptr)	((ptr) == &mons[PM_WRAITHWORM] ||\
-				 (ptr) == &mons[PM_FIRST_WRAITHWORM])
-#define flaming(ptr)		((ptr) == &mons[PM_FIRE_VORTEX] || \
-				 (ptr) == &mons[PM_FLAMING_SPHERE] || \
-				 (ptr) == &mons[PM_FIRE_ELEMENTAL] || \
-				 (ptr) == &mons[PM_SALAMANDER])
-#define is_gold(ptr)	((ptr) == &mons[PM_GOLD_GOLEM] || \
-				 (ptr) == &mons[PM_GOLDEN_HEART] || \
-				 (ptr) == &mons[PM_TREASURY_GOLEM] || \
-				 (ptr) == &mons[PM_AURUMACH_RILMANI] || \
-				 (ptr) == &mons[PM_ARA_KAMEREL] || \
-				 (ptr) == &mons[PM_ACERERAK] || \
-				 (ptr) == &mons[PM_RADIANT_PYRAMID])
-#define is_iron(ptr)	((ptr) == &mons[PM_IRON_PIERCER] || \
-				 (ptr) == &mons[PM_IRON_GOLEM] || \
-				 (ptr) == &mons[PM_CHAIN_GOLEM] || \
-				 (ptr) == &mons[PM_SCRAP_TITAN] || \
-				 (ptr) == &mons[PM_HELLFIRE_COLOSSUS] || \
-				 (ptr) == &mons[PM_HELLFIRE_ORB] || \
-				 (ptr) == &mons[PM_FERRUMACH_RILMANI])
+				 (ptr)->mtyp == PM_AIR_ELEMENTAL ||\
+				 (ptr)->mtyp == PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES ||\
+				 (ptr)->mtyp == PM_DREADBLOSSOM_SWARM)
+#define has_passthrough_displacement(ptr)	((ptr)->mtyp == PM_WRAITHWORM ||\
+				 (ptr)->mtyp == PM_FIRST_WRAITHWORM)
+#define flaming(ptr)		((ptr)->mtyp == PM_FIRE_VORTEX || \
+				 (ptr)->mtyp == PM_FLAMING_SPHERE || \
+				 (ptr)->mtyp == PM_FIRE_ELEMENTAL || \
+				 (ptr)->mtyp == PM_SALAMANDER)
+#define is_gold(ptr)	((ptr)->mtyp == PM_GOLD_GOLEM || \
+				 (ptr)->mtyp == PM_GOLDEN_HEART || \
+				 (ptr)->mtyp == PM_TREASURY_GOLEM || \
+				 (ptr)->mtyp == PM_AURUMACH_RILMANI || \
+				 (ptr)->mtyp == PM_ARA_KAMEREL || \
+				 (ptr)->mtyp == PM_ACERERAK || \
+				 (ptr)->mtyp == PM_RADIANT_PYRAMID)
+#define is_iron(ptr)	((ptr)->mtyp == PM_IRON_PIERCER || \
+				 (ptr)->mtyp == PM_IRON_GOLEM || \
+				 (ptr)->mtyp == PM_CHAIN_GOLEM || \
+				 (ptr)->mtyp == PM_SCRAP_TITAN || \
+				 (ptr)->mtyp == PM_HELLFIRE_COLOSSUS || \
+				 (ptr)->mtyp == PM_HELLFIRE_ORB || \
+				 (ptr)->mtyp == PM_FERRUMACH_RILMANI)
 #define is_iron_mon(mon)	(is_iron((mon)->data))
-#define is_silver(ptr)	((ptr) == &mons[PM_ARGENACH_RILMANI] || \
-				 (ptr) == &mons[PM_AMM_KAMEREL] || \
-				 (ptr) == &mons[PM_ARGENTUM_GOLEM])
+#define is_silver(ptr)	((ptr)->mtyp == PM_ARGENACH_RILMANI || \
+				 (ptr)->mtyp == PM_AMM_KAMEREL || \
+				 (ptr)->mtyp == PM_ARGENTUM_GOLEM)
 #define is_silver_mon(mon)	(is_silver((mon)->data))
-#define is_stone(ptr)	((ptr) == &mons[PM_DUST_VORTEX] || \
-				 (ptr) == &mons[PM_EARTH_ELEMENTAL] || \
-				 (ptr) == &mons[PM_TERRACOTTA_SOLDIER] || \
-				 (ptr) == &mons[PM_STONE_GOLEM] || \
-				 (ptr) == &mons[PM_SENTINEL_OF_MITHARDIR] || \
-				 (ptr) == &mons[PM_GARGOYLE] || \
-				 (ptr) == &mons[PM_WINGED_GARGOYLE] || \
-				 (ptr) == &mons[PM_XORN])
+#define is_stone(ptr)	((ptr)->mtyp == PM_DUST_VORTEX || \
+				 (ptr)->mtyp == PM_EARTH_ELEMENTAL || \
+				 (ptr)->mtyp == PM_TERRACOTTA_SOLDIER || \
+				 (ptr)->mtyp == PM_STONE_GOLEM || \
+				 (ptr)->mtyp == PM_SENTINEL_OF_MITHARDIR || \
+				 (ptr)->mtyp == PM_GARGOYLE || \
+				 (ptr)->mtyp == PM_WINGED_GARGOYLE || \
+				 (ptr)->mtyp == PM_XORN)
 #define is_anhydrous(ptr)	(flaming(ptr)  || \
 							 is_clockwork(ptr) || \
 							 is_stone(ptr) || \
 							 is_auton(ptr) || \
 				 (ptr)->mlet == S_KETER || \
-				 (ptr) == &mons[PM_AOA] || \
-				 (ptr) == &mons[PM_AOA_DROPLET])
-#define is_watery(ptr)	((ptr) == &mons[PM_WATER_ELEMENTAL] \
-				 || (ptr) == &mons[PM_WATER_DOLPHIN] \
-				 || (ptr) == &mons[PM_FOG_CLOUD] \
-				 || (ptr) == &mons[PM_STEAM_VORTEX] \
-				 || (ptr) == &mons[PM_ANCIENT_TEMPEST] \
-				 || (ptr) == &mons[PM_MORTAI] \
-				 || (ptr) == &mons[PM_HUDOR_KAMEREL] \
-				 || (ptr) == &mons[PM_LETHE_ELEMENTAL] \
+				 (ptr)->mtyp == PM_AOA || \
+				 (ptr)->mtyp == PM_AOA_DROPLET)
+#define is_watery(ptr)	((ptr)->mtyp == PM_WATER_ELEMENTAL \
+				 || (ptr)->mtyp == PM_WATER_DOLPHIN \
+				 || (ptr)->mtyp == PM_FOG_CLOUD \
+				 || (ptr)->mtyp == PM_STEAM_VORTEX \
+				 || (ptr)->mtyp == PM_ANCIENT_TEMPEST \
+				 || (ptr)->mtyp == PM_MORTAI \
+				 || (ptr)->mtyp == PM_HUDOR_KAMEREL \
+				 || (ptr)->mtyp == PM_LETHE_ELEMENTAL \
 				 )
-#define is_uvuudaum(ptr)	(ptr == &mons[PM_UVUUDAUM] || ptr == &mons[PM_MASKED_QUEEN])
-#define is_witch_mon(mon)	((mon)->data == &mons[PM_APPRENTICE_WITCH] || (mon)->data == &mons[PM_WITCH] || (mon)->data == &mons[PM_COVEN_LEADER])
-#define removed_innards(ptr)	(((ptr) == &mons[PM_HUNGRY_DEAD]) || \
-						 ((ptr) == &mons[PM_KOBOLD_MUMMY]) || \
-						 ((ptr) == &mons[PM_GNOME_MUMMY]) || \
-						 ((ptr) == &mons[PM_ORC_MUMMY]) || \
-						 ((ptr) == &mons[PM_DWARF_MUMMY]) || \
-						 ((ptr) == &mons[PM_ELF_MUMMY]) || \
-						 ((ptr) == &mons[PM_HUMAN_MUMMY]) || \
-						 ((ptr) == &mons[PM_HALF_DRAGON_MUMMY]) || \
-						 ((ptr) == &mons[PM_ETTIN_MUMMY]) || \
-						 ((ptr) == &mons[PM_CHIROPTERAN_MUMMY]) || \
-						 ((ptr) == &mons[PM_GIANT_MUMMY]) || \
-						 ((ptr) == &mons[PM_SHAMBLING_HORROR] && u.shambin == 3) || \
-						 ((ptr) == &mons[PM_STUMBLING_HORROR] && u.stumbin == 3) || \
-						 ((ptr) == &mons[PM_WANDERING_HORROR] && u.wandein == 3) || \
-						 ((ptr) == &mons[PM_NITOCRIS]) || \
-						 ((ptr) == &mons[PM_PHARAOH]) \
+#define is_uvuudaum(ptr)	((ptr)->mtyp == PM_UVUUDAUM \
+				 || (ptr)->mtyp == PM_MASKED_QUEEN \
+				 )
+#define is_witch_mon(mon)	((mon)->mtyp == PM_APPRENTICE_WITCH \
+				 || (mon)->mtyp == PM_WITCH \
+				 || (mon)->mtyp == PM_COVEN_LEADER \
+				 )
+#define removed_innards(ptr)	(((ptr)->mtyp == PM_HUNGRY_DEAD) || \
+						 ((ptr)->mtyp == PM_KOBOLD_MUMMY) || \
+						 ((ptr)->mtyp == PM_GNOME_MUMMY) || \
+						 ((ptr)->mtyp == PM_ORC_MUMMY) || \
+						 ((ptr)->mtyp == PM_DWARF_MUMMY) || \
+						 ((ptr)->mtyp == PM_ELF_MUMMY) || \
+						 ((ptr)->mtyp == PM_HUMAN_MUMMY) || \
+						 ((ptr)->mtyp == PM_HALF_DRAGON_MUMMY) || \
+						 ((ptr)->mtyp == PM_ETTIN_MUMMY) || \
+						 ((ptr)->mtyp == PM_CHIROPTERAN_MUMMY) || \
+						 ((ptr)->mtyp == PM_GIANT_MUMMY) || \
+						 ((ptr)->mtyp == PM_SHAMBLING_HORROR && u.shambin == 3) || \
+						 ((ptr)->mtyp == PM_STUMBLING_HORROR && u.stumbin == 3) || \
+						 ((ptr)->mtyp == PM_WANDERING_HORROR && u.wandein == 3) || \
+						 ((ptr)->mtyp == PM_NITOCRIS) || \
+						 ((ptr)->mtyp == PM_PHARAOH) \
 						)
-#define skeleton_innards(ptr)	(((ptr) == &mons[PM_SKELETON]) || \
-						 ((ptr) == &mons[PM_SKELETAL_PIRATE]) \
+#define skeleton_innards(ptr)	(((ptr)->mtyp == PM_SKELETON) || \
+						 ((ptr)->mtyp == PM_SKELETAL_PIRATE) \
 						)
 #define no_innards(ptr)	((ptr)->mlet == S_VORTEX || \
 						 (ptr)->mlet == S_LIGHT || \
 						 (ptr)->mlet == S_ELEMENTAL || \
-						 ((ptr) == &mons[PM_SHAMBLING_HORROR] && u.shambin == 2) || \
-						 ((ptr) == &mons[PM_STUMBLING_HORROR] && u.stumbin == 2) || \
-						 ((ptr) == &mons[PM_WANDERING_HORROR] && u.wandein == 2) || \
+						 ((ptr)->mtyp == PM_SHAMBLING_HORROR && u.shambin == 2) || \
+						 ((ptr)->mtyp == PM_STUMBLING_HORROR && u.stumbin == 2) || \
+						 ((ptr)->mtyp == PM_WANDERING_HORROR && u.wandein == 2) || \
 						 (ptr)->mlet == S_WRAITH || \
 						 (ptr)->mlet == S_GHOST || \
 						 (ptr)->mlet == S_SHADE || \
 						 (ptr)->mlet == S_GOLEM \
 						)
 #define undiffed_innards(ptr)	((ptr)->mlet == S_BLOB || \
-								 (ptr) == &mons[PM_FLOATING_EYE] || \
+								 (ptr)->mtyp == PM_FLOATING_EYE || \
 								 (ptr)->mlet == S_JELLY || \
 								 (ptr)->mlet == S_TRAPPER || \
 								 (ptr)->mlet == S_FUNGUS || \
 								 (ptr)->mlet == S_PUDDING || \
-								 ((ptr) == &mons[PM_DROW_MUMMY]) || \
-								 ((ptr) == &mons[PM_SHAMBLING_HORROR] && u.shambin == 1) || \
-								 ((ptr) == &mons[PM_STUMBLING_HORROR] && u.stumbin == 1) || \
-								 ((ptr) == &mons[PM_WANDERING_HORROR] && u.wandein == 1) || \
+								 ((ptr)->mtyp == PM_DROW_MUMMY) || \
+								 ((ptr)->mtyp == PM_SHAMBLING_HORROR && u.shambin == 1) || \
+								 ((ptr)->mtyp == PM_STUMBLING_HORROR && u.stumbin == 1) || \
+								 ((ptr)->mtyp == PM_WANDERING_HORROR && u.wandein == 1) || \
 								 (ptr)->mlet == S_PLANT \
 								)
 #define is_silent(ptr)		((ptr)->msound == MS_SILENT)
@@ -227,7 +235,7 @@
 #define is_insectoid(ptr)		(((ptr)->mflagsa & MA_INSECTOID) != 0L)
 #define is_arachnid(ptr)		(((ptr)->mflagsa & MA_ARACHNID) != 0L)
 #define is_aquatic(ptr)		(((ptr)->mflagsa & MA_AQUATIC) != 0L)
-#define is_wooden(ptr)		((ptr) == &mons[PM_WOOD_GOLEM] || (ptr) == &mons[PM_LIVING_LECTERN] || is_plant(ptr))
+#define is_wooden(ptr)		((ptr)->mtyp == PM_WOOD_GOLEM || (ptr)->mtyp == PM_LIVING_LECTERN || is_plant(ptr))
 #define thick_skinned(ptr)	(((ptr)->mflagsb & MB_THICK_HIDE) != 0L)
 #define lays_eggs(ptr)		(((ptr)->mflagsb & MB_OVIPAROUS) != 0L)
 #define species_regenerates(ptr)		(((ptr)->mflagsg & MG_REGEN) != 0L)
@@ -238,9 +246,14 @@
 #define is_armed(ptr)		(attacktype(ptr, AT_WEAP) || attacktype(ptr, AT_XWEP) || attacktype(ptr, AT_MARI) || attacktype(ptr, AT_DEVA))
 #define crpsdanger(ptr)		(acidic(ptr) || poisonous(ptr) ||\
 							 freezing(ptr) || burning(ptr))
-#define hideablewidegaze(ptr)	(ptr == &mons[PM_MEDUSA] || ptr == &mons[PM_GREAT_CTHULHU] || ptr == &mons[PM_DAGON] ||\
-									ptr == &mons[PM_PALE_NIGHT] || ptr == &mons[PM_OBOX_OB] || ptr == &mons[PM_UVUUDAUM] ||\
-									ptr == &mons[PM_MASKED_QUEEN])
+#define hideablewidegaze(ptr)	((ptr)->mtyp == PM_MEDUSA || \
+								 (ptr)->mtyp == PM_GREAT_CTHULHU || \
+								 (ptr)->mtyp == PM_DAGON || \
+								 (ptr)->mtyp == PM_PALE_NIGHT || \
+								 (ptr)->mtyp == PM_OBOX_OB || \
+								 (ptr)->mtyp == PM_UVUUDAUM || \
+								 (ptr)->mtyp == PM_MASKED_QUEEN \
+								 )
 #define controlledwidegaze(ptr)		(is_angel(ptr) || is_auton(ptr))
 #define controlledwidegaze_mon(mon)		(mon->mfaction == ILLUMINATED || controlledwidegaze((mon)->data))
 #define acidic(ptr)			(((ptr)->mflagsb & MB_ACID) != 0L)
@@ -254,10 +267,10 @@
 #define metallivorous(ptr)	(((ptr)->mflagst & MT_METALLIVORE) != 0L)
 #define magivorous(ptr)		(((ptr)->mflagst & MT_MAGIVORE) != 0L)
 #define polyok(ptr)			(((ptr)->mflagsg & MG_NOPOLY) == 0L)
-#define is_Rebel(ptr)		(ptr == &mons[PM_REBEL_RINGLEADER] ||\
-							 ptr == &mons[PM_ADVENTURING_WIZARD] ||\
-							 ptr == &mons[PM_MILITANT_CLERIC] ||\
-							 ptr == &mons[PM_HALF_ELF_RANGER])
+#define is_Rebel(ptr)		((ptr)->mtyp == PM_REBEL_RINGLEADER ||\
+							 (ptr)->mtyp == PM_ADVENTURING_WIZARD ||\
+							 (ptr)->mtyp == PM_MILITANT_CLERIC ||\
+							 (ptr)->mtyp == PM_HALF_ELF_RANGER)
 #define is_undead(ptr)		(((ptr)->mflagsa & MA_UNDEAD) != 0L)
 #define is_undead_mon(mon)	(mon && (is_undead((mon)->data) || (mon)->mfaction == VAMPIRIC || (mon)->mfaction == ZOMBIFIED || (mon)->mfaction == SKELIFIED || (mon)->mfaction == CRYSTALFIED || (mon)->mfaction == FRACTURED))
 #define is_derived_undead_mon(mon)	(mon && ((mon)->mfaction == VAMPIRIC || (mon)->mfaction == ZOMBIFIED || (mon)->mfaction == SKELIFIED || (mon)->mfaction == CRYSTALFIED || (mon)->mfaction == FRACTURED))
@@ -268,45 +281,45 @@
 #define is_weldproof_mon(mon)		(is_weldproof((mon)->data) || is_derived_undead_mon(mon))
 #define is_were(ptr)		(((ptr)->mflagsa & MA_WERE) != 0L)
 #define is_heladrin(ptr)		(\
-							 (ptr) == &mons[PM_COURE_ELADRIN] || \
-							 (ptr) == &mons[PM_NOVIERE_ELADRIN] || \
-							 (ptr) == &mons[PM_BRALANI_ELADRIN] || \
-							 (ptr) == &mons[PM_FIRRE_ELADRIN] || \
-							 (ptr) == &mons[PM_SHIERE_ELADRIN] || \
-							 (ptr) == &mons[PM_GHAELE_ELADRIN] || \
-							 (ptr) == &mons[PM_TULANI_ELADRIN] || \
-							 (ptr) == &mons[PM_GAE_ELADRIN] || \
-							 (ptr) == &mons[PM_DRACAE_ELADRIN] || \
-							 (ptr) == &mons[PM_ALRUNES] ||\
-							 (ptr) == &mons[PM_GWYNHARWYF] ||\
-							 (ptr) == &mons[PM_ASCODEL] ||\
-							 (ptr) == &mons[PM_FAERINAAL] ||\
-							 (ptr) == &mons[PM_QUEEN_MAB] ||\
-							 (ptr) == &mons[PM_QUEEN_OF_STARS] ||\
-							 (ptr) == &mons[PM_KETO] \
+							 (ptr)->mtyp == PM_COURE_ELADRIN || \
+							 (ptr)->mtyp == PM_NOVIERE_ELADRIN || \
+							 (ptr)->mtyp == PM_BRALANI_ELADRIN || \
+							 (ptr)->mtyp == PM_FIRRE_ELADRIN || \
+							 (ptr)->mtyp == PM_SHIERE_ELADRIN || \
+							 (ptr)->mtyp == PM_GHAELE_ELADRIN || \
+							 (ptr)->mtyp == PM_TULANI_ELADRIN || \
+							 (ptr)->mtyp == PM_GAE_ELADRIN || \
+							 (ptr)->mtyp == PM_DRACAE_ELADRIN || \
+							 (ptr)->mtyp == PM_ALRUNES ||\
+							 (ptr)->mtyp == PM_GWYNHARWYF ||\
+							 (ptr)->mtyp == PM_ASCODEL ||\
+							 (ptr)->mtyp == PM_FAERINAAL ||\
+							 (ptr)->mtyp == PM_QUEEN_MAB ||\
+							 (ptr)->mtyp == PM_QUEEN_OF_STARS ||\
+							 (ptr)->mtyp == PM_KETO \
 							)
 #define is_eeladrin(ptr)	(\
-							 (ptr) == &mons[PM_MOTE_OF_LIGHT] || \
-							 (ptr) == &mons[PM_WATER_DOLPHIN] || \
-							 (ptr) == &mons[PM_SINGING_SAND] || \
-							 (ptr) == &mons[PM_DANCING_FLAME] || \
-							 (ptr) == &mons[PM_BALL_OF_LIGHT] || \
-							 (ptr) == &mons[PM_LUMINOUS_CLOUD] || \
-							 (ptr) == &mons[PM_BALL_OF_RADIANCE] || \
-							 (ptr) == &mons[PM_WARDEN_TREE] || \
-							 (ptr) == &mons[PM_MOTHERING_MASS] || \
-							 (ptr) == &mons[PM_HATEFUL_WHISPERS] ||\
-							 (ptr) == &mons[PM_FURIOUS_WHIRLWIND] ||\
-							 (ptr) == &mons[PM_BLOODY_SUNSET] ||\
-							 (ptr) == &mons[PM_BALL_OF_GOSSAMER_SUNLIGHT] ||\
-							 (ptr) == &mons[PM_COTERIE_OF_MOTES] ||\
-							 (ptr) == &mons[PM_ETERNAL_LIGHT] ||\
-							 (ptr) == &mons[PM_ANCIENT_TEMPEST] \
+							 (ptr)->mtyp == PM_MOTE_OF_LIGHT || \
+							 (ptr)->mtyp == PM_WATER_DOLPHIN || \
+							 (ptr)->mtyp == PM_SINGING_SAND || \
+							 (ptr)->mtyp == PM_DANCING_FLAME || \
+							 (ptr)->mtyp == PM_BALL_OF_LIGHT || \
+							 (ptr)->mtyp == PM_LUMINOUS_CLOUD || \
+							 (ptr)->mtyp == PM_BALL_OF_RADIANCE || \
+							 (ptr)->mtyp == PM_WARDEN_TREE || \
+							 (ptr)->mtyp == PM_MOTHERING_MASS || \
+							 (ptr)->mtyp == PM_HATEFUL_WHISPERS ||\
+							 (ptr)->mtyp == PM_FURIOUS_WHIRLWIND ||\
+							 (ptr)->mtyp == PM_BLOODY_SUNSET ||\
+							 (ptr)->mtyp == PM_BALL_OF_GOSSAMER_SUNLIGHT ||\
+							 (ptr)->mtyp == PM_COTERIE_OF_MOTES ||\
+							 (ptr)->mtyp == PM_ETERNAL_LIGHT ||\
+							 (ptr)->mtyp == PM_ANCIENT_TEMPEST \
 							)
-#define is_yochlol(ptr)		((ptr) == &mons[PM_YOCHLOL] ||\
-							 (ptr) == &mons[PM_UNEARTHLY_DROW] ||\
-							 (ptr) == &mons[PM_STINKING_CLOUD] ||\
-							 (ptr) == &mons[PM_DEMONIC_BLACK_WIDOW])
+#define is_yochlol(ptr)		((ptr)->mtyp == PM_YOCHLOL ||\
+							 (ptr)->mtyp == PM_UNEARTHLY_DROW ||\
+							 (ptr)->mtyp == PM_STINKING_CLOUD ||\
+							 (ptr)->mtyp == PM_DEMONIC_BLACK_WIDOW)
 #define is_vampire(ptr)		(((ptr)->mflagsa & MA_VAMPIRE) != 0L)
 #define is_half_dragon(ptr)		attacktype_fordmg(ptr, AT_BREA, AD_HDRG)
 #define is_boreal_dragoon(ptr)		(attacktype_fordmg(ptr, AT_WEAP, AD_HDRG) || attacktype_fordmg(ptr, AT_XWEP, AD_HDRG))
@@ -315,66 +328,66 @@
 #define is_dwarf(ptr)		(((ptr)->mflagsa & MA_DWARF) != 0L)
 #define is_gnome(ptr)		(((ptr)->mflagsa & MA_GNOME) != 0L)
 #define is_gizmo(ptr)		((ptr)->mlet == S_GNOME && is_clockwork(ptr))
-#define is_szcultist(ptr)		((ptr) == &mons[PM_SHATTERED_ZIGGURAT_CULTIST] \
-								|| (ptr) == &mons[PM_SHATTERED_ZIGGURAT_KNIGHT] \
-								|| (ptr) == &mons[PM_SHATTERED_ZIGGURAT_WIZARD])
+#define is_szcultist(ptr)		((ptr)->mtyp == PM_SHATTERED_ZIGGURAT_CULTIST \
+								|| (ptr)->mtyp == PM_SHATTERED_ZIGGURAT_KNIGHT \
+								|| (ptr)->mtyp == PM_SHATTERED_ZIGGURAT_WIZARD)
 #define is_orc(ptr)		(((ptr)->mflagsa & MA_ORC) != 0L)
 #define is_ogre(ptr)		((ptr)->mlet == S_OGRE)
 #define is_troll(ptr)		((ptr)->mlet == S_TROLL)
 #define is_kobold(ptr)		((ptr)->mlet == S_KOBOLD)
-#define is_ettin(ptr)		((ptr) == &mons[PM_ETTIN])
+#define is_ettin(ptr)		((ptr)->mtyp == PM_ETTIN)
 #define is_human(ptr)		(((ptr)->mflagsa & MA_HUMAN) != 0L)
 #define is_untamable(ptr)	(((ptr)->mflagsg & MG_NOTAME) != 0L)
 #define is_unwishable(ptr)	((((ptr)->mflagsg & MG_NOWISH) != 0L) || ((((ptr)->mflagsg&MG_FUTURE_WISH) != 0L) && !Role_if(PM_TOURIST)))
 #define is_fungus(ptr)		((ptr)->mlet == S_FUNGUS)
-#define is_migo(ptr)		((ptr) == &mons[PM_MIGO_WORKER] ||\
-							 (ptr) == &mons[PM_MIGO_SOLDIER] ||\
-							 (ptr) == &mons[PM_MIGO_PHILOSOPHER] ||\
-							 (ptr) == &mons[PM_MIGO_QUEEN])
+#define is_migo(ptr)		((ptr)->mtyp == PM_MIGO_WORKER ||\
+							 (ptr)->mtyp == PM_MIGO_SOLDIER ||\
+							 (ptr)->mtyp == PM_MIGO_PHILOSOPHER ||\
+							 (ptr)->mtyp == PM_MIGO_QUEEN)
 #define your_race(ptr)		(((ptr)->mflagsa & urace.selfmask) != 0L)
-#define is_andromaliable(ptr)	(is_elf(ptr) || is_drow(ptr) || is_dwarf(ptr) || is_gnome(ptr) || is_orc(ptr) || is_human(ptr) || (ptr) == &mons[PM_HOBBIT] || \
-								 (ptr) == &mons[PM_MONKEY] || (ptr) == &mons[PM_APE] || (ptr) == &mons[PM_YETI] || \
-								 (ptr) == &mons[PM_CARNIVOROUS_APE] || (ptr) == &mons[PM_SASQUATCH]\
+#define is_andromaliable(ptr)	(is_elf(ptr) || is_drow(ptr) || is_dwarf(ptr) || is_gnome(ptr) || is_orc(ptr) || is_human(ptr) || (ptr)->mtyp == PM_HOBBIT || \
+								 (ptr)->mtyp == PM_MONKEY || (ptr)->mtyp == PM_APE || (ptr)->mtyp == PM_YETI || \
+								 (ptr)->mtyp == PM_CARNIVOROUS_APE || (ptr)->mtyp == PM_SASQUATCH\
 								)
-#define is_bat(ptr)		((ptr) == &mons[PM_BAT] || \
-				 (ptr) == &mons[PM_GIANT_BAT] || \
-				 (ptr) == &mons[PM_BATTLE_BAT] || \
-				 (ptr) == &mons[PM_WARBAT] || \
-				 (ptr) == &mons[PM_VAMPIRE_BAT])
-#define is_metroid(ptr) ((ptr)->mlet == S_TRAPPER && !((ptr) == &mons[PM_TRAPPER] || (ptr) == &mons[PM_LURKER_ABOVE]))
+#define is_bat(ptr)		((ptr)->mtyp == PM_BAT || \
+				 (ptr)->mtyp == PM_GIANT_BAT || \
+				 (ptr)->mtyp == PM_BATTLE_BAT || \
+				 (ptr)->mtyp == PM_WARBAT || \
+				 (ptr)->mtyp == PM_VAMPIRE_BAT)
+#define is_metroid(ptr) ((ptr)->mlet == S_TRAPPER && !((ptr)->mtyp == PM_TRAPPER || (ptr)->mtyp == PM_LURKER_ABOVE))
 #define is_social_insect(ptr) ((ptr)->mlet == S_ANT && (ptr)->maligntyp > 0)
 #define is_spider(ptr)	((ptr)->mlet == S_SPIDER && (\
-				 (ptr) == &mons[PM_CAVE_SPIDER] ||\
-				 (ptr) == &mons[PM_GIANT_SPIDER] ||\
-				 (ptr) == &mons[PM_MIRKWOOD_SPIDER] ||\
-				 (ptr) == &mons[PM_PHASE_SPIDER] ||\
-				 (ptr) == &mons[PM_MIRKWOOD_ELDER] \
+				 (ptr)->mtyp == PM_CAVE_SPIDER ||\
+				 (ptr)->mtyp == PM_GIANT_SPIDER ||\
+				 (ptr)->mtyp == PM_MIRKWOOD_SPIDER ||\
+				 (ptr)->mtyp == PM_PHASE_SPIDER ||\
+				 (ptr)->mtyp == PM_MIRKWOOD_ELDER \
 				 ))
-#define is_rat(ptr)		((ptr) == &mons[PM_SEWER_RAT] || \
-				 (ptr) == &mons[PM_GIANT_RAT] || \
-				 (ptr) == &mons[PM_RABID_RAT] || \
-				 (ptr) == &mons[PM_ENORMOUS_RAT] || \
-				 (ptr) == &mons[PM_RODENT_OF_UNUSUAL_SIZE])
+#define is_rat(ptr)		((ptr)->mtyp == PM_SEWER_RAT || \
+				 (ptr)->mtyp == PM_GIANT_RAT || \
+				 (ptr)->mtyp == PM_RABID_RAT || \
+				 (ptr)->mtyp == PM_ENORMOUS_RAT || \
+				 (ptr)->mtyp == PM_RODENT_OF_UNUSUAL_SIZE)
 #define is_dragon(ptr)		(((ptr)->mflagsa & MA_DRAGON) != 0L)
 #define is_true_dragon(ptr)		((monsndx(ptr) >= PM_BABY_GRAY_DRAGON && monsndx(ptr) <= PM_DEEP_DRAGON) || \
-								(ptr) == &mons[PM_PLATINUM_DRAGON] || (ptr) == &mons[PM_CHROMATIC_DRAGON])
+								(ptr)->mtyp == PM_PLATINUM_DRAGON || (ptr)->mtyp == PM_CHROMATIC_DRAGON)
 #define is_pseudodragon(ptr)	(monsndx(ptr) >= PM_TINY_PSEUDODRAGON && monsndx(ptr) <= PM_GIGANTIC_PSEUDODRAGON)
 #define is_bird(ptr)		(((ptr)->mflagsa & MA_AVIAN) != 0L)
 #define is_giant(ptr)		(((ptr)->mflagsa & MA_GIANT) != 0L)
-#define is_gnoll(ptr)		((ptr) == &mons[PM_GNOLL] || \
-				 (ptr) == &mons[PM_GNOLL_GHOUL] || \
-				 (ptr) == &mons[PM_ANUBITE] || \
-				 (ptr) == &mons[PM_GNOLL_MATRIARCH] || \
-				 (ptr) == &mons[PM_YEENOGHU])
-#define is_minotaur(ptr)		((ptr) == &mons[PM_MINOTAUR] || \
-				 (ptr) == &mons[PM_MINOTAUR_PRIESTESS] || \
-				 (ptr) == &mons[PM_BAPHOMET])
-#define is_pirate(ptr)	((ptr) == &mons[PM_PIRATE] || \
-				 (ptr) == &mons[PM_PIRATE_BROTHER] || \
-				 (ptr) == &mons[PM_SKELETAL_PIRATE] || \
-				 (ptr) == &mons[PM_DAMNED_PIRATE] || \
-				 (ptr) == &mons[PM_GITHYANKI_PIRATE] || \
-				 (ptr) == &mons[PM_MAYOR_CUMMERBUND])
+#define is_gnoll(ptr)		((ptr)->mtyp == PM_GNOLL || \
+				 (ptr)->mtyp == PM_GNOLL_GHOUL || \
+				 (ptr)->mtyp == PM_ANUBITE || \
+				 (ptr)->mtyp == PM_GNOLL_MATRIARCH || \
+				 (ptr)->mtyp == PM_YEENOGHU)
+#define is_minotaur(ptr)		((ptr)->mtyp == PM_MINOTAUR || \
+				 (ptr)->mtyp == PM_MINOTAUR_PRIESTESS || \
+				 (ptr)->mtyp == PM_BAPHOMET)
+#define is_pirate(ptr)	((ptr)->mtyp == PM_PIRATE || \
+				 (ptr)->mtyp == PM_PIRATE_BROTHER || \
+				 (ptr)->mtyp == PM_SKELETAL_PIRATE || \
+				 (ptr)->mtyp == PM_DAMNED_PIRATE || \
+				 (ptr)->mtyp == PM_GITHYANKI_PIRATE || \
+				 (ptr)->mtyp == PM_MAYOR_CUMMERBUND)
 #define is_golem(ptr)		((ptr)->mlet == S_GOLEM)
 #define is_clockwork(ptr)	(((ptr)->mflagsa & MA_CLOCK) != 0L)
 #define is_domestic(ptr)	(((ptr)->mflagst & MT_DOMESTIC) != 0L)
@@ -385,82 +398,82 @@
 #define is_angel(ptr)		((((ptr)->mflagsa & MA_MINION) != 0L) && ((ptr)->mlet == S_LAW_ANGEL || (ptr)->mlet == S_NEU_ANGEL || (ptr)->mlet == S_CHA_ANGEL))
 #define is_eladrin(ptr)		(is_heladrin(ptr) || is_eeladrin(ptr))
 #define is_archon(ptr)		((ptr)->mlet == S_LAW_ANGEL &&\
-							 !((ptr) == &mons[PM_COUATL] ||\
-							   (ptr) == &mons[PM_ALEAX] ||\
-							   (ptr) == &mons[PM_KI_RIN] ||\
-							   (ptr) == &mons[PM_GIANT_EAGLE] ||\
-							   (ptr) == &mons[PM_GOD] ||\
-							   (ptr) == &mons[PM_DAMAGED_ARCADIAN_AVENGER] ||\
-							   (ptr) == &mons[PM_ARCADIAN_AVENGER] ||\
-							   (ptr) == &mons[PM_APOLLYON] ||\
-							   (ptr) == &mons[PM_ANGEL]))
-#define is_auton(ptr)		(	(ptr) == &mons[PM_MONOTON] ||\
-								(ptr) == &mons[PM_DUTON] ||\
-								(ptr) == &mons[PM_TRITON] ||\
-								(ptr) == &mons[PM_QUATON] ||\
-								(ptr) == &mons[PM_QUINON] ||\
-								(ptr) == &mons[PM_AXUS]\
+							 !((ptr)->mtyp == PM_COUATL ||\
+							   (ptr)->mtyp == PM_ALEAX ||\
+							   (ptr)->mtyp == PM_KI_RIN ||\
+							   (ptr)->mtyp == PM_GIANT_EAGLE ||\
+							   (ptr)->mtyp == PM_GOD ||\
+							   (ptr)->mtyp == PM_DAMAGED_ARCADIAN_AVENGER ||\
+							   (ptr)->mtyp == PM_ARCADIAN_AVENGER ||\
+							   (ptr)->mtyp == PM_APOLLYON ||\
+							   (ptr)->mtyp == PM_ANGEL))
+#define is_auton(ptr)		(	(ptr)->mtyp == PM_MONOTON ||\
+								(ptr)->mtyp == PM_DUTON ||\
+								(ptr)->mtyp == PM_TRITON ||\
+								(ptr)->mtyp == PM_QUATON ||\
+								(ptr)->mtyp == PM_QUINON ||\
+								(ptr)->mtyp == PM_AXUS\
 							)
-#define is_kamerel(ptr)		(	(ptr) == &mons[PM_AMM_KAMEREL] ||\
-								(ptr) == &mons[PM_HUDOR_KAMEREL] ||\
-								(ptr) == &mons[PM_SHARAB_KAMEREL] ||\
-								(ptr) == &mons[PM_ARA_KAMEREL]\
+#define is_kamerel(ptr)		(	(ptr)->mtyp == PM_AMM_KAMEREL ||\
+								(ptr)->mtyp == PM_HUDOR_KAMEREL ||\
+								(ptr)->mtyp == PM_SHARAB_KAMEREL ||\
+								(ptr)->mtyp == PM_ARA_KAMEREL\
 							)
-#define is_rilmani(ptr)		(	(ptr) == &mons[PM_PLUMACH_RILMANI] ||\
-								(ptr) == &mons[PM_FERRUMACH_RILMANI] ||\
-								(ptr) == &mons[PM_CUPRILACH_RILMANI] ||\
-								(ptr) == &mons[PM_STANNUMACH_RILMANI] ||\
-								(ptr) == &mons[PM_ARGENACH_RILMANI] ||\
-								(ptr) == &mons[PM_MERCURIAL_ESSENCE] ||\
-								(ptr) == &mons[PM_BRIMSTONE_ESSENCE] ||\
-								(ptr) == &mons[PM_HYDRARGYRUMACH_RILMANI] ||\
-								(ptr) == &mons[PM_CENTER_OF_ALL] ||\
-								(ptr) == &mons[PM_AURUMACH_RILMANI]\
+#define is_rilmani(ptr)		(	(ptr)->mtyp == PM_PLUMACH_RILMANI ||\
+								(ptr)->mtyp == PM_FERRUMACH_RILMANI ||\
+								(ptr)->mtyp == PM_CUPRILACH_RILMANI ||\
+								(ptr)->mtyp == PM_STANNUMACH_RILMANI ||\
+								(ptr)->mtyp == PM_ARGENACH_RILMANI ||\
+								(ptr)->mtyp == PM_MERCURIAL_ESSENCE ||\
+								(ptr)->mtyp == PM_BRIMSTONE_ESSENCE ||\
+								(ptr)->mtyp == PM_HYDRARGYRUMACH_RILMANI ||\
+								(ptr)->mtyp == PM_CENTER_OF_ALL ||\
+								(ptr)->mtyp == PM_AURUMACH_RILMANI\
 							)
 #define is_deva(ptr)		((ptr)->mlet == S_NEU_ANGEL)
-#define is_divider(ptr)		( (ptr) == &mons[PM_BLACK_PUDDING]\
-							  || (ptr) == &mons[PM_BROWN_PUDDING]\
-							  || (ptr) == &mons[PM_DARKNESS_GIVEN_HUNGER]\
-							  || (ptr) == &mons[PM_GREMLIN]\
-							  || (ptr) == &mons[PM_DUNGEON_FERN_SPORE]\
-							  || (ptr) == &mons[PM_DUNGEON_FERN_SPROUT]\
-							  || (ptr) == &mons[PM_BURNING_FERN_SPORE]\
-							  || (ptr) == &mons[PM_BURNING_FERN_SPROUT]\
-							  || (ptr) == &mons[PM_SWAMP_FERN_SPORE]\
-							  || (ptr) == &mons[PM_SWAMP_FERN_SPROUT]\
-							  || (ptr) == &mons[PM_RAZORVINE]\
+#define is_divider(ptr)		( (ptr)->mtyp == PM_BLACK_PUDDING\
+							  || (ptr)->mtyp == PM_BROWN_PUDDING\
+							  || (ptr)->mtyp == PM_DARKNESS_GIVEN_HUNGER\
+							  || (ptr)->mtyp == PM_GREMLIN\
+							  || (ptr)->mtyp == PM_DUNGEON_FERN_SPORE\
+							  || (ptr)->mtyp == PM_DUNGEON_FERN_SPROUT\
+							  || (ptr)->mtyp == PM_BURNING_FERN_SPORE\
+							  || (ptr)->mtyp == PM_BURNING_FERN_SPROUT\
+							  || (ptr)->mtyp == PM_SWAMP_FERN_SPORE\
+							  || (ptr)->mtyp == PM_SWAMP_FERN_SPROUT\
+							  || (ptr)->mtyp == PM_RAZORVINE\
 							)
 #define is_mercenary(ptr)	(((ptr)->mflagsg & MG_MERC) != 0L)
 #define is_army_pm(pm)		(pm == PM_CAPTAIN || pm == PM_LIEUTENANT || pm == PM_SERGEANT || pm == PM_SOLDIER)
-#define is_bardmon(ptr)		((ptr) == &mons[PM_LILLEND] || (ptr) == &mons[PM_RHYMER] || (ptr) == &mons[PM_BARD])
+#define is_bardmon(ptr)		((ptr)->mtyp == PM_LILLEND || (ptr)->mtyp == PM_RHYMER || (ptr)->mtyp == PM_BARD)
 #define is_male(ptr)		(((ptr)->mflagsb & MB_MALE) != 0L)
 #define is_female(ptr)		(((ptr)->mflagsb & MB_FEMALE) != 0L)
 #define is_neuter(ptr)		(((ptr)->mflagsb & MB_NEUTER) != 0L)
 #define is_wanderer(ptr)	(((ptr)->mflagst & MT_WANDER) != 0L)
-#define goat_monster(pm) (\
-									pm == &mons[PM_SMALL_GOAT_SPAWN]\
-									|| pm == &mons[PM_GOAT_SPAWN]\
-									|| pm == &mons[PM_GIANT_GOAT_SPAWN]\
-									|| pm == &mons[PM_PLAINS_CENTAUR]\
-									|| pm == &mons[PM_FOREST_CENTAUR]\
-									|| pm == &mons[PM_MOUNTAIN_CENTAUR]\
-									|| pm == &mons[PM_QUICKLING]\
-									|| pm == &mons[PM_NAIAD]\
-									|| pm == &mons[PM_DRYAD]\
-									|| pm == &mons[PM_OREAD]\
-									|| pm == &mons[PM_YUKI_ONNA]\
-									|| pm == &mons[PM_DEMINYMPH]\
-									|| pm == &mons[PM_WHITE_UNICORN]\
-									|| pm == &mons[PM_GRAY_UNICORN]\
-									|| pm == &mons[PM_BLACK_UNICORN]\
-									|| pm == &mons[PM_NIGHTMARE]\
-									|| pm == &mons[PM_MIGO_WORKER]\
-									|| pm == &mons[PM_MIGO_SOLDIER]\
-									|| pm == &mons[PM_MIGO_PHILOSOPHER]\
-									|| pm == &mons[PM_MIGO_QUEEN]\
-									|| pm == &mons[PM_DARK_YOUNG]\
-									|| pm == &mons[PM_BLESSED]\
-									|| pm == &mons[PM_MOUTH_OF_THE_GOAT]\
+#define goat_monster(ptr) (\
+									   (ptr)->mtyp == PM_SMALL_GOAT_SPAWN \
+									|| (ptr)->mtyp == PM_GOAT_SPAWN \
+									|| (ptr)->mtyp == PM_GIANT_GOAT_SPAWN \
+									|| (ptr)->mtyp == PM_PLAINS_CENTAUR \
+									|| (ptr)->mtyp == PM_FOREST_CENTAUR \
+									|| (ptr)->mtyp == PM_MOUNTAIN_CENTAUR \
+									|| (ptr)->mtyp == PM_QUICKLING \
+									|| (ptr)->mtyp == PM_NAIAD \
+									|| (ptr)->mtyp == PM_DRYAD \
+									|| (ptr)->mtyp == PM_OREAD \
+									|| (ptr)->mtyp == PM_YUKI_ONNA \
+									|| (ptr)->mtyp == PM_DEMINYMPH \
+									|| (ptr)->mtyp == PM_WHITE_UNICORN \
+									|| (ptr)->mtyp == PM_GRAY_UNICORN \
+									|| (ptr)->mtyp == PM_BLACK_UNICORN \
+									|| (ptr)->mtyp == PM_NIGHTMARE \
+									|| (ptr)->mtyp == PM_MIGO_WORKER \
+									|| (ptr)->mtyp == PM_MIGO_SOLDIER \
+									|| (ptr)->mtyp == PM_MIGO_PHILOSOPHER \
+									|| (ptr)->mtyp == PM_MIGO_QUEEN \
+									|| (ptr)->mtyp == PM_DARK_YOUNG \
+									|| (ptr)->mtyp == PM_BLESSED \
+									|| (ptr)->mtyp == PM_MOUTH_OF_THE_GOAT \
 								  )
 #define always_hostile(ptr)	(((ptr)->mflagst & MT_HOSTILE) != 0L)
 #define always_hostile_mon(mon)	(always_hostile((mon)->data) || is_derived_undead_mon(mon))
@@ -513,16 +526,16 @@
 #define likes_objs(ptr)		(((ptr)->mflagst & MT_COLLECT) != 0L || \
 				 is_armed(ptr))
 #define likes_magic(ptr)	(((ptr)->mflagst & MT_MAGIC) != 0L)
-#define webmaker(ptr)		((ptr) == &mons[PM_CAVE_SPIDER] || \
-				 (ptr) == &mons[PM_GIANT_SPIDER] || (ptr) == &mons[PM_PHASE_SPIDER] || \
-				 (ptr) == &mons[PM_MIRKWOOD_SPIDER] || (ptr) == &mons[PM_MIRKWOOD_ELDER] || \
-				 (ptr) == &mons[PM_SPROW] || (ptr) == &mons[PM_DRIDER] || (ptr) == &mons[PM_ALIDER] || \
-				 (ptr) == &mons[PM_EDDERKOP] || \
-				 (ptr) == &mons[PM_AVATAR_OF_LOLTH] || (ptr) == &mons[PM_DROW_MUMMY])
+#define webmaker(ptr)		((ptr)->mtyp == PM_CAVE_SPIDER || \
+				 (ptr)->mtyp == PM_GIANT_SPIDER || (ptr)->mtyp == PM_PHASE_SPIDER || \
+				 (ptr)->mtyp == PM_MIRKWOOD_SPIDER || (ptr)->mtyp == PM_MIRKWOOD_ELDER || \
+				 (ptr)->mtyp == PM_SPROW || (ptr)->mtyp == PM_DRIDER || (ptr)->mtyp == PM_ALIDER || \
+				 (ptr)->mtyp == PM_EDDERKOP || \
+				 (ptr)->mtyp == PM_AVATAR_OF_LOLTH || (ptr)->mtyp == PM_DROW_MUMMY)
 #define is_unicorn(ptr)		((ptr)->mlet == S_UNICORN && likes_gems(ptr))
-#define is_longworm(ptr)	(((ptr) == &mons[PM_BABY_LONG_WORM]) || \
-				 ((ptr) == &mons[PM_LONG_WORM]) || \
-				 ((ptr) == &mons[PM_LONG_WORM_TAIL]))
+#define is_longworm(ptr)	(((ptr)->mtyp == PM_BABY_LONG_WORM) || \
+				 ((ptr)->mtyp == PM_LONG_WORM) || \
+				 ((ptr)->mtyp == PM_LONG_WORM_TAIL))
 #define wants_bell(ptr)	((ptr->mflagst & MT_WANTSBELL))
 #define wants_book(ptr)	((ptr->mflagst & MT_WANTSBOOK))
 #define wants_cand(ptr)	((ptr->mflagst & MT_WANTSCAND))
@@ -551,15 +564,15 @@
 #define can_betray(ptr)		((ptr->mflagst & MT_TRAITOR))
 #define opaque(ptr)	(((ptr)->mflagsg & MG_OPAQUE))
 #define mteleport(ptr)	(((ptr)->mflagsm & MM_TENGTPORT))
-#define is_mplayer(ptr)		(((ptr) >= &mons[PM_ARCHEOLOGIST]) && \
-				 ((ptr) <= &mons[PM_WIZARD]))
+#define is_mplayer(ptr)		(((ptr)->mtyp >= PM_ARCHEOLOGIST) && \
+				 ((ptr)->mtyp <= PM_WIZARD))
 #define is_deadly(ptr)		((ptr)->mflagsg & MG_DEADLY)
 #define is_rider(ptr)		((ptr)->mflagsg & MG_RIDER)
 #define rider_hp(ptr)		((ptr)->mflagsg & MG_RIDER_HP)
-#define is_placeholder(ptr)	((ptr) == &mons[PM_ORC] || \
-				 (ptr) == &mons[PM_GIANT] || \
-				 (ptr) == &mons[PM_ELF] || \
-				 (ptr) == &mons[PM_HUMAN])
+#define is_placeholder(ptr)	((ptr)->mtyp == PM_ORC || \
+				 (ptr)->mtyp == PM_GIANT || \
+				 (ptr)->mtyp == PM_ELF || \
+				 (ptr)->mtyp == PM_HUMAN)
 
 /* return TRUE if the monster tends to revive */
 #define is_reviver(ptr)		(is_rider(ptr) || (ptr)->mlet == S_TROLL || (ptr)->mlet == S_FUNGUS)
@@ -569,110 +582,115 @@
 /* this returns the light's range, or 0 if none; if we add more light emitting
    monsters, we'll likely have to add a new light range field to mons[] */
 #define emits_light(ptr)	(((ptr)->mlet == S_LIGHT || \
-				  (ptr) == &mons[PM_BRIGHT_WALKER] || \
-				  (ptr) == &mons[PM_FLAMING_SPHERE] || \
-				  (ptr) == &mons[PM_SHOCKING_SPHERE] || \
-				  (ptr) == &mons[PM_MOTE_OF_LIGHT] || \
-				  (ptr) == &mons[PM_BALL_OF_LIGHT] || \
-				  (ptr) == &mons[PM_BLOODY_SUNSET] || \
-				  (ptr) == &mons[PM_BALL_OF_GOSSAMER_SUNLIGHT] || \
-				  (ptr) == &mons[PM_LUMINOUS_CLOUD] || \
-				  (ptr) == &mons[PM_HOOLOOVOO] || \
-				  (ptr) == &mons[PM_LIGHTNING_PARAELEMENTAL] || \
-				  (ptr) == &mons[PM_FALLEN_ANGEL] || \
-				  (ptr) == &mons[PM_DARK_WORM] || \
-				  (ptr) == &mons[PM_FIRE_VORTEX]) ? 1 : \
-				 ((ptr) == &mons[PM_FIRE_ELEMENTAL] ||\
-				  (ptr) == &mons[PM_DANCING_FLAME] ||\
-				  (ptr) == &mons[PM_COTERIE_OF_MOTES] ||\
-				  (ptr) == &mons[PM_BALL_OF_RADIANCE]) ? 2 : \
-				 ((ptr) == &mons[PM_THRONE_ARCHON] ||\
-				 (ptr) == &mons[PM_ASPECT_OF_THE_SILENCE]) ? 3 : \
-				 ((ptr) == &mons[PM_BLESSED]) ? 4 : \
-				 ((ptr) == &mons[PM_LIGHT_ARCHON]|| \
-				  (ptr) == &mons[PM_GOD] ||\
-				  (ptr) == &mons[PM_LUCIFER]) ? 7 : \
-				 ((ptr) == &mons[PM_EDDERKOP]) ? 8 : \
-				 ((ptr) == &mons[PM_SURYA_DEVA]) ? 9 : \
+				  (ptr)->mtyp == PM_BRIGHT_WALKER || \
+				  (ptr)->mtyp == PM_FLAMING_SPHERE || \
+				  (ptr)->mtyp == PM_SHOCKING_SPHERE || \
+				  (ptr)->mtyp == PM_MOTE_OF_LIGHT || \
+				  (ptr)->mtyp == PM_BALL_OF_LIGHT || \
+				  (ptr)->mtyp == PM_BLOODY_SUNSET || \
+				  (ptr)->mtyp == PM_BALL_OF_GOSSAMER_SUNLIGHT || \
+				  (ptr)->mtyp == PM_LUMINOUS_CLOUD || \
+				  (ptr)->mtyp == PM_HOOLOOVOO || \
+				  (ptr)->mtyp == PM_LIGHTNING_PARAELEMENTAL || \
+				  (ptr)->mtyp == PM_FALLEN_ANGEL || \
+				  (ptr)->mtyp == PM_DARK_WORM || \
+				  (ptr)->mtyp == PM_FIRE_VORTEX) ? 1 : \
+				 ((ptr)->mtyp == PM_FIRE_ELEMENTAL ||\
+				  (ptr)->mtyp == PM_DANCING_FLAME ||\
+				  (ptr)->mtyp == PM_COTERIE_OF_MOTES ||\
+				  (ptr)->mtyp == PM_BALL_OF_RADIANCE) ? 2 : \
+				 ((ptr)->mtyp == PM_THRONE_ARCHON ||\
+				 (ptr)->mtyp == PM_ASPECT_OF_THE_SILENCE) ? 3 : \
+				 ((ptr)->mtyp == PM_BLESSED) ? 4 : \
+				 ((ptr)->mtyp == PM_LIGHT_ARCHON|| \
+				  (ptr)->mtyp == PM_GOD ||\
+				  (ptr)->mtyp == PM_LUCIFER) ? 7 : \
+				 ((ptr)->mtyp == PM_EDDERKOP) ? 8 : \
+				 ((ptr)->mtyp == PM_SURYA_DEVA) ? 9 : \
 				 0)
 #define emits_light_mon(mon) (mon->mfaction == ILLUMINATED ? \
 							 max(3, emits_light((mon)->data)) : \
 							 emits_light((mon)->data))
-#define Is_darklight_monster(ptr)	((ptr) == &mons[PM_EDDERKOP]\
-					|| (ptr) == &mons[PM_DARK_WORM]\
-					|| (ptr) == &mons[PM_ASPECT_OF_THE_SILENCE]\
+#define Is_darklight_monster(ptr)	((ptr)->mtyp == PM_EDDERKOP\
+					|| (ptr)->mtyp == PM_DARK_WORM\
+					|| (ptr)->mtyp == PM_ASPECT_OF_THE_SILENCE\
 					)
 /*	[note: the light ranges above were reduced to 1 for performance...] */
-#define likes_lava(ptr)		(ptr == &mons[PM_FIRE_ELEMENTAL] || \
-				 ptr == &mons[PM_SALAMANDER])
-#define pm_invisible(ptr) ((ptr) == &mons[PM_STALKER] || \
-			   (ptr) == &mons[PM_BLACK_LIGHT] ||\
-			   (ptr) == &mons[PM_PHANTOM_FUNGUS] ||\
-			   (ptr) == &mons[PM_CENTER_OF_ALL] ||\
-			   (ptr) == &mons[PM_DARKNESS_GIVEN_HUNGER] ||\
-			   (ptr) == &mons[PM_ANCIENT_OF_DEATH]\
-			   )
+#define likes_lava(ptr)		( \
+			(ptr)->mtyp == PM_FIRE_ELEMENTAL || \
+			(ptr)->mtyp == PM_SALAMANDER \
+			)
+
+#define pm_invisible(ptr) ( \
+			(ptr)->mtyp == PM_STALKER || \
+			(ptr)->mtyp == PM_BLACK_LIGHT ||\
+			(ptr)->mtyp == PM_PHANTOM_FUNGUS ||\
+			(ptr)->mtyp == PM_CENTER_OF_ALL ||\
+			(ptr)->mtyp == PM_DARKNESS_GIVEN_HUNGER ||\
+			(ptr)->mtyp == PM_ANCIENT_OF_DEATH\
+			)
 
 /* could probably add more */
-#define likes_fire(ptr)		((ptr) == &mons[PM_FIRE_VORTEX] || \
-				  (ptr) == &mons[PM_FLAMING_SPHERE] || \
-				 likes_lava(ptr))
+#define likes_fire(ptr)		( \
+			(ptr)->mtyp == PM_FIRE_VORTEX || \
+			(ptr)->mtyp == PM_FLAMING_SPHERE || \
+			likes_lava(ptr))
 
-#define touch_petrifies(ptr)	((ptr) == &mons[PM_COCKATRICE] || \
-				 (ptr) == &mons[PM_CHICKATRICE])
+#define touch_petrifies(ptr)	((ptr)->mtyp == PM_COCKATRICE || \
+				 (ptr)->mtyp == PM_CHICKATRICE)
 
-#define is_weeping(ptr)		((ptr) == &mons[PM_WEEPING_ANGEL])
+#define is_weeping(ptr)		((ptr)->mtyp == PM_WEEPING_ANGEL)
 
 #define is_alienist(ptr)		(is_mind_flayer(ptr) || \
 								 (ptr)->mlet == S_UMBER ||\
-								 (ptr) == &mons[PM_DROW_ALIENIST] ||\
-								 (ptr) == &mons[PM_DARUTH_XAXOX] ||\
-								 (ptr) == &mons[PM_EMBRACED_DROWESS]\
+								 (ptr)->mtyp == PM_DROW_ALIENIST ||\
+								 (ptr)->mtyp == PM_DARUTH_XAXOX ||\
+								 (ptr)->mtyp == PM_EMBRACED_DROWESS\
 								)
 #define has_mind_blast(ptr)	(is_mind_flayer(ptr) || \
-				 (ptr) == &mons[PM_BRAIN_GOLEM] || \
-				 (ptr) == &mons[PM_SEMBLANCE] \
+				 (ptr)->mtyp == PM_BRAIN_GOLEM || \
+				 (ptr)->mtyp == PM_SEMBLANCE \
 				)
 
-#define is_mind_flayer(ptr)	((ptr) == &mons[PM_MIND_FLAYER] || \
-				 (ptr) == &mons[PM_MASTER_MIND_FLAYER] || \
-				 (ptr) == &mons[PM_STAR_SPAWN] || \
-				 (ptr) == &mons[PM_PARASITIZED_ANDROID] || \
-				 (ptr) == &mons[PM_PARASITIZED_GYNOID] || \
-				 (ptr) == &mons[PM_PARASITIC_MIND_FLAYER] || \
-				 (ptr) == &mons[PM_PARASITIC_MASTER_MIND_FLAYER] || \
-				 (ptr) == &mons[PM_ALHOON] || \
-				 (ptr) == &mons[PM_ELDER_BRAIN] || \
-				 (ptr) == &mons[PM_LUGRIBOSSK] || \
-				 (ptr) == &mons[PM_MAANZECORIAN] || \
-				 (ptr) == &mons[PM_GREAT_CTHULHU] \
+#define is_mind_flayer(ptr)	((ptr)->mtyp == PM_MIND_FLAYER || \
+				 (ptr)->mtyp == PM_MASTER_MIND_FLAYER || \
+				 (ptr)->mtyp == PM_STAR_SPAWN || \
+				 (ptr)->mtyp == PM_PARASITIZED_ANDROID || \
+				 (ptr)->mtyp == PM_PARASITIZED_GYNOID || \
+				 (ptr)->mtyp == PM_PARASITIC_MIND_FLAYER || \
+				 (ptr)->mtyp == PM_PARASITIC_MASTER_MIND_FLAYER || \
+				 (ptr)->mtyp == PM_ALHOON || \
+				 (ptr)->mtyp == PM_ELDER_BRAIN || \
+				 (ptr)->mtyp == PM_LUGRIBOSSK || \
+				 (ptr)->mtyp == PM_MAANZECORIAN || \
+				 (ptr)->mtyp == PM_GREAT_CTHULHU \
 				)
 
-#define is_android(ptr)	((ptr) == &mons[PM_ANDROID] || \
-				 (ptr) == &mons[PM_GYNOID] || \
-				 (ptr) == &mons[PM_OPERATOR] || \
-				 (ptr) == &mons[PM_COMMANDER] || \
-				 (ptr) == &mons[PM_MUMMIFIED_ANDROID] || \
-				 (ptr) == &mons[PM_MUMMIFIED_GYNOID] || \
-				 (ptr) == &mons[PM_FLAYED_ANDROID] || \
-				 (ptr) == &mons[PM_FLAYED_GYNOID] || \
-				 (ptr) == &mons[PM_CRUCIFIED_ANDROID] || \
-				 (ptr) == &mons[PM_CRUCIFIED_GYNOID] || \
-				 (ptr) == &mons[PM_PARASITIZED_ANDROID] || \
-				 (ptr) == &mons[PM_PARASITIZED_GYNOID] || \
-				 (ptr) == &mons[PM_PARASITIZED_OPERATOR] || \
-				 (ptr) == &mons[PM_PARASITIZED_COMMANDER] \
+#define is_android(ptr)	((ptr)->mtyp == PM_ANDROID || \
+				 (ptr)->mtyp == PM_GYNOID || \
+				 (ptr)->mtyp == PM_OPERATOR || \
+				 (ptr)->mtyp == PM_COMMANDER || \
+				 (ptr)->mtyp == PM_MUMMIFIED_ANDROID || \
+				 (ptr)->mtyp == PM_MUMMIFIED_GYNOID || \
+				 (ptr)->mtyp == PM_FLAYED_ANDROID || \
+				 (ptr)->mtyp == PM_FLAYED_GYNOID || \
+				 (ptr)->mtyp == PM_CRUCIFIED_ANDROID || \
+				 (ptr)->mtyp == PM_CRUCIFIED_GYNOID || \
+				 (ptr)->mtyp == PM_PARASITIZED_ANDROID || \
+				 (ptr)->mtyp == PM_PARASITIZED_GYNOID || \
+				 (ptr)->mtyp == PM_PARASITIZED_OPERATOR || \
+				 (ptr)->mtyp == PM_PARASITIZED_COMMANDER \
 				)
 
-#define is_dollable(ptr)	((ptr) == &mons[PM_ANDROID] || \
-				 (ptr) == &mons[PM_GYNOID] || \
-				 (ptr) == &mons[PM_OPERATOR] || \
-				 (ptr) == &mons[PM_COMMANDER] || \
-				 (ptr) == &mons[PM_LIVING_DOLL] \
+#define is_dollable(ptr)	((ptr)->mtyp == PM_ANDROID || \
+				 (ptr)->mtyp == PM_GYNOID || \
+				 (ptr)->mtyp == PM_OPERATOR || \
+				 (ptr)->mtyp == PM_COMMANDER || \
+				 (ptr)->mtyp == PM_LIVING_DOLL \
 				)
 
 #define nonliving(ptr)	(is_unalive(ptr) || is_undead(ptr) || \
-				 (ptr) == &mons[PM_MANES] \
+				 (ptr)->mtyp == PM_MANES \
 				)
 
 #define nonliving_mon(mon)	(mon && (nonliving((mon)->data) || is_undead_mon(mon)))
@@ -681,72 +699,72 @@
 
 #define is_naturally_unalive(ptr)		(((ptr)->mflagsa & MA_UNLIVING))
 
-#define is_indigestible(ptr)	((ptr) == &mons[PM_DANCING_BLADE] ||\
-								 (ptr) == &mons[PM_EARTH_ELEMENTAL] ||\
-								 (ptr) == &mons[PM_TERRACOTTA_SOLDIER] ||\
-								 (ptr) == &mons[PM_CLOCKWORK_SOLDIER] ||\
-								 (ptr) == &mons[PM_CLOCKWORK_DWARF] ||\
-								 (ptr) == &mons[PM_CLOCKWORK_FACTORY] ||\
-								 (ptr) == &mons[PM_GOLDEN_HEART] ||\
-								 (ptr) == &mons[PM_JUGGERNAUT] ||\
-								 (ptr) == &mons[PM_ID_JUGGERNAUT] ||\
-								 (ptr) == &mons[PM_SCRAP_TITAN] ||\
-								 (ptr) == &mons[PM_HELLFIRE_COLOSSUS] ||\
-								 (ptr) == &mons[PM_HELLFIRE_ORB] ||\
-								 (ptr) == &mons[PM_CLOCKWORK_AUTOMATON] ||\
-								 (ptr) == &mons[PM_COLOSSAL_CLOCKWORK_WAR_MACHINE] ||\
-								 (ptr) == &mons[PM_MALKUTH_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_YESOD_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_DAAT_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_HOD_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_NETZACH_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_GEVURAH_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_BINAH_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_CHOKHMAH_SEPHIRAH] ||\
-								 (ptr) == &mons[PM_HALF_STONE_DRAGON] ||\
-								 (ptr) == &mons[PM_HOOLOOVOO] ||\
-								 (ptr) == &mons[PM_GOLD_GOLEM] ||\
-								 (ptr) == &mons[PM_CLAY_GOLEM] ||\
-								 (ptr) == &mons[PM_TREASURY_GOLEM] ||\
-								 (ptr) == &mons[PM_SEMBLANCE] ||\
-								 (ptr) == &mons[PM_STONE_GOLEM] ||\
-								 (ptr) == &mons[PM_GLASS_GOLEM] ||\
-								 (ptr) == &mons[PM_IRON_GOLEM] ||\
-								 (ptr) == &mons[PM_ARGENTUM_GOLEM] ||\
-								 (ptr) == &mons[PM_RETRIEVER] ||\
-								 (ptr) == &mons[PM_LIVING_DOLL] ||\
-								 (ptr) == &mons[PM_ARA_KAMEREL] ||\
-								 (ptr) == &mons[PM_ANCIENT_OF_DEATH] ||\
-								 (ptr) == &mons[PM_PALE_NIGHT] ||\
-								 (ptr) == &mons[PM_BAALPHEGOR] ||\
-								 (ptr) == &mons[PM_ARCADIAN_AVENGER] ||\
-								 (ptr) == &mons[PM_DAMAGED_ARCADIAN_AVENGER] ||\
-								 (ptr) == &mons[PM_MUMMIFIED_ANDROID] ||\
-								 (ptr) == &mons[PM_MUMMIFIED_GYNOID] ||\
-								 (ptr) == &mons[PM_FLAYED_ANDROID] ||\
-								 (ptr) == &mons[PM_FLAYED_GYNOID] ||\
-								 (ptr) == &mons[PM_CRUCIFIED_ANDROID] ||\
-								 (ptr) == &mons[PM_CRUCIFIED_GYNOID] ||\
-								 (ptr) == &mons[PM_ANDROID] ||\
-								 (ptr) == &mons[PM_GYNOID] ||\
-								 (ptr) == &mons[PM_OPERATOR] ||\
-								 (ptr) == &mons[PM_COMMANDER] ||\
-								 (ptr) == &mons[PM_SENTINEL_OF_MITHARDIR] ||\
-								 (ptr) == &mons[PM_CHAIN_GOLEM] ||\
+#define is_indigestible(ptr)	((ptr)->mtyp == PM_DANCING_BLADE ||\
+								 (ptr)->mtyp == PM_EARTH_ELEMENTAL ||\
+								 (ptr)->mtyp == PM_TERRACOTTA_SOLDIER ||\
+								 (ptr)->mtyp == PM_CLOCKWORK_SOLDIER ||\
+								 (ptr)->mtyp == PM_CLOCKWORK_DWARF ||\
+								 (ptr)->mtyp == PM_CLOCKWORK_FACTORY ||\
+								 (ptr)->mtyp == PM_GOLDEN_HEART ||\
+								 (ptr)->mtyp == PM_JUGGERNAUT ||\
+								 (ptr)->mtyp == PM_ID_JUGGERNAUT ||\
+								 (ptr)->mtyp == PM_SCRAP_TITAN ||\
+								 (ptr)->mtyp == PM_HELLFIRE_COLOSSUS ||\
+								 (ptr)->mtyp == PM_HELLFIRE_ORB ||\
+								 (ptr)->mtyp == PM_CLOCKWORK_AUTOMATON ||\
+								 (ptr)->mtyp == PM_COLOSSAL_CLOCKWORK_WAR_MACHINE ||\
+								 (ptr)->mtyp == PM_MALKUTH_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_YESOD_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_DAAT_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_HOD_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_NETZACH_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_GEVURAH_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_BINAH_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_CHOKHMAH_SEPHIRAH ||\
+								 (ptr)->mtyp == PM_HALF_STONE_DRAGON ||\
+								 (ptr)->mtyp == PM_HOOLOOVOO ||\
+								 (ptr)->mtyp == PM_GOLD_GOLEM ||\
+								 (ptr)->mtyp == PM_CLAY_GOLEM ||\
+								 (ptr)->mtyp == PM_TREASURY_GOLEM ||\
+								 (ptr)->mtyp == PM_SEMBLANCE ||\
+								 (ptr)->mtyp == PM_STONE_GOLEM ||\
+								 (ptr)->mtyp == PM_GLASS_GOLEM ||\
+								 (ptr)->mtyp == PM_IRON_GOLEM ||\
+								 (ptr)->mtyp == PM_ARGENTUM_GOLEM ||\
+								 (ptr)->mtyp == PM_RETRIEVER ||\
+								 (ptr)->mtyp == PM_LIVING_DOLL ||\
+								 (ptr)->mtyp == PM_ARA_KAMEREL ||\
+								 (ptr)->mtyp == PM_ANCIENT_OF_DEATH ||\
+								 (ptr)->mtyp == PM_PALE_NIGHT ||\
+								 (ptr)->mtyp == PM_BAALPHEGOR ||\
+								 (ptr)->mtyp == PM_ARCADIAN_AVENGER ||\
+								 (ptr)->mtyp == PM_DAMAGED_ARCADIAN_AVENGER ||\
+								 (ptr)->mtyp == PM_MUMMIFIED_ANDROID ||\
+								 (ptr)->mtyp == PM_MUMMIFIED_GYNOID ||\
+								 (ptr)->mtyp == PM_FLAYED_ANDROID ||\
+								 (ptr)->mtyp == PM_FLAYED_GYNOID ||\
+								 (ptr)->mtyp == PM_CRUCIFIED_ANDROID ||\
+								 (ptr)->mtyp == PM_CRUCIFIED_GYNOID ||\
+								 (ptr)->mtyp == PM_ANDROID ||\
+								 (ptr)->mtyp == PM_GYNOID ||\
+								 (ptr)->mtyp == PM_OPERATOR ||\
+								 (ptr)->mtyp == PM_COMMANDER ||\
+								 (ptr)->mtyp == PM_SENTINEL_OF_MITHARDIR ||\
+								 (ptr)->mtyp == PM_CHAIN_GOLEM ||\
 								 is_uvuudaum(ptr) ||\
 								 is_rilmani(ptr))
 
-#define is_delouseable(ptr) ((ptr) == &mons[PM_PARASITIZED_DOLL] ||\
-								   (ptr) == &mons[PM_PARASITIZED_ANDROID] ||\
-								   (ptr) == &mons[PM_PARASITIZED_GYNOID] ||\
-								   (ptr) == &mons[PM_PARASITIZED_OPERATOR] ||\
-								   (ptr) == &mons[PM_PARASITIZED_COMMANDER])
+#define is_delouseable(ptr) ((ptr)->mtyp == PM_PARASITIZED_DOLL ||\
+								   (ptr)->mtyp == PM_PARASITIZED_ANDROID ||\
+								   (ptr)->mtyp == PM_PARASITIZED_GYNOID ||\
+								   (ptr)->mtyp == PM_PARASITIZED_OPERATOR ||\
+								   (ptr)->mtyp == PM_PARASITIZED_COMMANDER)
 
 #define is_elemental(ptr)		( (ptr->mflagsa & MA_ELEMENTAL) )
 
 #define likes_swamp(ptr)	((ptr)->mlet == S_PUDDING || \
 				 (ptr)->mlet == S_FUNGUS || \
-				 (ptr) == &mons[PM_OCHRE_JELLY])
+				 (ptr)->mtyp == PM_OCHRE_JELLY)
 #define stationary(ptr)		((ptr)->mflagsm & MM_STATIONARY)
 #define sessile(ptr)		((ptr)->mmove == 0)
 
@@ -754,7 +772,7 @@
 /* G_NOCORPSE monsters might still be swallowed as a purple worm */
 /* Maybe someday this could be in mflags... */
 #define vegan(ptr)		(((ptr)->mlet == S_BLOB && \
-							(ptr) != &mons[PM_BLOB_OF_PRESERVED_ORGANS]) || \
+							(ptr)->mtyp != PM_BLOB_OF_PRESERVED_ORGANS) || \
 				 (ptr)->mlet == S_JELLY ||            \
 				((ptr)->mlet == S_FUNGUS && 		  \
 					!is_migo(ptr)) ||				  \
@@ -765,45 +783,45 @@
 				 (is_clockwork(ptr) &&                \
 					is_naturally_unalive(ptr)) ||     \
 				((ptr)->mlet == S_ELEMENTAL &&        \
-				 (ptr) != &mons[PM_STALKER]) ||       \
+				 (ptr)->mtyp != PM_STALKER) ||       \
 				((ptr)->mlet == S_GOLEM &&            \
-				 (ptr) != &mons[PM_FLESH_GOLEM] &&    \
-				 (ptr) != &mons[PM_LEATHER_GOLEM]) || \
-				 (ptr) == &mons[PM_WOOD_TROLL] ||     \
+				 (ptr)->mtyp != PM_FLESH_GOLEM &&    \
+				 (ptr)->mtyp != PM_LEATHER_GOLEM) || \
+				 (ptr)->mtyp == PM_WOOD_TROLL ||     \
 				 noncorporeal(ptr))
 #define is_burnable(ptr)	((ptr)->mlet == S_PLANT || \
 							((ptr)->mlet == S_FUNGUS && !is_migo(ptr)) || \
-							(ptr) == &mons[PM_WOOD_TROLL])
+							(ptr)->mtyp == PM_WOOD_TROLL)
 #define vegetarian(ptr)		(vegan(ptr) || \
 				((ptr)->mlet == S_PUDDING &&         \
-				 (ptr) != &mons[PM_BLACK_PUDDING] && \
-				 (ptr) != &mons[PM_DARKNESS_GIVEN_HUNGER]))
+				 (ptr)->mtyp != PM_BLACK_PUDDING && \
+				 (ptr)->mtyp != PM_DARKNESS_GIVEN_HUNGER))
 
 /* For vampires */
 #define has_blood(ptr)		(!vegetarian(ptr) && \
 				   (ptr)->mlet != S_GOLEM && \
 				   (ptr)->mlet != S_KETER && \
 				   (ptr)->mlet != S_MIMIC && \
-				   (ptr) != &mons[PM_WEEPING_ANGEL] && \
-				   (ptr) != &mons[PM_GREAT_CTHULHU] && \
+				   (ptr)->mtyp != PM_WEEPING_ANGEL && \
+				   (ptr)->mtyp != PM_GREAT_CTHULHU && \
 				   !is_clockwork(ptr) && \
 				   (!nonliving(ptr) || is_vampire(ptr)))
 #define has_blood_mon(mon)	(has_blood((mon)->data) && !is_derived_undead_mon(mon))
 
 /* Keep track of ferns, fern sprouts, fern spores, and other plants */
 
-#define is_fern_sprout(ptr)	((ptr) == &mons[PM_DUNGEON_FERN_SPROUT] || \
-				 (ptr) == &mons[PM_SWAMP_FERN_SPROUT] || \
-				 (ptr) == &mons[PM_BURNING_FERN_SPROUT])
+#define is_fern_sprout(ptr)	((ptr)->mtyp == PM_DUNGEON_FERN_SPROUT || \
+				 (ptr)->mtyp == PM_SWAMP_FERN_SPROUT || \
+				 (ptr)->mtyp == PM_BURNING_FERN_SPROUT)
 
-#define is_fern_spore(ptr)	((ptr) == &mons[PM_DUNGEON_FERN_SPORE] || \
-				 (ptr) == &mons[PM_SWAMP_FERN_SPORE] || \
-				 (ptr) == &mons[PM_BURNING_FERN_SPORE])
+#define is_fern_spore(ptr)	((ptr)->mtyp == PM_DUNGEON_FERN_SPORE || \
+				 (ptr)->mtyp == PM_SWAMP_FERN_SPORE || \
+				 (ptr)->mtyp == PM_BURNING_FERN_SPORE)
 
 #define is_fern(ptr)		(is_fern_sprout(ptr) || \
-				 (ptr) == &mons[PM_DUNGEON_FERN] || \
-				 (ptr) == &mons[PM_SWAMP_FERN] || \
-				 (ptr) == &mons[PM_BURNING_FERN])
+				 (ptr)->mtyp == PM_DUNGEON_FERN || \
+				 (ptr)->mtyp == PM_SWAMP_FERN || \
+				 (ptr)->mtyp == PM_BURNING_FERN)
 
 #define is_vegetation(ptr)	((ptr)->mlet == S_PLANT || is_fern(ptr))
 

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -106,7 +106,7 @@
 #define nofeet(ptr)			((ptr)->mflagsb & MB_NOFEET)
 #define notake(ptr)		(((ptr)->mflagst & MT_NOTAKE) != 0L)
 #define has_head(ptr)		(((ptr)->mflagsb & MB_NOHEAD) == 0L)
-#define has_head_mon(mon) ((mon)->mfaction == MISTWEAVER || has_head((mon)->data))
+#define has_head_mon(mon) (has_head((mon)->data))
 #define has_horns(ptr)		(num_horns(ptr) > 0)
 #define is_whirly(ptr)		((ptr)->mlet == S_VORTEX || \
 				 (ptr)->mtyp == PM_AIR_ELEMENTAL ||\
@@ -212,10 +212,10 @@
 								 (ptr)->mlet == S_PLANT \
 								)
 #define is_silent(ptr)		((ptr)->msound == MS_SILENT)
-#define is_silent_mon(mon)	(is_silent((mon)->data) || (mon)->mfaction == ZOMBIFIED || (mon)->mfaction == CRYSTALFIED)
+#define is_silent_mon(mon)	(is_silent((mon)->data))
 #define unsolid(ptr)		(((ptr)->mflagsb & MB_UNSOLID) != 0L)
 #define mindless(ptr)		(((ptr)->mflagst & MT_MINDLESS) != 0L || on_level(&valley_level, &u.uz))
-#define mindless_mon(mon)		(mon && (((mon)->mfaction == ZOMBIFIED) || ((mon)->mfaction == SKELIFIED) || ((mon)->mfaction == CRYSTALFIED) || mindless((mon)->data)))
+#define mindless_mon(mon)		(mon && mindless((mon)->data))
 
 #define slithy(ptr)			((ptr)->mflagsb & MB_SLITHY)
 #define humanoid_torso(ptr)	(((ptr)->mflagsb & MB_HUMANOID) != 0)
@@ -255,7 +255,7 @@
 								 (ptr)->mtyp == PM_MASKED_QUEEN \
 								 )
 #define controlledwidegaze(ptr)		(is_angel(ptr) || is_auton(ptr))
-#define controlledwidegaze_mon(mon)		(mon->mfaction == ILLUMINATED || controlledwidegaze((mon)->data))
+#define controlledwidegaze_mon(mon)		(controlledwidegaze((mon)->data))
 #define acidic(ptr)			(((ptr)->mflagsb & MB_ACID) != 0L)
 #define poisonous(ptr)		(((ptr)->mflagsb & MB_POIS) != 0L)
 #define freezing(ptr)		(((ptr)->mflagsb & MB_CHILL) != 0L)
@@ -272,13 +272,13 @@
 							 (ptr)->mtyp == PM_MILITANT_CLERIC ||\
 							 (ptr)->mtyp == PM_HALF_ELF_RANGER)
 #define is_undead(ptr)		(((ptr)->mflagsa & MA_UNDEAD) != 0L)
-#define is_undead_mon(mon)	(mon && (is_undead((mon)->data) || (mon)->mfaction == VAMPIRIC || (mon)->mfaction == ZOMBIFIED || (mon)->mfaction == SKELIFIED || (mon)->mfaction == CRYSTALFIED || (mon)->mfaction == FRACTURED))
+#define is_undead_mon(mon)	(mon && is_undead((mon)->data))
 #define is_derived_undead_mon(mon)	(mon && ((mon)->mfaction == VAMPIRIC || (mon)->mfaction == ZOMBIFIED || (mon)->mfaction == SKELIFIED || (mon)->mfaction == CRYSTALFIED || (mon)->mfaction == FRACTURED))
 #define	can_undead_mon(mon)	(mon && !nonliving_mon(mon) && !is_minion((mon)->data) && ((mon)->data->mlet != S_PUDDING) &&\
 								((mon)->data->mlet != S_JELLY) && ((mon)->data->mlet != S_BLOB) && !is_elemental((mon)->data) &&\
 								!is_plant((mon)->data) && !is_demon((mon)->data) && !is_primordial((mon)->data) && !(mvitals[monsndx((mon)->data)].mvflags&G_NOCORPSE))
 #define is_weldproof(ptr)		(is_undead(ptr) || is_demon(ptr) || is_were(ptr))
-#define is_weldproof_mon(mon)		(is_weldproof((mon)->data) || is_derived_undead_mon(mon))
+#define is_weldproof_mon(mon)		(is_weldproof((mon)->data))
 #define is_were(ptr)		(((ptr)->mflagsa & MA_WERE) != 0L)
 #define is_heladrin(ptr)		(\
 							 (ptr)->mtyp == PM_COURE_ELADRIN || \
@@ -476,7 +476,7 @@
 									|| (ptr)->mtyp == PM_MOUTH_OF_THE_GOAT \
 								  )
 #define always_hostile(ptr)	(((ptr)->mflagst & MT_HOSTILE) != 0L)
-#define always_hostile_mon(mon)	(always_hostile((mon)->data) || is_derived_undead_mon(mon))
+#define always_hostile_mon(mon)	(always_hostile((mon)->data))
 #define always_peaceful(ptr)	(((ptr)->mflagst & MT_PEACEFUL) != 0L)
 #define race_hostile(ptr)	(((ptr)->mflagsa & urace.hatemask) != 0L)
 #define race_peaceful(ptr)	(((ptr)->mflagsa & urace.lovemask) != 0L)
@@ -501,10 +501,10 @@
 #define helm_match(ptr,obj)	(((ptr->mflagsb&MB_HEADMODIMASK) == (obj->bodytypeflag&MB_HEADMODIMASK)))
 /*Note: No-modifier helms are "normal"*/
 
-#define hates_holy_mon(mon)	((is_demon((mon)->data) || is_undead_mon(mon) || (((mon)->data->mflagsg&MG_HATESHOLY) != 0)) && (mon)->mfaction != ILLUMINATED)
+#define hates_holy_mon(mon)	(is_demon((mon)->data) || is_undead_mon(mon) || (((mon)->data->mflagsg&MG_HATESHOLY) != 0))
 #define hates_holy(ptr)		(is_demon(ptr) || is_undead(ptr) || (((ptr)->mflagsg&MG_HATESHOLY) != 0))
 #define hates_unholy(ptr)	((ptr->mflagsg&MG_HATESUNHOLY) != 0)
-#define hates_unholy_mon(mon)	((mon)->mfaction == ILLUMINATED || hates_unholy((mon)->data))
+#define hates_unholy_mon(mon)	(hates_unholy((mon)->data))
 #define hates_silver(ptr)	((ptr->mflagsg&MG_HATESSILVER) != 0)
 #define hates_iron(ptr)		((ptr->mflagsg&MG_HATESIRON) != 0)
 
@@ -554,7 +554,7 @@
 
 #define infravision(ptr)	((ptr->mflagsv & MV_INFRAVISION))
 #define infravisible(ptr)	((ptr->mflagsg & MG_INFRAVISIBLE))
-#define infravisible_mon(mon)	(infravisible((mon)->data) && !is_derived_undead_mon(mon))
+#define infravisible_mon(mon)	(infravisible((mon)->data))
 #define bloodsense(ptr)		((ptr->mflagsv & MV_BLOODSENSE))
 #define lifesense(ptr)		((ptr->mflagsv & MV_LIFESENSE))
 #define earthsense(ptr)		((ptr->mflagsv & MV_EARTHSENSE))
@@ -806,7 +806,7 @@
 				   (ptr)->mtyp != PM_GREAT_CTHULHU && \
 				   !is_clockwork(ptr) && \
 				   (!nonliving(ptr) || is_vampire(ptr)))
-#define has_blood_mon(mon)	(has_blood((mon)->data) && !is_derived_undead_mon(mon))
+#define has_blood_mon(mon)	(has_blood((mon)->data))
 
 /* Keep track of ferns, fern sprouts, fern spores, and other plants */
 

--- a/include/monst.h
+++ b/include/monst.h
@@ -213,6 +213,7 @@ struct monst {
 #define	DELOUSED	FACTION_PADDING+14	/* android flag: parasite is killed, but not host */
 #define	M_BLACK_WEB	FACTION_PADDING+15	/* Has a shadow blade attack */
 #define	M_GREAT_WEB	FACTION_PADDING+16	/* Has a stronger shadow blade attack */
+#define MAXFACTION	M_GREAT_WEB
 //define	HALF_DEMON	FACTION_PADDING+1	/* half-demon */
 //define	HALF_DEVIL	FACTION_PADDING+2	/* half-devil */
 //define	HALF_DRAGON	FACTION_PADDING+3	/* half-dragon */

--- a/include/monst.h
+++ b/include/monst.h
@@ -46,7 +46,7 @@ struct monst {
 	struct monst *nmon;
 	struct permonst *data;
 	unsigned m_id;
-	int mnum;		/* permanent monster index number */
+	int mtyp;			/* index number of base permonst array */
 	short movement;		/* movement points (derived from permonst definition and added effects */
 	uchar m_lev;		/* adjusted difficulty level of monster */
 	aligntyp malign;	/* alignment of this monster, relative to the

--- a/include/permonst.h
+++ b/include/permonst.h
@@ -108,6 +108,7 @@ struct permonst {
 # ifdef TEXTCOLOR
 	uchar		mcolor;			/* color to use */
 # endif
+	int				mtyp;			/* Index number of this permonst entry */
 };
 
 extern NEARDATA struct permonst

--- a/include/permonst.h
+++ b/include/permonst.h
@@ -21,6 +21,7 @@ struct attack {
 	uchar		aatyp;
 	uchar		adtyp, damn, damd;
 };
+#define is_null_attk(attk)	((attk) && ((attk)->aatyp == 0 && (attk)->adtyp == 0 && (attk)->damn == 0 && (attk)->damd == 0))
 
 /*	Max # of attacks for any given monster.
  */

--- a/include/xhity.h
+++ b/include/xhity.h
@@ -42,7 +42,7 @@
 /* TODO: put these in their specified header files */
 /* mondata.h */
 #define is_holy_mon(mon)	(is_uvuudaum((mon)->data) || ((mon)->mfaction == ILLUMINATED))
-#define is_unholy_mon(mon)	((mon)->data == &mons[PM_UVUUDAUM])
+#define is_unholy_mon(mon)	((mon)->mtyp == PM_UVUUDAUM)
 /* obj. h*/
 #define multistriking(otmp)	(!(otmp) ? 0 : \
 	(otmp)->otyp == SET_OF_CROW_TALONS ? 2 : \

--- a/include/xhity.h
+++ b/include/xhity.h
@@ -26,7 +26,6 @@
 #define Magic_res(mon)		((mon)==&youmonst ? Antimagic : resists_magm((mon)))
 #define Half_phys(mon)		((mon)==&youmonst ? Half_physical_damage : mon_resistance((mon), HALF_PHDAM))
 #define Change_res(mon)		((mon)==&youmonst ? Unchanging : mon_resistance((mon), UNCHANGING))
-#define is_null_attk(attk)	((attk) && ((attk)->aatyp == 0 && (attk)->adtyp == 0 && (attk)->damn == 0 && (attk)->damd == 0))
 #define creature_at(x,y)	(isok(x,y) ? MON_AT(x, y) ? level.monsters[x][y] : (x==u.ux && y==u.uy) ? &youmonst : (struct monst *)0 : (struct monst *)0)
 
 #define FATAL_DAMAGE_MODIFIER 9001

--- a/include/you.h
+++ b/include/you.h
@@ -815,8 +815,8 @@ struct you {
 #define	WRITHE							0x00000000000020000L
 #define	RADIANCE						0x00000000000040000L
 };	/* end of `struct you' */
-#define uclockwork ((Race_if(PM_CLOCKWORK_AUTOMATON) && !Upolyd) || (Upolyd && youmonst.data == &mons[PM_CLOCKWORK_AUTOMATON]))
-#define uandroid ((Race_if(PM_ANDROID) && !Upolyd) || (Upolyd && (youmonst.data == &mons[PM_ANDROID] || youmonst.data == &mons[PM_GYNOID])))
+#define uclockwork ((Race_if(PM_CLOCKWORK_AUTOMATON) && !Upolyd) || (Upolyd && youmonst.data->mtyp == PM_CLOCKWORK_AUTOMATON))
+#define uandroid ((Race_if(PM_ANDROID) && !Upolyd) || (Upolyd && (youmonst.data->mtyp == PM_ANDROID || youmonst.data->mtyp == PM_GYNOID)))
 #define umechanoid (uclockwork || uandroid)
 //BAB
 #define BASE_ATTACK_BONUS	((Role_if(PM_BARBARIAN) || Role_if(PM_CONVICT) || Role_if(PM_KNIGHT) || Role_if(PM_ANACHRONONAUT) || \

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -207,7 +207,7 @@
 				 (Upolyd && dmgtype(youmonst.data, AD_HALU)))
 #define Hallucination		(HHallucination && !Halluc_resistance)
 
-#define Delusion(mon)	((mon) && !ClearThoughts && ((u.umadness&MAD_DELUSIONS && u.usanity < (mon)->m_san_level) || (mon)->data == &mons[PM_WALKING_DELIRIUM] || (u.umadness&MAD_REAL_DELUSIONS && u.usanity < (mon)->m_san_level*0.8)))
+#define Delusion(mon)	((mon) && !ClearThoughts && ((u.umadness&MAD_DELUSIONS && u.usanity < (mon)->m_san_level) || (mon)->mtyp == PM_WALKING_DELIRIUM || (u.umadness&MAD_REAL_DELUSIONS && u.usanity < (mon)->m_san_level*0.8)))
 
 /* Timeout, plus a worn mask */
 #define HFumbling		u.uprops[FUMBLING].intrinsic

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1124,6 +1124,11 @@ moveloop()
 			flags.shade_level=0;
 		    for (mtmp = fmon; mtmp; mtmp = nxtmon){
 				nxtmon = mtmp->nmon;
+				/* check for mtyp not being correct */
+				if (&mons[mtmp->mtyp] != mtmp->data) {
+					impossible("non-matching mtyp (%d) and data (%ld)", mtmp->mtyp, mtmp->data - mons);
+					mtmp->mtyp = mtmp->data - mons;
+				}
 				/* check for bad swap weapons */
 				if (mtmp->msw) {
 					struct obj *obj;

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -487,7 +487,7 @@ you_regen_hp()
 	}
 
 	// invidiaks out of dark
-	if (youracedata == &mons[PM_INVIDIAK] && !isdark(u.ux, u.uy)) {
+	if (youracedata->mtyp == PM_INVIDIAK && !isdark(u.ux, u.uy)) {
 		perX -= HEALCYCLE;
 		u.regen_blocked++;
 	}
@@ -876,7 +876,7 @@ moveloop()
 				average_dogs();
 			for (mtmp = fmon; mtmp; mtmp = nxtmon){
 				nxtmon = mtmp->nmon;
-				if(mtmp->data == &mons[PM_HELLCAT]){
+				if(mtmp->mtyp == PM_HELLCAT){
 					if(!isdark(mtmp->mx,mtmp->my) && !mtmp->minvis){
 						mtmp->minvis = TRUE;
 						mtmp->perminvis = TRUE;
@@ -886,7 +886,7 @@ moveloop()
 						mtmp->perminvis = FALSE;
 						newsym(mtmp->mx,mtmp->my);
 					}
-				} else if(mtmp->data == &mons[PM_HUDOR_KAMEREL]){
+				} else if(mtmp->mtyp == PM_HUDOR_KAMEREL){
 					if(is_pool(mtmp->mx,mtmp->my, TRUE) && !mtmp->minvis){
 						mtmp->minvis = TRUE;
 						mtmp->perminvis = TRUE;
@@ -896,7 +896,7 @@ moveloop()
 						mtmp->perminvis = FALSE;
 						newsym(mtmp->mx,mtmp->my);
 					}
-				} else if(mtmp->data == &mons[PM_GRUE] || mtmp->data == &mons[PM_INVIDIAK]){
+				} else if(mtmp->mtyp == PM_GRUE || mtmp->mtyp == PM_INVIDIAK){
 					if(isdark(mtmp->mx,mtmp->my) && !mtmp->minvis){
 						mtmp->minvis = TRUE;
 						mtmp->perminvis = TRUE;
@@ -1012,7 +1012,7 @@ moveloop()
 			if(u.sealsActive){
 				if(u.sealsActive&SEAL_MALPHAS){
 					for (mtmp = fmon; mtmp; mtmp = mtmp->nmon){
-						if(mtmp->data == &mons[PM_CROW] && mtmp->mtame && !um_dist(mtmp->mx,mtmp->my,1)){
+						if(mtmp->mtyp == PM_CROW && mtmp->mtame && !um_dist(mtmp->mx,mtmp->my,1)){
 							u.spiritAC++;
 							u.spiritAttk++;
 						}
@@ -1196,10 +1196,10 @@ moveloop()
 					if(!mtmp->mpeacetime) mtmp->mpeaceful = FALSE;
 				}
 				/* Possibly change hostility */
-				if(mtmp->data == &mons[PM_SURYA_DEVA]){
+				if(mtmp->mtyp == PM_SURYA_DEVA){
 					struct monst *blade;
 					for(blade = fmon; blade; blade = blade->nmon)
-						if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+						if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 					if(blade){
 						if(mtmp->mtame && !blade->mtame){
 							if(blade == nxtmon) nxtmon = nxtmon->nmon;
@@ -1216,16 +1216,16 @@ moveloop()
 				/*Reset fracture flag*/
 				if(mtmp->zombify && is_kamerel(mtmp->data)) mtmp->zombify = 0;
 				
-				if(mtmp->data == &mons[PM_ARA_KAMEREL]) flags.goldka_level=1;
-				if(mtmp->data == &mons[PM_ASPECT_OF_THE_SILENCE]){
+				if(mtmp->mtyp == PM_ARA_KAMEREL) flags.goldka_level=1;
+				if(mtmp->mtyp == PM_ASPECT_OF_THE_SILENCE){
 					flags.silence_level=1;
 					losepw(3);
 				}
-				if(mtmp->data == &mons[PM_ZUGGTMOY]) flags.spore_level=1;
-				if(mtmp->data == &mons[PM_JUIBLEX]) flags.slime_level=1;
-				if(mtmp->data == &mons[PM_PALE_NIGHT] || mtmp->data == &mons[PM_DREAD_SERAPH] || mtmp->data == &mons[PM_LEGION]) flags.walky_level=1;
-				if(mtmp->data == &mons[PM_ORCUS] || mtmp->data == &mons[PM_NAZGUL]) flags.shade_level=1;
-				if(mtmp->data == &mons[PM_DREAD_SERAPH] && (mtmp->mstrategy & STRAT_WAITMASK) && (u.uevent.invoked || (Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz)))){
+				if(mtmp->mtyp == PM_ZUGGTMOY) flags.spore_level=1;
+				if(mtmp->mtyp == PM_JUIBLEX) flags.slime_level=1;
+				if(mtmp->mtyp == PM_PALE_NIGHT || mtmp->mtyp == PM_DREAD_SERAPH || mtmp->mtyp == PM_LEGION) flags.walky_level=1;
+				if(mtmp->mtyp == PM_ORCUS || mtmp->mtyp == PM_NAZGUL) flags.shade_level=1;
+				if(mtmp->mtyp == PM_DREAD_SERAPH && (mtmp->mstrategy & STRAT_WAITMASK) && (u.uevent.invoked || (Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz)))){
 					mtmp->mstrategy &= ~STRAT_WAITMASK;
 					pline_The("entire %s is shaking around you!",
 						   In_endgame(&u.uz) ? "plane" : "dungeon");
@@ -1241,15 +1241,15 @@ moveloop()
 					}
 				}
 				
-				if(mtmp->data == &mons[PM_DEEPEST_ONE] && !mtmp->female && u.uevent.ukilled_dagon){
+				if(mtmp->mtyp == PM_DEEPEST_ONE && !mtmp->female && u.uevent.ukilled_dagon){
 					set_mon_data(mtmp, PM_FATHER_DAGON, 0);
 					u.uevent.ukilled_dagon = 0;
 				}
-				if(mtmp->data == &mons[PM_DEEPEST_ONE] && mtmp->female && u.uevent.ukilled_hydra){
+				if(mtmp->mtyp == PM_DEEPEST_ONE && mtmp->female && u.uevent.ukilled_hydra){
 					set_mon_data(mtmp, PM_MOTHER_HYDRA, 0);
 					u.uevent.ukilled_hydra = 0;
 				}
-				if(mtmp->data == &mons[PM_GOLD_GOLEM]){
+				if(mtmp->mtyp == PM_GOLD_GOLEM){
 					int golds = u.goldkamcount_tame + level.flags.goldkamcount_peace + level.flags.goldkamcount_hostile;
 					if(golds > 0){
 						if(canseemon_eyes(mtmp)){
@@ -1291,7 +1291,7 @@ karemade:
 					}
 				}
 				
-				if(mtmp->data == &mons[PM_WALKING_DELIRIUM] && canseemon(mtmp) && distmin(mtmp->mx, mtmp->my, u.ux, u.uy) <= 1){
+				if(mtmp->mtyp == PM_WALKING_DELIRIUM && canseemon(mtmp) && distmin(mtmp->mx, mtmp->my, u.ux, u.uy) <= 1){
 					static long lastusedmove = 0;
 					if(lastusedmove != moves){
 						pline("%s takes on forms new and terrible!", Monnam(mtmp));
@@ -1300,7 +1300,7 @@ karemade:
 					}
 				}
 				
-				if(mtmp->data == &mons[PM_DREADBLOSSOM_SWARM]){
+				if(mtmp->mtyp == PM_DREADBLOSSOM_SWARM){
 					if(canseemon(mtmp) || u.ustuck == mtmp) mtmp->movement += mcalcmove(mtmp);
 					else {
 						struct monst *tmpm;
@@ -1313,7 +1313,7 @@ karemade:
 					}
 				} else mtmp->movement += mcalcmove(mtmp);
 				
-				if(mtmp->data == &mons[PM_NITOCRIS]){
+				if(mtmp->mtyp == PM_NITOCRIS){
 					if(which_armor(mtmp, W_ARMC) && which_armor(mtmp, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF)
 						mtmp->mspec_used = 1;
 				}
@@ -1343,14 +1343,14 @@ karemade:
 						pline("%s looks calm again.", Monnam(mtmp));
 				}
 //endif
-				if(mtmp->data == &mons[PM_GREAT_CTHULHU] || mtmp->data == &mons[PM_ZUGGTMOY] 
-					|| mtmp->data == &mons[PM_SWAMP_FERN]) mtmp->mspec_used = 0;
+				if(mtmp->mtyp == PM_GREAT_CTHULHU || mtmp->mtyp == PM_ZUGGTMOY 
+					|| mtmp->mtyp == PM_SWAMP_FERN) mtmp->mspec_used = 0;
 				if(is_weeping(mtmp->data)) mtmp->mspec_used = 0;
-				if(mtmp->data == &mons[PM_CLOCKWORK_SOLDIER] || mtmp->data == &mons[PM_CLOCKWORK_DWARF] || 
-				   mtmp->data == &mons[PM_FABERGE_SPHERE] || mtmp->data == &mons[PM_FIREWORK_CART] ||
-				   mtmp->data == &mons[PM_ID_JUGGERNAUT]
+				if(mtmp->mtyp == PM_CLOCKWORK_SOLDIER || mtmp->mtyp == PM_CLOCKWORK_DWARF || 
+				   mtmp->mtyp == PM_FABERGE_SPHERE || mtmp->mtyp == PM_FIREWORK_CART ||
+				   mtmp->mtyp == PM_ID_JUGGERNAUT
 				) if(rn2(2)) mtmp->mvar_vector = ((int)mtmp->mvar_vector + rn2(3)-1)%8;
-				if((mtmp->data == &mons[PM_JUGGERNAUT] || mtmp->data == &mons[PM_ID_JUGGERNAUT]) && !rn2(3)){
+				if((mtmp->mtyp == PM_JUGGERNAUT || mtmp->mtyp == PM_ID_JUGGERNAUT) && !rn2(3)){
 					int mdx=0, mdy=0, i;
 					if(mtmp->mux == 0 && mtmp->muy == 0){
 						i = rn2(8);
@@ -2124,7 +2124,7 @@ karemade:
 ////////////////////////////////////////////////////////////////////////////////////////////////
 	for (mtmp = fmon; mtmp; mtmp = nxtmon){
 		nxtmon = mtmp->nmon;
-		if(mtmp->data == &mons[PM_HELLCAT]){
+		if(mtmp->mtyp == PM_HELLCAT){
 			if(!isdark(mtmp->mx,mtmp->my) && !mtmp->minvis){
 				mtmp->minvis = TRUE;
 				mtmp->perminvis = TRUE;
@@ -2134,7 +2134,7 @@ karemade:
 				mtmp->perminvis = FALSE;
 				newsym(mtmp->mx,mtmp->my);
 			}
-		} else if(mtmp->data == &mons[PM_HUDOR_KAMEREL]){
+		} else if(mtmp->mtyp == PM_HUDOR_KAMEREL){
 			if(is_pool(mtmp->mx,mtmp->my, TRUE) && !mtmp->minvis){
 				mtmp->minvis = TRUE;
 				mtmp->perminvis = TRUE;
@@ -2144,7 +2144,7 @@ karemade:
 				mtmp->perminvis = FALSE;
 				newsym(mtmp->mx,mtmp->my);
 			}
-		} else if(mtmp->data == &mons[PM_GRUE] || mtmp->data == &mons[PM_INVIDIAK]){
+		} else if(mtmp->mtyp == PM_GRUE || mtmp->mtyp == PM_INVIDIAK){
 			if(isdark(mtmp->mx,mtmp->my) && !mtmp->minvis){
 				mtmp->minvis = TRUE;
 				mtmp->perminvis = TRUE;
@@ -2447,6 +2447,7 @@ newgame()
 		mvitals[i].mvflags = mons[i].geno & G_NOCORPSE;
 
 	init_objects();		/* must be before u_init() */
+	id_permonst();		/* must be before u_init() */
 	
 	flags.pantheon = -1;	/* role_init() will reset this */
 	flags.panLgod = -1;	/* role_init() will reset this */
@@ -2834,15 +2835,15 @@ unseen_actions(mon)
 struct monst *mon;
 {
 	//Note: May cause mon to change its state, including moving to a different monster chain.
-	if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->data == &mons[PM_BLESSED])
+	if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->mtyp == PM_BLESSED)
 		blessed_spawn(mon);
-	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->data == &mons[PM_THE_GOOD_NEIGHBOR])
+	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->mtyp == PM_THE_GOOD_NEIGHBOR)
 		good_neighbor(mon);
-	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->data == &mons[PM_HMNYW_PHARAOH])
+	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->mtyp == PM_HMNYW_PHARAOH)
 		dark_pharaoh(mon);
-	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->data == &mons[PM_POLYPOID_BEING])
+	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->mtyp == PM_POLYPOID_BEING)
 		polyp_pickup(mon);
-	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->data == &mons[PM_MOUTH_OF_THE_GOAT])
+	else if(mon->mux == u.uz.dnum && mon->muy == u.uz.dlevel && mon->mtyp == PM_MOUTH_OF_THE_GOAT)
 		goat_sacrifice(mon);
 }
 
@@ -2894,10 +2895,10 @@ struct monst *mon;
 				set_malign(mtmp);
 			}
 		} else if((mtmp = m_at(xlocale, ylocale))){
-			if(mtmp->data == &mons[PM_APPRENTICE_WITCH]
-				|| mtmp->data == &mons[PM_WITCH]
-				|| mtmp->data == &mons[PM_COVEN_LEADER]
-				|| mtmp->data == &mons[PM_WITCH_S_FAMILIAR]
+			if(mtmp->mtyp == PM_APPRENTICE_WITCH
+				|| mtmp->mtyp == PM_WITCH
+				|| mtmp->mtyp == PM_COVEN_LEADER
+				|| mtmp->mtyp == PM_WITCH_S_FAMILIAR
 			){
 				//Heal and fix troubles
 				if(needs_familiar(mtmp)){
@@ -2964,7 +2965,7 @@ struct monst *mon;
 	ylocale = mon->mtrack[1].y;
 	struct obj *otmp;
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon){
-		if(mtmp->data != &mons[PM_NITOCRIS] && mtmp->data != &mons[PM_GHOUL_QUEEN_NITOCRIS])
+		if(mtmp->mtyp != PM_NITOCRIS && mtmp->mtyp != PM_GHOUL_QUEEN_NITOCRIS)
 			continue;
 		//found her
 		if(xyloc == MIGR_EXACT_XY){
@@ -2975,7 +2976,7 @@ struct monst *mon;
 			if(which_armor(mtmp, W_ARMC) && which_armor(mtmp, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF){
 				//Directed to cast spells on her behalf
 				mtmp->mspec_used = 0;
-			} else if(mtmp->data == &mons[PM_NITOCRIS]){
+			} else if(mtmp->mtyp == PM_NITOCRIS){
 				//No longer protected, kill her
 				if(canseemon(mtmp)){
 					pline("Dark waters pour into %s's mouth and throat!", mon_nam(mtmp));
@@ -2983,7 +2984,7 @@ struct monst *mon;
 				}
 				mtmp->mhp = 0;
 				mondied(mtmp);
-			} else if(mtmp->data == &mons[PM_GHOUL_QUEEN_NITOCRIS]){
+			} else if(mtmp->mtyp == PM_GHOUL_QUEEN_NITOCRIS){
 				if(mtmp->mhp < mtmp->mhpmax/2){
 					mtmp->mhp = mtmp->mhpmax;
 					if(canseemon(mtmp)) pline("Dark waters seal %s's wounds!", mon_nam(mtmp));
@@ -3238,8 +3239,8 @@ dogoat()
 		if(!mon || mon->mpeaceful)
 			continue;
 		if(touch_petrifies(mon->data)
-		 || mon->data == &mons[PM_MEDUSA]
-		 || mon->data == &mons[PM_PALE_NIGHT]
+		 || mon->mtyp == PM_MEDUSA
+		 || mon->mtyp == PM_PALE_NIGHT
 		) continue;
 		
 		if(mon && !mon->mtame){

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1237,11 +1237,11 @@ moveloop()
 				}
 				
 				if(mtmp->mtyp == PM_DEEPEST_ONE && !mtmp->female && u.uevent.ukilled_dagon){
-					set_mon_data(mtmp, PM_FATHER_DAGON, 0);
+					set_mon_data(mtmp, PM_FATHER_DAGON);
 					u.uevent.ukilled_dagon = 0;
 				}
 				if(mtmp->mtyp == PM_DEEPEST_ONE && mtmp->female && u.uevent.ukilled_hydra){
-					set_mon_data(mtmp, PM_MOTHER_HYDRA, 0);
+					set_mon_data(mtmp, PM_MOTHER_HYDRA);
 					u.uevent.ukilled_hydra = 0;
 				}
 				if(mtmp->mtyp == PM_GOLD_GOLEM){
@@ -1251,7 +1251,7 @@ moveloop()
 							pline("%s blossoms into a swirl of mirrored arcs!", Monnam(mtmp));
 							You("see the image of %s reflected in the golden mirrors!", an(mons[PM_ARA_KAMEREL].mname));
 						}
-						set_mon_data(mtmp, PM_ARA_KAMEREL, 0);
+						set_mon_data(mtmp, PM_ARA_KAMEREL);
 						mtmp->m_lev = 15;
 						mtmp->mhpmax = d(15, 8);
 						mtmp->mhp = mtmp->mhpmax;

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -3115,7 +3115,7 @@ struct monst *mon;
 						pline("%s puts on a mask!", Monnam(mon));
 					m_useup(mon, otmp);
 					mon->ispolyp = TRUE;
-					newcham(mon, &mons[pm], FALSE, FALSE);
+					newcham(mon, pm, FALSE, FALSE);
 					mon->m_insight_level = 0;
 					m_dowear(mon, TRUE);
 					init_mon_wield_item(mon);

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1242,11 +1242,11 @@ moveloop()
 				}
 				
 				if(mtmp->data == &mons[PM_DEEPEST_ONE] && !mtmp->female && u.uevent.ukilled_dagon){
-					set_mon_data(mtmp, &mons[PM_FATHER_DAGON], 0);
+					set_mon_data(mtmp, PM_FATHER_DAGON, 0);
 					u.uevent.ukilled_dagon = 0;
 				}
 				if(mtmp->data == &mons[PM_DEEPEST_ONE] && mtmp->female && u.uevent.ukilled_hydra){
-					set_mon_data(mtmp, &mons[PM_MOTHER_HYDRA], 0);
+					set_mon_data(mtmp, PM_MOTHER_HYDRA, 0);
 					u.uevent.ukilled_hydra = 0;
 				}
 				if(mtmp->data == &mons[PM_GOLD_GOLEM]){
@@ -1256,7 +1256,7 @@ moveloop()
 							pline("%s blossoms into a swirl of mirrored arcs!", Monnam(mtmp));
 							You("see the image of %s reflected in the golden mirrors!", an(mons[PM_ARA_KAMEREL].mname));
 						}
-						set_mon_data(mtmp, &mons[PM_ARA_KAMEREL], 0);
+						set_mon_data(mtmp, PM_ARA_KAMEREL, 0);
 						mtmp->m_lev = 15;
 						mtmp->mhpmax = d(15, 8);
 						mtmp->mhp = mtmp->mhpmax;

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1124,11 +1124,6 @@ moveloop()
 			flags.shade_level=0;
 		    for (mtmp = fmon; mtmp; mtmp = nxtmon){
 				nxtmon = mtmp->nmon;
-				/* check for mtyp not being correct */
-				if (&mons[mtmp->mtyp] != mtmp->data) {
-					impossible("non-matching mtyp (%d) and data (%ld)", mtmp->mtyp, mtmp->data - mons);
-					mtmp->mtyp = mtmp->data - mons;
-				}
 				/* check for bad swap weapons */
 				if (mtmp->msw) {
 					struct obj *obj;

--- a/src/apply.c
+++ b/src/apply.c
@@ -226,7 +226,7 @@ do_present_ring(obj)
 					monflee(mtmp, rnd(100), TRUE, TRUE);
 			}
 		} else if(obj->ohaluengr && obj->oward >= FIRST_DROW_SYM && obj->oward <= LAST_DROW_SYM && 
-			(is_elf(mtmp->data) || is_drow(mtmp->data) || mtmp->data == &mons[PM_EDDERKOP])
+			(is_elf(mtmp->data) || is_drow(mtmp->data) || mtmp->mtyp == PM_EDDERKOP)
 		){
 			if(flags.stag && 
 				(mtmp->mfaction == u.start_house || allied_faction(mtmp->mfaction,u.start_house)) && 
@@ -236,7 +236,7 @@ do_present_ring(obj)
 				verbalize("The revolution has begun!");
 				for(tm = fmon; tm; tm = tm->nmon){
 					if((is_drow(tm->data) && (obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction))) || 
-						((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->data == &mons[PM_EDDERKOP]) ||
+						((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->mtyp == PM_EDDERKOP) ||
 						((tm->mfaction == u.start_house || allied_faction(tm->mfaction,u.start_house)) && 
 							obj->oward == EDDER_SYMBOL && !(tm->female))
 					){
@@ -250,13 +250,13 @@ do_present_ring(obj)
 				}
 			} else if((obj->oward == mtmp->mfaction || allied_faction(obj->oward, mtmp->mfaction)) || 
 				(obj->oward == EILISTRAEE_SYMBOL && is_elf(mtmp->data)) || 
-				((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  mtmp->data == &mons[PM_EDDERKOP])
+				((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  mtmp->mtyp == PM_EDDERKOP)
 			){
 				if(mtmp->housealert && !(mtmp->mpeaceful)){
 					verbalize("Die, spy!");
 					for(tm = fmon; tm; tm = tm->nmon){
 						if((is_drow(tm->data) && (obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction))) || 
-							((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->data == &mons[PM_EDDERKOP]) ||
+							((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->mtyp == PM_EDDERKOP) ||
 							(obj->oward == EILISTRAEE_SYMBOL && is_elf(tm->data))
 						){
 							tm->housealert = 1;
@@ -278,7 +278,7 @@ do_present_ring(obj)
 						if(obj->oward != XAXOX && obj->oward != EDDER_SYMBOL) verbalize("Apologies, my lady!");
 						for(tm = fmon; tm; tm = tm->nmon){
 							if((is_drow(tm->data) && (obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction))) || 
-								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->data == &mons[PM_EDDERKOP]) ||
+								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->mtyp == PM_EDDERKOP) ||
 								(obj->oward == EILISTRAEE_SYMBOL && is_elf(tm->data))
 							){
 								tm->housealert = 1;
@@ -289,7 +289,7 @@ do_present_ring(obj)
 						verbalize("Die, spy!");
 						for(tm = fmon; tm; tm = tm->nmon){
 							if((is_drow(tm->data) && (obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction))) || 
-								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->data == &mons[PM_EDDERKOP]) ||
+								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->mtyp == PM_EDDERKOP) ||
 								(obj->oward == EILISTRAEE_SYMBOL && is_elf(tm->data))
 							){
 								tm->housealert = 1;
@@ -311,7 +311,7 @@ do_present_ring(obj)
 						verbalize("Move along, sir.");
 						for(tm = fmon; tm; tm = tm->nmon){
 							if((is_drow(tm->data) && (obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction))) || 
-								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->data == &mons[PM_EDDERKOP]) ||
+								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->mtyp == PM_EDDERKOP) ||
 								(obj->oward == EILISTRAEE_SYMBOL && is_elf(tm->data))
 							){
 								tm->mpeaceful = 1;
@@ -321,7 +321,7 @@ do_present_ring(obj)
 						verbalize("Die, spy!");
 						for(tm = fmon; tm; tm = tm->nmon){
 							if((is_drow(tm->data) && (obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction))) || 
-								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->data == &mons[PM_EDDERKOP]) ||
+								((obj->oward == EDDER_SYMBOL || obj->oward == XAXOX) &&  tm->mtyp == PM_EDDERKOP) ||
 								(obj->oward == EILISTRAEE_SYMBOL && is_elf(tm->data))
 							){
 								tm->housealert = 1;
@@ -335,8 +335,8 @@ do_present_ring(obj)
 				mtmp->housealert = 1;
 				for(tm = fmon; tm; tm = tm->nmon){
 					if((is_drow(tm->data) && (mtmp->mfaction == tm->mfaction || allied_faction(mtmp->mfaction, tm->mfaction))) || 
-						((mtmp->mfaction == EDDER_SYMBOL || mtmp->mfaction == XAXOX || tm->data == &mons[PM_EDDERKOP]) && 
-							(tm->mfaction == EDDER_SYMBOL || tm->mfaction == XAXOX || tm->data == &mons[PM_EDDERKOP])) ||
+						((mtmp->mfaction == EDDER_SYMBOL || mtmp->mfaction == XAXOX || tm->mtyp == PM_EDDERKOP) && 
+							(tm->mfaction == EDDER_SYMBOL || tm->mfaction == XAXOX || tm->mtyp == PM_EDDERKOP)) ||
 						((mtmp->mfaction == EILISTRAEE_SYMBOL || is_elf(mtmp->data)) && 
 							(tm->mfaction == EILISTRAEE_SYMBOL || is_elf(tm->data)))
 					){
@@ -863,7 +863,7 @@ register xchar x, y;
 			pline("%s chokes on the leash!", Monnam(mtmp));
 			/* tameness eventually drops to 1 here (never 0) */
 			if (mtmp->mtame && rn2(mtmp->mtame)) mtmp->mtame--;
-			if(mtmp->data == &mons[PM_CROW] && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
+			if(mtmp->mtyp == PM_CROW && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
 		    }
 		} else {
 		    if (um_dist(mtmp->mx, mtmp->my, 5)) {
@@ -1014,7 +1014,7 @@ struct obj *obj;
 			xkilled(mtmp, 1);
 		}
 	} else if(!mtmp->mcan && !mtmp->minvis &&
-					mtmp->data == &mons[PM_MEDUSA]  && 
+					mtmp->mtyp == PM_MEDUSA  && 
 					ward_at(mtmp->mx,mtmp->my) != HAMSA) {
 		if (mon_reflects(mtmp, "The gaze is reflected away by %s %s!"))
 			return 1;
@@ -1025,7 +1025,7 @@ struct obj *obj;
 			killed(mtmp);
 		}
 	} else if(!mtmp->mcan && !mtmp->minvis &&
-					mtmp->data == &mons[PM_FLOATING_EYE] && 
+					mtmp->mtyp == PM_FLOATING_EYE && 
 					ward_at(mtmp->mx,mtmp->my) != HAMSA) {
 		int tmp = d(min(MAX_BONUS_DICE, (int)mtmp->m_lev), (int)mtmp->data->mattk[0].damd);
 		if (!rn2(4)) tmp = 120;
@@ -1037,13 +1037,13 @@ struct obj *obj;
 			mtmp->mfrozen = 127;
 		else mtmp->mfrozen += tmp;
 	} else if(!mtmp->mcan && !mtmp->minvis &&
-					mtmp->data == &mons[PM_UMBER_HULK] && 
+					mtmp->mtyp == PM_UMBER_HULK && 
 					ward_at(mtmp->mx,mtmp->my) != HAMSA) {
 		if (vis)
 			pline ("%s confuses itself!", Monnam(mtmp));
 		mtmp->mconf = 1;
 	} else if(!mtmp->mcan && !mtmp->minvis && (mlet == S_NYMPH
-				     || mtmp->data==&mons[PM_SUCCUBUS])) {
+				     || mtmp->mtyp==PM_SUCCUBUS)) {
 		if (vis) {
 		    pline ("%s admires herself in your mirror.", Monnam(mtmp));
 		    pline ("She takes it!");
@@ -2999,7 +2999,7 @@ struct obj *hypo;
 			pline("It would seem that the patient has no circulatory system....");
 		} else switch(amp->ovar1){
 			case POT_HEALING:
-				if (mtarg->data == &mons[PM_PESTILENCE]){
+				if (mtarg->mtyp == PM_PESTILENCE){
 					mtarg->mhp -= d(6 + 2 * bcsign(amp), 4);
 					if(mtarg->mhp <= 0) xkilled(mtarg,1);
 					break;
@@ -3011,7 +3011,7 @@ struct obj *hypo;
 				}
 			break;
 			case POT_EXTRA_HEALING:
-				if (mtarg->data == &mons[PM_PESTILENCE]){
+				if (mtarg->mtyp == PM_PESTILENCE){
 					mtarg->mhp -= d(6 + 2 * bcsign(amp), 8);
 					if(mtarg->mhp <= 0) xkilled(mtarg,1);
 					break;
@@ -3023,7 +3023,7 @@ struct obj *hypo;
 				}
 			break;
 			case POT_FULL_HEALING:
-				if (mtarg->data == &mons[PM_PESTILENCE]){
+				if (mtarg->mtyp == PM_PESTILENCE){
 					if((mtarg->mhpmax > 3) && !resist(mtarg, POTION_CLASS, 0, NOTELL))
 						mtarg->mhpmax /= 2;
 					if((mtarg->mhp > 2) && !resist(mtarg, POTION_CLASS, 0, NOTELL))
@@ -5663,10 +5663,10 @@ struct obj **optr;
 		if((mm = m_at(x,y))){
 			if(is_clockwork(mm->data)){
 				if(obj->otyp == CLOCKWORK_COMPONENT){
-					if(	mm->data != &mons[PM_GOLDEN_HEART] && 
-						mm->data != &mons[PM_ID_JUGGERNAUT] && 
-						mm->data != &mons[PM_HELLFIRE_ORB] && 
-						mm->data != &mons[PM_HELLFIRE_COLOSSUS]
+					if(	mm->mtyp != PM_GOLDEN_HEART && 
+						mm->mtyp != PM_ID_JUGGERNAUT && 
+						mm->mtyp != PM_HELLFIRE_ORB && 
+						mm->mtyp != PM_HELLFIRE_COLOSSUS
 					){
 						if(mm->mhp < mm->mhpmax){
 							if(yn("Repair it?") == 'y'){
@@ -5678,9 +5678,9 @@ struct obj **optr;
 						} else pline("It doesn't need repairs.");
 					}
 				} else if(obj->otyp == HELLFIRE_COMPONENT && (
-					mm->data == &mons[PM_HELLFIRE_ORB] || 
-					mm->data == &mons[PM_HELLFIRE_COLOSSUS] || 
-					mm->data == &mons[PM_SCRAP_TITAN]
+					mm->mtyp == PM_HELLFIRE_ORB || 
+					mm->mtyp == PM_HELLFIRE_COLOSSUS || 
+					mm->mtyp == PM_SCRAP_TITAN
 				)){
 					if(mm->mhp < mm->mhpmax){
 						if(yn("Repair it?") == 'y'){
@@ -5691,9 +5691,9 @@ struct obj **optr;
 						}
 					} else pline("It doesn't need repairs.");
 				} else if(obj->otyp == SUBETHAIC_COMPONENT && (
-					mm->data == &mons[PM_GOLDEN_HEART] || 
-					mm->data == &mons[PM_ID_JUGGERNAUT] || 
-					mm->data == &mons[PM_SCRAP_TITAN]
+					mm->mtyp == PM_GOLDEN_HEART || 
+					mm->mtyp == PM_ID_JUGGERNAUT || 
+					mm->mtyp == PM_SCRAP_TITAN
 				)){
 					if(mm->mhp < mm->mhpmax){
 						if(yn("Repair it?") == 'y'){
@@ -5738,9 +5738,9 @@ struct obj **optr;
 			mm->mhp =  mm->mhpmax;
 			mm->mtame = 10;
 			mm->mpeaceful = 1;
-			if((u.dx || u.dy) && (mm->data == &mons[PM_CLOCKWORK_SOLDIER] || mm->data == &mons[PM_CLOCKWORK_DWARF] || 
-				mm->data == &mons[PM_FABERGE_SPHERE] || mm->data == &mons[PM_FIREWORK_CART] || 
-				mm->data == &mons[PM_JUGGERNAUT] || mm->data == &mons[PM_ID_JUGGERNAUT])
+			if((u.dx || u.dy) && (mm->mtyp == PM_CLOCKWORK_SOLDIER || mm->mtyp == PM_CLOCKWORK_DWARF || 
+				mm->mtyp == PM_FABERGE_SPHERE || mm->mtyp == PM_FIREWORK_CART || 
+				mm->mtyp == PM_JUGGERNAUT || mm->mtyp == PM_ID_JUGGERNAUT)
 			){
 				mm->mvar_vector = -1;
 				while(xdir[(int)(++mm->mvar_vector)] != u.dx || ydir[(int)mm->mvar_vector] != u.dy);

--- a/src/apply.c
+++ b/src/apply.c
@@ -1469,8 +1469,7 @@ struct obj *obj;
 		fix_object(dagger);
 		
 		if (obj->oartifact && obj->oartifact == ART_BLADE_SINGER_S_SABER){
-			dagger->oartifact = 0;
-			artiexist[ART_BLADE_DANCER_S_DAGGER] = FALSE;
+			artifact_exists(dagger, artiname(ART_BLADE_DANCER_S_DAGGER), FALSE);
 			dagger = oname(dagger, artiname(ART_BLADE_DANCER_S_DAGGER));
 		}
 
@@ -3088,7 +3087,7 @@ struct obj *hypo;
 			case POT_POLYMORPH:
 				if (canseemon(mtarg)) pline("%s suddenly mutates!", Monnam(mtarg));
 				if(!resists_poly(mtarg->data))
-					newcham(mtarg, (struct permonst *) 0, FALSE, FALSE);
+					newcham(mtarg, NON_PM, FALSE, FALSE);
 			break;
 			case POT_AMNESIA:
 				if(!amp->cursed){

--- a/src/apply.c
+++ b/src/apply.c
@@ -240,7 +240,7 @@ do_present_ring(obj)
 						((tm->mfaction == u.start_house || allied_faction(tm->mfaction,u.start_house)) && 
 							obj->oward == EDDER_SYMBOL && !(tm->female))
 					){
-						if(is_drow(tm->data)) tm->mfaction = EDDER_SYMBOL;
+						if(is_drow(tm->data)) set_faction(tm, EDDER_SYMBOL);
 						tm->housealert = 1;
 						tm->mpeaceful = 1;
 					} else if(is_drow(tm->data) && !(obj->oward == tm->mfaction || allied_faction(obj->oward, tm->mfaction)) && mtmp->female){
@@ -1018,12 +1018,6 @@ struct obj *obj;
 					ward_at(mtmp->mx,mtmp->my) != HAMSA) {
 		if (mon_reflects(mtmp, "The gaze is reflected away by %s %s!"))
 			return 1;
-		if(mtmp->mfaction != FRACTURED || !rn2(8)){
-			if (vis)
-				pline("%s is turned to stone!", Monnam(mtmp));
-			stoned = TRUE;
-			killed(mtmp);
-		}
 	} else if(!mtmp->mcan && !mtmp->minvis &&
 					mtmp->mtyp == PM_FLOATING_EYE && 
 					ward_at(mtmp->mx,mtmp->my) != HAMSA) {
@@ -3296,7 +3290,7 @@ struct obj *hypo;
 					if (u.ulycn >= LOW_PM && !Race_if(PM_HUMAN_WEREWOLF)) {
 					You("forget your affinity to %s!",
 							makeplural(mons[u.ulycn].mname));
-					if (youmonst.data == &mons[u.ulycn])
+					if (youmonst.data->mtyp == u.ulycn)
 						you_unwere(FALSE);
 					u.ulycn = NON_PM;	/* cure lycanthropy */
 					}

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1350,7 +1350,7 @@ touch_artifact(obj, mon, hypothetical)
 	} else if (!is_covetous(mon->data) && !is_mplayer(mon->data)) {
 		if(oart->otyp != UNICORN_HORN){
 			badclass = self_willed &&
-				   ((oart->role != NON_PM && &mons[oart->role] != mon->data && 
+				   ((oart->role != NON_PM && mon->mtyp != oart->role && 
 				   !(oart == &artilist[ART_EXCALIBUR] || oart == &artilist[ART_CLARENT]))
 				   ||
 				   (oart->race != NON_PM && ((mons[oart->race].mflagsa & mon->data->mflagsa) == 0)));
@@ -5957,7 +5957,7 @@ arti_invoke(obj)
 			mtmp = tamedog(mtmp, (struct obj *) 0);
 			
 			if (mtmp->mtyp != PM_SKELETON)
-				mtmp->mfaction = SKELIFIED;
+				set_faction(mtmp, SKELIFIED);
 
 			if (onfloor) useupf(corpse, 1);
 			else useup(corpse);
@@ -9470,7 +9470,7 @@ mind_blast_items()
 		// if(obj->otyp == STATUE && obj->oattached != OATTACHED_MONST && !(obj->spe)){
 			mtmp = animate_statue(obj, obj->ox, obj->oy, ANIMATE_NORMAL, (int *) 0);
 			if(mtmp){
-				mtmp->mfaction = TOMB_HERD;
+				set_faction(mtmp, TOMB_HERD);
 				mtmp->m_lev += 4;
 				mtmp->mhpmax += d(4, 8);
 				mtmp->mhp = mtmp->mhpmax;
@@ -9662,7 +9662,7 @@ struct monst *mon;
 			if((otmp->wrathdata >> 2) == PM_MIND_FLAYER)
 				return 1;
 		} else {
-			if(&mons[(otmp->wrathdata >> 2)] == mon->data)
+			if((otmp->wrathdata >> 2) == mon->mtyp)
 				return 1;
 			
 			if(mons[(otmp->wrathdata >> 2)].mflagsa && 

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1354,8 +1354,8 @@ touch_artifact(obj, mon, hypothetical)
 				   !(oart == &artilist[ART_EXCALIBUR] || oart == &artilist[ART_CLARENT]))
 				   ||
 				   (oart->race != NON_PM && ((mons[oart->race].mflagsa & mon->data->mflagsa) == 0)));
-			if(mon->isminion && (mon->data == &mons[PM_ALIGNED_PRIEST]
-				|| mon->data == &mons[PM_ANGEL])
+			if(mon->isminion && (mon->mtyp == PM_ALIGNED_PRIEST
+				|| mon->mtyp == PM_ANGEL)
 			){
 				badalign = !(oart->gflags & ARTG_NAME) && oart->alignment != A_NONE &&
 				   (oart->alignment != sgn(EPRI(mon)->shralign));
@@ -1369,8 +1369,8 @@ touch_artifact(obj, mon, hypothetical)
 		}
 		else{/* Unicorn horns */
 			badclass = TRUE;
-			if(mon->isminion && (mon->data == &mons[PM_ALIGNED_PRIEST]
-				|| mon->data == &mons[PM_ANGEL])
+			if(mon->isminion && (mon->mtyp == PM_ALIGNED_PRIEST
+				|| mon->mtyp == PM_ANGEL)
 			){
 				badalign = oart->alignment != A_NONE && (oart->alignment != sgn(EPRI(mon)->shralign));
 			} else if(mon->isminion){
@@ -1382,7 +1382,7 @@ touch_artifact(obj, mon, hypothetical)
     } else {    /* an M3_WANTSxxx monster or a fake player */
 		/* special monsters trying to take the Amulet, invocation tools or
 		   quest item can touch anything except for `spec_applies' artifacts */
-		if(mon->data == &mons[PM_WARDEN_ARIANNA] && obj->oartifact == ART_IRON_SPOON_OF_LIBERATION)
+		if(mon->mtyp == PM_WARDEN_ARIANNA && obj->oartifact == ART_IRON_SPOON_OF_LIBERATION)
 			badclass = badalign = forceEvade = TRUE;
 		else badclass = badalign = FALSE;
     }
@@ -1411,7 +1411,7 @@ touch_artifact(obj, mon, hypothetical)
 			// badclass = FALSE;
 		}
 	}
-	if(mon->data == &mons[PM_DAEMON]) badclass = badalign = FALSE;
+	if(mon->mtyp == PM_DAEMON) badclass = badalign = FALSE;
 	
 	if(obj->oartifact >= ART_BLACK_CRYSTAL && obj->oartifact <= ART_AIR_CRYSTAL){
 		if(obj->oartifact == ART_BLACK_CRYSTAL){
@@ -1775,7 +1775,7 @@ int * truedmgptr;
 	if (otmp->oartifact == ART_BLACK_ARROW) {
 		if (goodpointers) {
 			*plusdmgptr += basedmg * 3 + 108;
-			if (mon->data == &mons[PM_SMAUG])
+			if (mon->mtyp == PM_SMAUG)
 				*truedmgptr += mon->mhpmax;
 		}
 		/* return immediately */
@@ -2106,9 +2106,9 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 				&& (!uarms->cursed || rn2(3))
 			   ) || u.sealsActive&SEAL_ENKI)
 			) {
-				int mult = (flaming(youracedata) || youracedata == &mons[PM_EARTH_ELEMENTAL] || youracedata == &mons[PM_IRON_GOLEM] || youracedata == &mons[PM_CHAIN_GOLEM]) ? 2 : 1;
+				int mult = (flaming(youracedata) || youracedata->mtyp == PM_EARTH_ELEMENTAL || youracedata->mtyp == PM_IRON_GOLEM || youracedata->mtyp == PM_CHAIN_GOLEM) ? 2 : 1;
 				*dmgptr += d(dnum,4)*mult;
-				if(youracedata == &mons[PM_GREMLIN] && rn2(3)){
+				if(youracedata->mtyp == PM_GREMLIN && rn2(3)){
 					(void)split_mon(&youmonst, (struct monst *)0);
 				}
 			}
@@ -2132,9 +2132,9 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 				// && (!ublindf->cursed || rn2(3))
 			   ))
 			) {
-				int mult = (flaming(mdef->data) || mdef->data == &mons[PM_EARTH_ELEMENTAL] || mdef->data == &mons[PM_IRON_GOLEM] || mdef->data == &mons[PM_CHAIN_GOLEM]) ? 2 : 1;
+				int mult = (flaming(mdef->data) || mdef->mtyp == PM_EARTH_ELEMENTAL || mdef->mtyp == PM_IRON_GOLEM || mdef->mtyp == PM_CHAIN_GOLEM) ? 2 : 1;
 				*dmgptr += d(dnum,4)*mult;
-				if(mdef->data == &mons[PM_GREMLIN] && rn2(3)){
+				if(mdef->mtyp == PM_GREMLIN && rn2(3)){
 					(void)split_mon(mdef, (struct monst *)0);
 				}
 			}
@@ -2679,7 +2679,7 @@ char *type;			/* blade, staff, etc */
 		    flags.botl = 1;
 		}
 	    } else {
-		if (mdef->data == &mons[PM_CLAY_GOLEM] || mdef->data == &mons[PM_SPELL_GOLEM])
+		if (mdef->mtyp == PM_CLAY_GOLEM || mdef->mtyp == PM_SPELL_GOLEM)
 		    mdef->mhp = 1;	/* cancelled clay golems will die */
 		if (youattack && (attacktype(mdef->data, AT_MAGC) || attacktype(mdef->data, AT_MMGC))) {
 		    You("absorb magical energy!");
@@ -2819,7 +2819,7 @@ int * truedmgptr;
 			youdef && u.sealsActive&SEAL_ENKI
 			))
 			) {
-			int mult = (flaming(pd) || pd == &mons[PM_EARTH_ELEMENTAL] || pd == &mons[PM_IRON_GOLEM] || pd == &mons[PM_CHAIN_GOLEM]) ? 2 : 1;
+			int mult = (flaming(pd) || pd->mtyp == PM_EARTH_ELEMENTAL || pd->mtyp == PM_IRON_GOLEM || pd->mtyp == PM_CHAIN_GOLEM) ? 2 : 1;
 			if (otmp->oproperties&OPROP_LESSW)
 				*truedmgptr += d(1, 8)*mult;
 			else
@@ -2998,7 +2998,7 @@ int dieroll; /* needed for Magicbane and vorpal blades */
 
 	if (otmp->otyp == KAMEREL_VAJRA && litsaber(otmp)) {
 		if (!Shock_res(mdef)) {
-			if (otmp->where == OBJ_MINVENT && otmp->ocarry->data == &mons[PM_ARA_KAMEREL])
+			if (otmp->where == OBJ_MINVENT && otmp->ocarry->mtyp == PM_ARA_KAMEREL)
 				*truedmgptr += d(6, 6);
 			else
 				*truedmgptr += d(2, 6);
@@ -3494,7 +3494,7 @@ boolean * messaged;
 		}
 	}
 		//sunlight code adapted from Sporkhack
-	if ((pd == &mons[PM_GREMLIN] || pd == &mons[PM_HUNTING_HORROR]) && arti_bright(otmp))
+	if ((pd->mtyp == PM_GREMLIN || pd->mtyp == PM_HUNTING_HORROR) && arti_bright(otmp))
 	{
 		wepdesc = artilist[oartifact].name;
 		/* Sunlight kills gremlins */
@@ -3619,7 +3619,7 @@ boolean * messaged;
 			return result;
 		}
 		/* special effects vs earth elementals */
-		else if (pd == &mons[PM_EARTH_ELEMENTAL]){
+		else if (pd->mtyp == PM_EARTH_ELEMENTAL){
 			struct monst *mtmp = 0;
 			int result = 0;
 			pline("The winds blast the stone and sweep the fragments into a whirling dust storm!");
@@ -3658,7 +3658,7 @@ boolean * messaged;
 			return result;
 		}
 		/* special effects vs water elementals */
-		else if (pd == &mons[PM_WATER_ELEMENTAL]) {
+		else if (pd->mtyp == PM_WATER_ELEMENTAL) {
 			struct monst *mtmp = 0;
 			int result = 0;
 			pline("The winds whip the waters into a rolling fog!");
@@ -3927,7 +3927,7 @@ boolean * messaged;
 			break;
 		case ART_VORPAL_BLADE:
 			wepdesc = "vorpal blade";
-			if (dieroll == 1 || pd == &mons[PM_JABBERWOCK]) {
+			if (dieroll == 1 || pd->mtyp == PM_JABBERWOCK) {
 				behead = TRUE;
 			}
 			break;
@@ -4192,7 +4192,7 @@ boolean * messaged;
 			youdef && u.sealsActive&SEAL_ENKI
 			))
 			) {
-			if (pd == &mons[PM_GREMLIN] && rn2(3)){
+			if (pd->mtyp == PM_GREMLIN && rn2(3)){
 				(void)split_mon(mdef, (struct monst *)0);
 			}
 		}
@@ -4342,7 +4342,7 @@ boolean * messaged;
 		if (youagr) {
 			losehp(d(4,6) + otmp->spe + (Cold_resistance ? 0 : (d(2,6) + otmp->spe)), "a cold black blade", KILLED_BY);
 			if(!Cold_resistance && !rn2(4)) (void) destroy_mitem(magr, POTION_CLASS, AD_COLD);
-		} else if(magr->data != &mons[PM_LEVISTUS]){
+		} else if(magr->mtyp != PM_LEVISTUS){
 			magr->mhp -= d(4,6) + otmp->spe + (resists_cold(magr) ? 0 : (d(2,6) + otmp->spe));
 			if(!resists_cold(magr) && !rn2(4)) (void) destroy_mitem(magr, POTION_CLASS, AD_COLD);
 			// if(magr->mhp < 0){
@@ -5956,7 +5956,7 @@ arti_invoke(obj)
 			struct monst *mtmp = makemon(pm, u.ux, u.uy, MM_EDOG|MM_ADJACENTOK);
 			mtmp = tamedog(mtmp, (struct obj *) 0);
 			
-			if (mtmp->data != &mons[PM_SKELETON])
+			if (mtmp->mtyp != PM_SKELETON)
 				mtmp->mfaction = SKELIFIED;
 
 			if (onfloor) useupf(corpse, 1);
@@ -6323,9 +6323,9 @@ arti_invoke(obj)
 									pline("The %s quickly lengthens and pierces %s %s wall!",
 									obj->oartifact == ART_SCEPTRE_OF_LOLTH ? "Sceptre" : "Rod", 
 									s_suffix(mon_nam(mtmp)), mbodypart(mtmp, STOMACH));
-								if(mtmp->data == &mons[PM_JUIBLEX] 
-									|| mtmp->data == &mons[PM_LEVIATHAN]
-									|| mtmp->data == &mons[PM_METROID_QUEEN]
+								if(mtmp->mtyp == PM_JUIBLEX 
+									|| mtmp->mtyp == PM_LEVIATHAN
+									|| mtmp->mtyp == PM_METROID_QUEEN
 								) mtmp->mhp = (int)(.75*mtmp->mhp + 1);
 								else mtmp->mhp = 1;		/* almost dead */
 								expels(mtmp, mtmp->data, !is_animal(mtmp->data));
@@ -6642,7 +6642,7 @@ arti_invoke(obj)
 							for(; mtmp; mtmp = ntmp){
 								ntmp = mtmp->nmon;
 								if(mon_resistance(mtmp,TELEPAT) && couldsee(mtmp->mx,mtmp->my)){
-									if(mtmp->data == &mons[PM_LUGRIBOSSK]) maanze = TRUE;
+									if(mtmp->mtyp == PM_LUGRIBOSSK) maanze = TRUE;
 									killed(mtmp);
 								} else if(is_magical(mtmp->data) && couldsee(mtmp->mx,mtmp->my) 
 									&& !resist(mtmp, WEAPON_CLASS, 0, NOTELL)
@@ -9592,7 +9592,7 @@ int spe;
 					m2->msleeping = 0;
 					if (!m2->mcanmove && !rn2(5)) {
 						m2->mfrozen = 0;
-						if (m2->data != &mons[PM_GIANT_TURTLE] || !(m2->mflee))
+						if (m2->mtyp != PM_GIANT_TURTLE || !(m2->mflee))
 							m2->mcanmove = 1;
 					}
 					m2->mux = u.ux;

--- a/src/bones.c
+++ b/src/bones.c
@@ -360,20 +360,20 @@ struct obj *corpse;
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 	    if (DEADMONSTER(mtmp)) continue;
 	    mptr = mtmp->data;
-	    if (mtmp->iswiz || mptr == &mons[PM_MEDUSA] ||
+	    if (mtmp->iswiz || mptr->mtyp == PM_MEDUSA ||
 		    mptr->msound == MS_NEMESIS || mptr->msound == MS_LEADER ||
 			quest_status.leader_m_id == mtmp->m_id || 
-		    mptr == &mons[PM_VLAD_THE_IMPALER] || 
+		    mptr->mtyp == PM_VLAD_THE_IMPALER || 
 		    is_keter(mptr) || 
-		    mptr == &mons[PM_HOUND_OF_TINDALOS] || 
-		    mptr == &mons[PM_CLAIRVOYANT_CHANGED] || 
-			(mptr == &mons[PM_DREAD_SERAPH] && !(mtmp->mstrategy & STRAT_WAITFORU)) || 
-			(mptr == &mons[PM_WEEPING_ANGEL] && angelnum > 0) || 
+		    mptr->mtyp == PM_HOUND_OF_TINDALOS || 
+		    mptr->mtyp == PM_CLAIRVOYANT_CHANGED || 
+			(mptr->mtyp == PM_DREAD_SERAPH && !(mtmp->mstrategy & STRAT_WAITFORU)) || 
+			(mptr->mtyp == PM_WEEPING_ANGEL && angelnum > 0) || 
 			(is_drow(mptr) && mtmp->mfaction == LOST_HOUSE) ||
 			(is_dprince(mptr) && !Inhell) || 
 			(is_dlord(mptr) && !Inhell)
 		) mongone(mtmp);
-		if(mptr == &mons[PM_WEEPING_ANGEL]) angelnum++;
+		if(mptr->mtyp == PM_WEEPING_ANGEL) angelnum++;
 	}
 #ifdef STEED
 	if (u.usteed) dismount_steed(DISMOUNT_BONES);

--- a/src/bones.c
+++ b/src/bones.c
@@ -445,28 +445,28 @@ struct obj *corpse;
 			mtmp = makemon(&mons[u.ugrave_arise], u.ux, u.uy, NO_MM_FLAGS);
 			in_mklev = FALSE;
 			if(mtmp)
-				mtmp->mfaction = ZOMBIFIED;
+				set_faction(mtmp, ZOMBIFIED);
 		} else if(u.ugrave_arise == PM_SKELETON){
 			u.ugrave_arise = (u.mfemale && urace.femalenum != NON_PM) ? urace.femalenum : urace.malenum;
 			in_mklev = TRUE;
 			mtmp = makemon(&mons[u.ugrave_arise], u.ux, u.uy, NO_MM_FLAGS);
 			in_mklev = FALSE;
 			if(mtmp)
-				mtmp->mfaction = SKELIFIED;
+				set_faction(mtmp, SKELIFIED);
 		} else if(u.ugrave_arise == PM_BAALPHEGOR){
 			u.ugrave_arise = (u.mfemale && urace.femalenum != NON_PM) ? urace.femalenum : urace.malenum;
 			in_mklev = TRUE;
 			mtmp = makemon(&mons[u.ugrave_arise], u.ux, u.uy, NO_MM_FLAGS);
 			in_mklev = FALSE;
 			if(mtmp)
-				mtmp->mfaction = CRYSTALFIED;
+				set_faction(mtmp, CRYSTALFIED);
 		} else if(u.ugrave_arise == PM_VAMPIRE){
 			u.ugrave_arise = (u.mfemale && urole.femalenum != NON_PM) ? urole.femalenum : urole.malenum;
 			in_mklev = TRUE;
 			mtmp = makemon(&mons[u.ugrave_arise], u.ux, u.uy, NO_MM_FLAGS);
 			in_mklev = FALSE;
 			if(mtmp)
-				mtmp->mfaction = VAMPIRIC;
+				set_faction(mtmp, VAMPIRIC);
 		} else {
 			in_mklev = TRUE;
 			mtmp = makemon(&mons[u.ugrave_arise], u.ux, u.uy, NO_MM_FLAGS);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -575,7 +575,7 @@ domonability()
 			MENU_UNSELECTED);
 		atleastone = TRUE;
 	}
-	if(youracedata == &mons[PM_TOVE]){
+	if(youracedata->mtyp == PM_TOVE){
 		Sprintf(buf, "Bore Hole");
 		any.a_int = MATTK_HOLE;	/* must be non-zero */
 		incntlet = 'B';
@@ -3964,13 +3964,13 @@ signs_enlightenment()
 	if(u.specialSealsActive&SEAL_MISKA && u.ulevel >= 10){
 		static char mbuf[BUFSZ] = {'\0'};
 		if(u.ulevel >= 26){
-			int howManyArms = (youracedata == &mons[PM_VALAVI]) ? 6 : 
-						  (youracedata == &mons[PM_MAN_SERPENT_MAGE]) ? 6 : 
-						  (youracedata == &mons[PM_PHALANX]) ? 6 : 
-						  (youracedata == &mons[PM_MARILITH]) ? 8 : 
-						  (youracedata == &mons[PM_KARY__THE_FIEND_OF_FIRE]) ? 8 : 
-						  (youracedata == &mons[PM_CATHEZAR]) ? 8 : 
-						  (youracedata == &mons[PM_SHAKTARI]) ? 8 : 
+			int howManyArms = (youracedata->mtyp == PM_VALAVI) ? 6 : 
+						  (youracedata->mtyp == PM_MAN_SERPENT_MAGE) ? 6 : 
+						  (youracedata->mtyp == PM_PHALANX) ? 6 : 
+						  (youracedata->mtyp == PM_MARILITH) ? 8 : 
+						  (youracedata->mtyp == PM_KARY__THE_FIEND_OF_FIRE) ? 8 : 
+						  (youracedata->mtyp == PM_CATHEZAR) ? 8 : 
+						  (youracedata->mtyp == PM_SHAKTARI) ? 8 : 
 						  4;
 			Sprintf(mbuf, "You have %d arms, and a wolf head grows from each hip.", howManyArms);
 			putstr(en_win, 0, mbuf);
@@ -4509,13 +4509,13 @@ signs_mirror()
 	if(u.specialSealsActive&SEAL_MISKA && !Invis && u.ulevel >= 10){
 		static char mbuf[BUFSZ] = {'\0'};
 		if(u.ulevel >= 26){
-			int howManyArms = (youracedata == &mons[PM_VALAVI]) ? 6 : 
-						  (youracedata == &mons[PM_MAN_SERPENT_MAGE]) ? 6 : 
-						  (youracedata == &mons[PM_PHALANX]) ? 6 : 
-						  (youracedata == &mons[PM_MARILITH]) ? 8 : 
-						  (youracedata == &mons[PM_KARY__THE_FIEND_OF_FIRE]) ? 8 : 
-						  (youracedata == &mons[PM_CATHEZAR]) ? 8 : 
-						  (youracedata == &mons[PM_SHAKTARI]) ? 8 : 
+			int howManyArms = (youracedata->mtyp == PM_VALAVI) ? 6 : 
+						  (youracedata->mtyp == PM_MAN_SERPENT_MAGE) ? 6 : 
+						  (youracedata->mtyp == PM_PHALANX) ? 6 : 
+						  (youracedata->mtyp == PM_MARILITH) ? 8 : 
+						  (youracedata->mtyp == PM_KARY__THE_FIEND_OF_FIRE) ? 8 : 
+						  (youracedata->mtyp == PM_CATHEZAR) ? 8 : 
+						  (youracedata->mtyp == PM_SHAKTARI) ? 8 : 
 						  4;
 			Sprintf(mbuf, "You have %d arms, and a wolf head grows from each hip.", howManyArms);
 			putstr(en_win, 0, mbuf);

--- a/src/dbridge.c
+++ b/src/dbridge.c
@@ -281,7 +281,7 @@ struct entity *etmp;
 		etmp->ex = x;
 		etmp->ey = y;
 		if (mtmp->wormno && (x != mtmp->mx || y != mtmp->my))
-			etmp->edata = mtmp->data == &mons[PM_HUNTING_HORROR] ? 
+			etmp->edata = mtmp->mtyp == PM_HUNTING_HORROR ? 
 				&mons[PM_HUNTING_HORROR_TAIL] :
 				&mons[PM_LONG_WORM_TAIL];
 		else

--- a/src/detect.c
+++ b/src/detect.c
@@ -228,7 +228,7 @@ register struct obj *sobj;
 	   adjust message if you have gold in your inventory */
 	if (sobj) {
 		char buf[BUFSZ];
-		if (youracedata == &mons[PM_GOLD_GOLEM] || youracedata == &mons[PM_TREASURY_GOLEM]) {
+		if (youracedata->mtyp == PM_GOLD_GOLEM || youracedata->mtyp == PM_TREASURY_GOLEM) {
 			Sprintf(buf, "You feel like a million %s!",
 				currency(2L));
 		} else if (hidden_gold() ||
@@ -876,7 +876,7 @@ int mclass;			/* monster class, 0 for all */
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 		if (DEADMONSTER(mtmp)) continue;
 		if (!mclass || mtmp->data->mlet == mclass ||
-		(mtmp->data == &mons[PM_LONG_WORM] && mclass == S_WORM_TAIL))
+		(mtmp->mtyp == PM_LONG_WORM && mclass == S_WORM_TAIL))
 			if (mtmp->mx > 0) {
 				if (mclass && def_monsyms[mclass] == ' ')
 				show_glyph(mtmp->mx,mtmp->my,
@@ -884,12 +884,12 @@ int mclass;			/* monster class, 0 for all */
 			else
 				show_glyph(mtmp->mx,mtmp->my,mon_to_glyph(mtmp));
 			/* don't be stingy - display entire worm */
-			if (mtmp->data == &mons[PM_LONG_WORM]) detect_wsegs(mtmp,0);
+			if (mtmp->mtyp == PM_LONG_WORM) detect_wsegs(mtmp,0);
 			}
 		if (otmp && otmp->cursed &&
 		(mtmp->msleeping || !mtmp->mcanmove)) {
 		mtmp->msleeping = mtmp->mfrozen = 0;
-	  if(mtmp->data!= &mons[PM_GIANT_TURTLE] || !(mtmp->mflee))
+	  if(mtmp->mtyp!= PM_GIANT_TURTLE || !(mtmp->mflee))
 		mtmp->mcanmove = 1;
 		woken = TRUE;
 		}
@@ -942,7 +942,7 @@ register struct obj *otmp;	/* detecting object (if any) */
 		if (mtmp->mtame && mtmp->mx > 0) {
 		show_glyph(mtmp->mx,mtmp->my,mon_to_glyph(mtmp));
 		/* don't be stingy - display entire worm */
-		if (mtmp->data == &mons[PM_LONG_WORM]) detect_wsegs(mtmp,0);
+		if (mtmp->mtyp == PM_LONG_WORM) detect_wsegs(mtmp,0);
 		/* heal */
 		if(canseemon(mtmp) && mtmp->mtame < 20) mtmp->mhp += d(4, 8);
 		if (mtmp->mhp > mtmp->mhpmax)
@@ -1006,7 +1006,7 @@ register struct obj *otmp;	/* detecting object (if any) */
 		if (mtmp->mtame && mtmp->mx > 0) {
 		show_glyph(mtmp->mx,mtmp->my,mon_to_glyph(mtmp));
 		/* don't be stingy - display entire worm */
-		if (mtmp->data == &mons[PM_LONG_WORM]) detect_wsegs(mtmp,0);
+		if (mtmp->mtyp == PM_LONG_WORM) detect_wsegs(mtmp,0);
 		/* increase tameness */
 		if(canseemon(mtmp) && mtmp->mtame < 20) mtmp->mtame++;
 		}

--- a/src/dig.c
+++ b/src/dig.c
@@ -759,7 +759,7 @@ boolean msgs;
 		if (mtmp) {
 		     /*[don't we need special sokoban handling here?]*/
 		    if (mon_resistance(mtmp,FLYING) || mon_resistance(mtmp,LEVITATION) ||
-		        mtmp->data == &mons[PM_WUMPUS] ||
+		        mtmp->mtyp == PM_WUMPUS ||
 			(mtmp->wormno && count_wsegs(mtmp) > 5) ||
 			mtmp->data->msize >= MZ_HUGE) return;
 		    if (mtmp == u.ustuck)	/* probably a vortex */
@@ -895,7 +895,7 @@ int ttyp;
 		if (mtmp) {
 		     /*[don't we need special sokoban handling here?]*/
 		    if (mon_resistance(mtmp,FLYING) || mon_resistance(mtmp,LEVITATION) ||
-		        mtmp->data == &mons[PM_WUMPUS] ||
+		        mtmp->mtyp == PM_WUMPUS ||
 			(mtmp->wormno && count_wsegs(mtmp) > 5) ||
 			mtmp->data->msize >= MZ_HUGE) return;
 		    if (mtmp == u.ustuck)	/* probably a vortex */
@@ -1785,8 +1785,8 @@ watch_dig(mtmp, x, y, zap)
 	    if (!mtmp) {
 		for(mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 		    if (DEADMONSTER(mtmp)) continue;
-		    if ((mtmp->data == &mons[PM_WATCHMAN] ||
-			 mtmp->data == &mons[PM_WATCH_CAPTAIN]) &&
+		    if ((mtmp->mtyp == PM_WATCHMAN ||
+			 mtmp->mtyp == PM_WATCH_CAPTAIN) &&
 			!is_blind(mtmp) && m_canseeu(mtmp) &&
 			couldsee(mtmp->mx, mtmp->my) && mtmp->mpeaceful)
 			break;
@@ -1876,7 +1876,7 @@ register struct monst *mtmp;
 		here->typ = DOOR;
 		here->doormask = D_NODOOR;
 	    }
-		if(mtmp->data == &mons[PM_MANY_TALONED_THING]){
+		if(mtmp->mtyp == PM_MANY_TALONED_THING){
 			struct engr *oep = engr_at(mtmp->mx, mtmp->my);
 			if(!oep){
 				make_engr_at(mtmp->mx, mtmp->my,
@@ -1955,9 +1955,9 @@ register int zx, zy, digdepth;
 		if (is_animal(mtmp->data))
 		    You("pierce %s %s wall!",
 			s_suffix(mon_nam(mtmp)), mbodypart(mtmp, STOMACH));
-		if(mtmp->data == &mons[PM_JUIBLEX] 
-			|| mtmp->data == &mons[PM_LEVIATHAN]
-			|| mtmp->data == &mons[PM_METROID_QUEEN]
+		if(mtmp->mtyp == PM_JUIBLEX 
+			|| mtmp->mtyp == PM_LEVIATHAN
+			|| mtmp->mtyp == PM_METROID_QUEEN
 												) mtmp->mhp = (int)(.75*mtmp->mhp + 1); 
 		else mtmp->mhp = 1;		/* almost dead */
 		expels(mtmp, mtmp->data, !is_animal(mtmp->data));

--- a/src/display.c
+++ b/src/display.c
@@ -1820,15 +1820,15 @@ back_to_glyph(x,y)
  * a random monster in swallowed() and don't use what_mon() here.
  */
 STATIC_OVL int
-swallow_to_glyph(mnum, loc)
-    int mnum;
+swallow_to_glyph(mtyp, loc)
+int mtyp;
     int loc;
 {
     if (loc < S_sw_tl || S_sw_br < loc) {
 	impossible("swallow_to_glyph: bad swallow location");
 	loc = S_sw_br;
     }
-    return ((int) (what_mon(mnum, u.ustuck)<<3) | (loc - S_sw_tl)) + GLYPH_SWALLOW_OFF;
+	return ((int)(what_mon(mtyp, u.ustuck) << 3) | (loc - S_sw_tl)) + GLYPH_SWALLOW_OFF;
 }
 
 

--- a/src/display.c
+++ b/src/display.c
@@ -459,19 +459,19 @@ display_monster(x, y, mon, sightflags, worm_tail)
 	int num;
 
 	if (mon->mtame && !Hallucination) {
-	    if (worm_tail) num = mon->data == &mons[PM_HUNTING_HORROR] ?
+	    if (worm_tail) num = mon->mtyp == PM_HUNTING_HORROR ?
 			petnum_to_glyph(PM_HUNTING_HORROR_TAIL):
 			petnum_to_glyph(PM_LONG_WORM_TAIL);
 	    else
 		num = pet_to_glyph(mon);
 	} else if (mon->mpeaceful && !Hallucination) {
-	    if (worm_tail) num = mon->data == &mons[PM_HUNTING_HORROR] ?
+	    if (worm_tail) num = mon->mtyp == PM_HUNTING_HORROR ?
 			peacenum_to_glyph(PM_HUNTING_HORROR_TAIL):
 			peacenum_to_glyph(PM_LONG_WORM_TAIL);
 	    else
 		num = peace_to_glyph(mon);
 	} else if (is_derived_undead_mon(mon) && !Hallucination) {
-	    if (worm_tail) num = mon->data == &mons[PM_HUNTING_HORROR] ?
+	    if (worm_tail) num = mon->mtyp == PM_HUNTING_HORROR ?
 			zombienum_to_glyph(PM_HUNTING_HORROR_TAIL):
 			zombienum_to_glyph(PM_LONG_WORM_TAIL);
 	    else
@@ -480,13 +480,13 @@ display_monster(x, y, mon, sightflags, worm_tail)
 	 * visible by any other means.
 	 */
 	} else if (sightflags == DETECTED) {
-	    if (worm_tail) num = mon->data == &mons[PM_HUNTING_HORROR] ?
+	    if (worm_tail) num = mon->mtyp == PM_HUNTING_HORROR ?
 			detected_monnum_to_glyph(what_mon(PM_HUNTING_HORROR_TAIL, mon)):
 			detected_monnum_to_glyph(what_mon(PM_LONG_WORM_TAIL, mon));
 	    else
 		num = detected_mon_to_glyph(mon);
 	} else {
-	    if (worm_tail) num = mon->data == &mons[PM_HUNTING_HORROR] ?
+	    if (worm_tail) num = mon->mtyp == PM_HUNTING_HORROR ?
 			monnum_to_glyph(what_mon(PM_HUNTING_HORROR_TAIL, mon)):
 			monnum_to_glyph(what_mon(PM_LONG_WORM_TAIL, mon));
 	    else

--- a/src/do.c
+++ b/src/do.c
@@ -1774,7 +1774,7 @@ int different;
 		    else if (different==REVIVE_SHADE)
 				pline("%s forms from a corpse!",
 				  Amonnam(mtmp));
-		    else if (mtmp->data==&mons[PM_DEATH])
+		    else if (mtmp->mtyp==PM_DEATH)
 				pline("Death cannot die.");
 			else
 				pline("%s rises from the dead!", chewed ?

--- a/src/do.c
+++ b/src/do.c
@@ -1728,7 +1728,7 @@ int different;
 	chewed = !different && (mtmp->mhp < mtmp->mhpmax);
 	if (chewed) cname = cname_buf;	/* include "bite-covered" prefix */
 	if(different==REVIVE_ZOMBIE){
-		mtmp->mfaction = ZOMBIFIED;
+		set_faction(mtmp, ZOMBIFIED);
 		mtmp->zombify = 0;
 		if(mtmp->mpeaceful && !mtmp->mtame){
 			mtmp->mpeaceful = 0;

--- a/src/do.c
+++ b/src/do.c
@@ -618,8 +618,7 @@ register struct obj *obj;
 		if (is_animal(u.ustuck->data)) {
 		    if (could_poly || could_slime) {
 			(void) newcham(u.ustuck,
-				       could_poly ? (struct permonst *)0 :
-				       &mons[PM_GREEN_SLIME],
+				       could_poly ? NON_PM : PM_GREEN_SLIME,
 				       FALSE, could_slime);
 			delobj(obj);	/* corpse is digested */
 		    } else if (could_petrify) {

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -862,7 +862,7 @@ boolean called;
 	}
 
 	/* priests and minions: don't even use this function */
-	if ((mtmp->ispriest || mtmp->isminion) && mtmp->data != &mons[PM_BLASPHEMOUS_LURKER]) {
+	if ((mtmp->ispriest || mtmp->isminion) && mtmp->mtyp != PM_BLASPHEMOUS_LURKER) {
 	    char priestnambuf[BUFSZ];
 	    char *name;
 	    long save_prop = EHalluc_resistance;
@@ -894,11 +894,11 @@ boolean called;
 		return buf;
 	    }
 	    Strcat(buf, shkname(mtmp));
-	    if (mdat == &mons[PM_SHOPKEEPER] && !do_invis)
+	    if (mdat->mtyp == PM_SHOPKEEPER && !do_invis)
 		return buf;
 	    Strcat(buf, " the ");
 	    if (do_invis) Strcat(buf, "invisible ");
-		if (mtmp->mflee && mtmp->data == &mons[PM_BANDERSNATCH]){
+		if (mtmp->mflee && mtmp->mtyp == PM_BANDERSNATCH){
 			Strcat(buf, "frumious ");
 			name_at_start = FALSE;
 		}
@@ -970,17 +970,17 @@ boolean called;
 	} else if (mtmp->mnamelth) {
 	    char *name = NAME(mtmp);
 
-	    if (mdat == &mons[PM_GHOST]) {
+	    if (mdat->mtyp == PM_GHOST) {
 			Sprintf(eos(buf), "%s ghost", s_suffix(name));
 			name_at_start = TRUE;
-	    } else if (mdat == &mons[PM_SHADE]) {
+	    } else if (mdat->mtyp == PM_SHADE) {
 			Sprintf(eos(buf), "%s shade", s_suffix(name));
 			name_at_start = TRUE;
-	    } else if (mdat == &mons[PM_BROKEN_SHADOW]) {
+	    } else if (mdat->mtyp == PM_BROKEN_SHADOW) {
 			Sprintf(eos(buf), "%s broken shadow", s_suffix(name));
 			name_at_start = TRUE;
 	    } else if (called) {
-			if (mtmp->mflee && mtmp->data == &mons[PM_BANDERSNATCH]){
+			if (mtmp->mflee && mtmp->mtyp == PM_BANDERSNATCH){
 				Sprintf(eos(buf), "frumious ");
 				name_at_start = FALSE;
 			}
@@ -1080,7 +1080,7 @@ boolean called;
 	    name_at_start = FALSE;
 	} else {
 	    name_at_start = (boolean)type_is_pname(mdat);
-		if (mtmp->mflee && mtmp->data == &mons[PM_BANDERSNATCH]){
+		if (mtmp->mflee && mtmp->mtyp == PM_BANDERSNATCH){
 			Strcat(buf, "frumious ");
 			name_at_start = FALSE;
 		}
@@ -1142,11 +1142,11 @@ boolean called;
 	}
 
 	if (name_at_start && (article == ARTICLE_YOUR || !has_adjectives)) {
-	    if (mdat == &mons[PM_WIZARD_OF_YENDOR])
+	    if (mdat->mtyp == PM_WIZARD_OF_YENDOR)
 		article = ARTICLE_THE;
 	    else
 		article = ARTICLE_NONE;
-	} else if ((mdat->geno & G_UNIQ) && article == ARTICLE_A && mdat != &mons[PM_GOD]) {
+	} else if ((mdat->geno & G_UNIQ) && article == ARTICLE_A && mdat->mtyp != PM_GOD) {
 	    article = ARTICLE_THE;
 	}
 
@@ -1214,11 +1214,11 @@ boolean called;
 	}
 
 	if (name_at_start && (article == ARTICLE_YOUR || !has_adjectives)) {
-	    if (mdat == &mons[PM_WIZARD_OF_YENDOR])
+	    if (mdat->mtyp == PM_WIZARD_OF_YENDOR)
 		article = ARTICLE_THE;
 	    else
 		article = ARTICLE_NONE;
-	} else if ((mdat->geno & G_UNIQ) && article == ARTICLE_A && mdat != &mons[PM_GOD]) {
+	} else if ((mdat->geno & G_UNIQ) && article == ARTICLE_A && mdat->mtyp != PM_GOD) {
 	    article = ARTICLE_THE;
 	}
 
@@ -1418,7 +1418,7 @@ char *outbuf;
     /* high priest(ess)'s identity is concealed on the Astral Plane,
        unless you're adjacent (overridden for hallucination which does
        its own obfuscation) */
-    if ( (mon->data == &mons[PM_HIGH_PRIEST] || mon->data == &mons[PM_ELDER_PRIEST]) && !(Hallucination || Delusion(mon)) &&
+    if ( (mon->mtyp == PM_HIGH_PRIEST || mon->mtyp == PM_ELDER_PRIEST) && !(Hallucination || Delusion(mon)) &&
 	    Is_astralevel(&u.uz) && distu(mon->mx, mon->my) > 2) {
 	Strcpy(outbuf, article == ARTICLE_THE ? "the " : "");
 	Strcat(outbuf, mon->female ? "high priestess" : "high priest");

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2521,7 +2521,7 @@ struct monst *magr;
 	}
 	
 	//Note: Bias this somehow?
-	if(magr && magr->data == &mons[PM_XAN])
+	if(magr && magr->mtyp == PM_XAN)
 		goto boot_hit;
 	switch(slot){
 		case UPPER_TORSO_DR:
@@ -3732,8 +3732,8 @@ dosymbiotic()
 		if(!mon || mon->mpeaceful || !rn2(4))
 			continue;
 		if(touch_petrifies(mon->data)
-		 || mon->data == &mons[PM_MEDUSA]
-		 || mon->data == &mons[PM_PALE_NIGHT]
+		 || mon->mtyp == PM_MEDUSA
+		 || mon->mtyp == PM_PALE_NIGHT
 		) continue;
 		
 		if (mon && !mon->mtame && magr_can_attack_mdef(&youmonst, mon, u.ux + clockwisex[(i + j) % 8], u.uy + clockwisey[(i + j) % 8], FALSE)){

--- a/src/dog.c
+++ b/src/dog.c
@@ -1187,7 +1187,7 @@ int enhanced;
 	struct monst *mtmp2, *curmon, *weakdog = (struct monst *) 0;
 	/* The Wiz, Medusa and the quest nemeses aren't even made peaceful. || mtmp->mtyp == PM_MEDUSA */
 	if (is_untamable(mtmp->data) || mtmp->notame || mtmp->iswiz
-		|| (&mons[urole.neminum] == mtmp->data)
+		|| (mtmp->mtyp == urole.neminum)
 	) return((struct monst *)0);
 
 	/* worst case, at least it'll be peaceful. */
@@ -1278,7 +1278,7 @@ int enhanced;
 	if (mtmp->mtame || (!mtmp->mcanmove && !mtmp->moccupation) ||
 	    /* monsters with conflicting structures cannot be tamed */
 	    mtmp->isshk || mtmp->isgd || mtmp->ispriest || mtmp->isminion ||
-	    mtmp->data == &mons[urole.neminum] ||
+	    mtmp->mtyp == urole.neminum ||
 	    (!enhanced && is_demon(mtmp->data) && !is_demon(youracedata)) ||
 	    (obj
 			&& !is_instrument(obj) && obj->otyp != DOLL_OF_FRIENDSHIP 

--- a/src/dog.c
+++ b/src/dog.c
@@ -1327,13 +1327,13 @@ int enhanced;
 }
 
 struct monst *
-make_pet_minion(mnum,alignment)
-int mnum;
+make_pet_minion(mtyp,alignment)
+int mtyp;
 aligntyp alignment;
 {
     register struct monst *mon;
     register struct monst *mtmp2;
-    mon = makemon(&mons[mnum], u.ux, u.uy, NO_MM_FLAGS);
+	mon = makemon(&mons[mtyp], u.ux, u.uy, NO_MM_FLAGS);
     if (!mon) return 0;
     /* now tame that puppy... */
     mtmp2 = newmonst(sizeof(struct edog) + mon->mnamelth);
@@ -1347,10 +1347,11 @@ aligntyp alignment;
     set_malign(mtmp2);
     mtmp2->mtame = 10;
     /* this section names the creature "of ______" */
-    if (mons[mnum].pxlth == 0) {
+	if (mons[mtyp].pxlth == 0) {
 		mtmp2->isminion = TRUE;
 		EMIN(mtmp2)->min_align = alignment;
-    } else if (mnum == PM_ANGEL) {
+	}
+	else if (mtyp == PM_ANGEL) {
 		 mtmp2->isminion = TRUE;
 		 EPRI(mtmp2)->shralign = alignment;
     }

--- a/src/dog.c
+++ b/src/dog.c
@@ -15,9 +15,9 @@ void
 initedog(mtmp)
 register struct monst *mtmp;
 {
-	if(mtmp->data == &mons[PM_SURYA_DEVA]){
+	if(mtmp->mtyp == PM_SURYA_DEVA){
 		struct monst *blade;
-		for(blade = fmon; blade; blade = blade->nmon) if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+		for(blade = fmon; blade; blade = blade->nmon) if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 		if(blade && !blade->mtame) tamedog(blade, (struct obj *) 0);
 	}
 	
@@ -361,7 +361,7 @@ boolean with_you;
 
 	num_segs = mtmp->wormno;
 	/* baby long worms have no tail so don't use is_longworm() */
-	if ((mtmp->data == &mons[PM_LONG_WORM]) &&
+	if ((mtmp->mtyp == PM_LONG_WORM) &&
 #ifdef DCC30_BUG
 	    (mtmp->wormno = get_wormno(), mtmp->wormno != 0))
 #else
@@ -697,10 +697,10 @@ boolean pets_only;	/* true for ascension or final escape */
 	    mtmp2 = mtmp->nmon;
 	    if (DEADMONSTER(mtmp)) continue;
 	    if (pets_only && !mtmp->mtame) continue;
-	    if (mtmp->data == &mons[PM_DANCING_BLADE]) continue;
+	    if (mtmp->mtyp == PM_DANCING_BLADE) continue;
 	    if (((monnear(mtmp, u.ux, u.uy) && levl_follower(mtmp)) || 
 			(mtmp->mtame && (all_pets ||
-							// (u.sealsActive&SEAL_MALPHAS && mtmp->data == &mons[PM_CROW]) || //Allow distant crows to get left behind.
+							// (u.sealsActive&SEAL_MALPHAS && mtmp->mtyp == PM_CROW) || //Allow distant crows to get left behind.
 							(distmin(mtmp->mx, mtmp->my, u.ux, u.uy) <= pet_dist)
 							)
 			) ||
@@ -781,9 +781,9 @@ boolean pets_only;	/* true for ascension or final escape */
 			mtmp->mlstmv = monstermoves;
 			mtmp->nmon = mydogs;
 			mydogs = mtmp;
-			if(mtmp->data == &mons[PM_SURYA_DEVA]){
+			if(mtmp->mtyp == PM_SURYA_DEVA){
 				struct monst *blade;
-				for(blade = fmon; blade; blade = blade->nmon) if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+				for(blade = fmon; blade; blade = blade->nmon) if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 				if(blade) {
 					if(mtmp2 == blade) mtmp2 = mtmp2->nmon; /*mtmp2 is about to end up on the migrating mons chain*/
 					/* set minvent's obj->no_charge to 0 */
@@ -802,12 +802,12 @@ boolean pets_only;	/* true for ascension or final escape */
 			}
 	    } else if (quest_status.touched_artifact && Race_if(PM_DROW) && !flags.initgend && Role_if(PM_NOBLEMAN) && mtmp->m_id == quest_status.leader_m_id) {
 			mongone(mtmp);
-	    // } else if(u.uevent.qcompleted && mtmp->data == &mons[PM_ORION]){
+	    // } else if(u.uevent.qcompleted && mtmp->mtyp == PM_ORION){
 			// mondied(mtmp);
 	    } else if (mtmp->iswiz || 
-			mtmp->data == &mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES] || 
-			mtmp->data == &mons[PM_CENTER_OF_ALL] || 
-			mtmp->data == &mons[PM_HUNGRY_DEAD] ||
+			mtmp->mtyp == PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES || 
+			mtmp->mtyp == PM_CENTER_OF_ALL || 
+			mtmp->mtyp == PM_HUNGRY_DEAD ||
 			mtmp->mtame
 		) {
 			if (mtmp->mleashed) {
@@ -819,9 +819,9 @@ boolean pets_only;	/* true for ascension or final escape */
 			/* we want to be able to find him when his next resurrection
 			   chance comes up, but have him resume his present location
 			   if player returns to this level before that time */
-			if(mtmp->data == &mons[PM_SURYA_DEVA] && mtmp2 && mtmp2->data == &mons[PM_DANCING_BLADE] && mtmp2->mvar_suryaID == mtmp->m_id)
+			if(mtmp->mtyp == PM_SURYA_DEVA && mtmp2 && mtmp2->mtyp == PM_DANCING_BLADE && mtmp2->mvar_suryaID == mtmp->m_id)
 				mtmp2 = mtmp2->nmon; /*mtmp2 is about to end up on the migrating mons chain*/
-			if(mtmp->data != &mons[PM_DANCING_BLADE]) migrate_to_level(mtmp, ledger_no(&u.uz),
+			if(mtmp->mtyp != PM_DANCING_BLADE) migrate_to_level(mtmp, ledger_no(&u.uz),
 					 MIGR_EXACT_XY, (coord *)0);
 	    }
 	}
@@ -885,9 +885,9 @@ migrate_to_level(mtmp, tolev, xyloc, cc)
 	mtmp->muy = new_lev.dlevel;
 	mtmp->mx = mtmp->my = 0;	/* this implies migration */
 	
-	if(mtmp->data == &mons[PM_SURYA_DEVA]){
+	if(mtmp->mtyp == PM_SURYA_DEVA){
 		struct monst *blade;
-		for(blade = fmon; blade; blade = blade->nmon) if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+		for(blade = fmon; blade; blade = blade->nmon) if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 		if(blade) {
 			/* set minvent's obj->no_charge to 0 */
 			for(obj = blade->minvent; obj; obj = obj->nobj) {
@@ -950,7 +950,7 @@ register struct obj *obj;
 		    return TABU;
 
 	    /* Ghouls only eat old corpses... yum! */
-	    if (mon->data == &mons[PM_GHOUL]){
+	    if (mon->mtyp == PM_GHOUL){
 		return (obj->otyp == CORPSE && obj->corpsenm != PM_ACID_BLOB &&
 		  peek_at_iced_corpse_age(obj) + 5*rn1(20,10) <= monstermoves) ?
 			DOGFOOD : TABU;
@@ -1052,9 +1052,9 @@ rock:
 		return(TABU);
 	    if (herbi && !carni && (obj->otyp == SHEAF_OF_HAY || obj->otyp == SEDGE_HAT))
 		return CADAVER;
-	    if (mon->data == &mons[PM_GELATINOUS_CUBE] && is_organic(obj))
+	    if (mon->mtyp == PM_GELATINOUS_CUBE && is_organic(obj))
 		return(ACCFOOD);
-	    if (metallivorous(mon->data) && is_metallic(obj) && (is_rustprone(obj) || mon->data != &mons[PM_RUST_MONSTER])) {
+	    if (metallivorous(mon->data) && is_metallic(obj) && (is_rustprone(obj) || mon->mtyp != PM_RUST_MONSTER)) {
 		/* Non-rustproofed ferrous based metals are preferred. */
 		return((is_rustprone(obj) && !obj->oerodeproof) ? DOGFOOD :
 			ACCFOOD);
@@ -1185,7 +1185,7 @@ struct obj *obj;
 int enhanced;
 {
 	struct monst *mtmp2, *curmon, *weakdog = (struct monst *) 0;
-	/* The Wiz, Medusa and the quest nemeses aren't even made peaceful. || mtmp->data == &mons[PM_MEDUSA] */
+	/* The Wiz, Medusa and the quest nemeses aren't even made peaceful. || mtmp->mtyp == PM_MEDUSA */
 	if (is_untamable(mtmp->data) || mtmp->notame || mtmp->iswiz
 		|| (&mons[urole.neminum] == mtmp->data)
 	) return((struct monst *)0);

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -853,8 +853,8 @@ boolean ranged;
 		 mtmp2->mtyp==PM_GELATINOUS_CUBE && rn2(10)) ||
 		(!ranged &&
 		 max_passive_dmg(mtmp2, mtmp) >= mtmp->mhp) ||
-		((   mtmp2->data == &mons[urole.guardnum]
-		  || mtmp2->data == &mons[urole.ldrnum]
+		((   mtmp2->mtyp == urole.guardnum
+		  || mtmp2->mtyp == urole.ldrnum
 		  || (Role_if(PM_NOBLEMAN) && (mtmp->mtyp == PM_KNIGHT || mtmp->mtyp == PM_MAID || mtmp->mtyp == PM_PEASANT) && mtmp->mpeaceful)
 		  || (Race_if(PM_DROW) && is_drow(mtmp->data) && mtmp->mpeaceful)
 		  || (Role_if(PM_KNIGHT) && (mtmp->mtyp == PM_KNIGHT) && mtmp->mpeaceful)

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -439,7 +439,7 @@ boolean devour;
 #endif /* PET_SATIATION */
 
 	if (poly) {
-	    (void) newcham(mtmp, (struct permonst *)0, FALSE,
+	    (void) newcham(mtmp, NON_PM, FALSE,
 			   cansee(mtmp->mx, mtmp->my));
 	}
 	/* limit "instant" growth to prevent potential abuse */

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -116,16 +116,16 @@ boolean check_if_better;
 	    /* food */
             ((dogfood(mtmp, otmp) < APPORT) ||
 	    /* chains for some */
-		 ((mtmp->data == &mons[PM_CATHEZAR]) && otmp->otyp == CHAIN) ||
+		 ((mtmp->mtyp == PM_CATHEZAR) && otmp->otyp == CHAIN) ||
 	    /* better weapons */
 	     (is_armed(mtmp->data) &&
 	      (otmp->oclass == WEAPON_CLASS || is_weptool(otmp)) && 
 		   (!check_if_better ||
-		    mtmp->data == &mons[PM_MARILITH] ||
+		    mtmp->mtyp == PM_MARILITH ||
 		    would_prefer_hwep(mtmp, otmp) ||
 		    would_prefer_rwep(mtmp, otmp))) ||
 	    /* useful masks */
-	     (otmp->otyp == MASK && mtmp->data == &mons[PM_LILLEND]) ||
+	     (otmp->otyp == MASK && mtmp->mtyp == PM_LILLEND) ||
 	    /* better armor */
 	     (otmp->oclass == ARMOR_CLASS &&
 	      (!check_if_better || is_better_armor(mtmp, otmp))) ||
@@ -344,7 +344,7 @@ boolean devour;
 	    nutrit = (nutrit + 4) / 5;
 	}
 	edog->hungrytime += nutrit;
-	if(u.sealsActive&SEAL_MALPHAS && mtmp->data == &mons[PM_CROW] && obj->otyp == CORPSE){
+	if(u.sealsActive&SEAL_MALPHAS && mtmp->mtyp == PM_CROW && obj->otyp == CORPSE){
 		more_experienced(ptrexperience(&mons[obj->corpsenm]),0);
 		newexplevel();
 	}
@@ -380,7 +380,7 @@ boolean devour;
 	    edog->apport += (int)(200L/
 		((long)edog->dropdist + monstermoves - edog->droptime));
 #endif
-	if (mtmp->data == &mons[PM_RUST_MONSTER] && obj->oerodeproof) {
+	if (mtmp->mtyp == PM_RUST_MONSTER && obj->oerodeproof) {
 	    /* The object's rustproofing is gone now */
 	    obj->oerodeproof = 0;
 	    mtmp->mstun = 1;
@@ -826,7 +826,7 @@ boolean ranged;
 	if(mtmp2->mtrapped && t_at(mtmp2->mx, mtmp2->my) && t_at(mtmp2->mx, mtmp2->my)->ttyp == VIVI_TRAP)
 		return FALSE;
 	
-	if(mtmp->mtame && mtmp2->mpeaceful && !u.uevent.uaxus_foe && mtmp2->data == &mons[PM_AXUS])
+	if(mtmp->mtame && mtmp2->mpeaceful && !u.uevent.uaxus_foe && mtmp2->mtyp == PM_AXUS)
 		return FALSE;
 	
 	if(mtmp->mhp < 100 && attacktype_fordmg(mtmp2->data, AT_BOOM, AD_MAND))
@@ -835,7 +835,7 @@ boolean ranged;
 	if((Upolyd ? u.mh < 100 : u.uhp < 100) && mtmp->mtame && attacktype_fordmg(mtmp2->data, AT_BOOM, AD_MAND))
 		return FALSE;
 	
-	if(mtmp2->data == &mons[PM_MANDRAKE])
+	if(mtmp2->mtyp == PM_MANDRAKE)
 		return FALSE;
 	
     return !((!ranged &&
@@ -846,18 +846,18 @@ boolean ranged;
 #endif
 		!(attacktype(mtmp->data, AT_EXPL) || extra_nasty(mtmp->data))) ||
 		(!ranged &&
-		 mtmp2->data == &mons[PM_FLOATING_EYE] && rn2(10) &&
+		 mtmp2->mtyp == PM_FLOATING_EYE && rn2(10) &&
 		 !is_blind(mtmp) && haseyes(mtmp->data) && !is_blind(mtmp2)
 		 && (mon_resistance(mtmp,SEE_INVIS) || !mtmp2->minvis)) ||
 		(!ranged &&
-		 mtmp2->data==&mons[PM_GELATINOUS_CUBE] && rn2(10)) ||
+		 mtmp2->mtyp==PM_GELATINOUS_CUBE && rn2(10)) ||
 		(!ranged &&
 		 max_passive_dmg(mtmp2, mtmp) >= mtmp->mhp) ||
 		((   mtmp2->data == &mons[urole.guardnum]
 		  || mtmp2->data == &mons[urole.ldrnum]
-		  || (Role_if(PM_NOBLEMAN) && (mtmp->data == &mons[PM_KNIGHT] || mtmp->data == &mons[PM_MAID] || mtmp->data == &mons[PM_PEASANT]) && mtmp->mpeaceful)
+		  || (Role_if(PM_NOBLEMAN) && (mtmp->mtyp == PM_KNIGHT || mtmp->mtyp == PM_MAID || mtmp->mtyp == PM_PEASANT) && mtmp->mpeaceful)
 		  || (Race_if(PM_DROW) && is_drow(mtmp->data) && mtmp->mpeaceful)
-		  || (Role_if(PM_KNIGHT) && (mtmp->data == &mons[PM_KNIGHT]) && mtmp->mpeaceful)
+		  || (Role_if(PM_KNIGHT) && (mtmp->mtyp == PM_KNIGHT) && mtmp->mpeaceful)
 		  || (Race_if(PM_GNOME) && (is_gnome(mtmp->data) && !is_undead_mon(mtmp)) && mtmp->mpeaceful)
 		  || always_peaceful(mtmp2->data)) &&
 		 mtmp2->mpeaceful && !Conflict) ||
@@ -1241,9 +1241,9 @@ newdogpos:
 		/* insert a worm_move() if worms ever begin to eat things */
 		remove_monster(omx, omy);
 		place_monster(mtmp, nix, niy);
-		if(mtmp->data == &mons[PM_SURYA_DEVA]){
+		if(mtmp->mtyp == PM_SURYA_DEVA){
 			struct monst *blade;
-			for(blade = fmon; blade; blade = blade->nmon) if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+			for(blade = fmon; blade; blade = blade->nmon) if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 			if(blade){
 				int bx = blade->mx, by = blade->my;
 				remove_monster(bx, by);

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -231,16 +231,16 @@ register struct obj *gold;
 		    long goldreqd = 0L;
 
 		    if (rn2(3)) {
-			if (mtmp->data == &mons[PM_SOLDIER])
+			if (mtmp->mtyp == PM_SOLDIER)
 			   goldreqd = 100L;
-			else if (mtmp->data == &mons[PM_SERGEANT])
+			else if (mtmp->mtyp == PM_SERGEANT)
 			   goldreqd = 250L;
-			else if (mtmp->data == &mons[PM_LIEUTENANT])
+			else if (mtmp->mtyp == PM_LIEUTENANT)
 			   goldreqd = 500L;
-			else if (mtmp->data == &mons[PM_CAPTAIN])
+			else if (mtmp->mtyp == PM_CAPTAIN)
 			   goldreqd = 750L;
 #ifdef CONVICT
-			else if (mtmp->data == &mons[PM_PRISON_GUARD])
+			else if (mtmp->mtyp == PM_PRISON_GUARD)
 			   goldreqd = 200L;
 #endif /* CONVICT */
 
@@ -1267,8 +1267,8 @@ dumb:
 		if (in_town(x, y))
 		  for(mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 		    if (DEADMONSTER(mtmp)) continue;
-		    if((mtmp->data == &mons[PM_WATCHMAN] ||
-			mtmp->data == &mons[PM_WATCH_CAPTAIN]) &&
+		    if((mtmp->mtyp == PM_WATCHMAN ||
+			mtmp->mtyp == PM_WATCH_CAPTAIN) &&
 			couldsee(mtmp->mx, mtmp->my) &&
 			mtmp->mpeaceful) {
 			if (canspotmon(mtmp))
@@ -1287,8 +1287,8 @@ dumb:
 	    if (in_town(x, y))
 		for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 		    if (DEADMONSTER(mtmp)) continue;
-		    if ((mtmp->data == &mons[PM_WATCHMAN] ||
-				mtmp->data == &mons[PM_WATCH_CAPTAIN]) &&
+		    if ((mtmp->mtyp == PM_WATCHMAN ||
+				mtmp->mtyp == PM_WATCH_CAPTAIN) &&
 			    mtmp->mpeaceful && couldsee(mtmp->mx, mtmp->my)) {
 			if (canspotmon(mtmp))
 			    pline("%s yells:", Amonnam(mtmp));

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -601,7 +601,7 @@ quest_arti_hits_leader(obj,mon)
 struct obj *obj;
 struct monst *mon;
 {
-	if(obj->oartifact && is_quest_artifact(obj) && (mon->data == &mons[urole.ldrnum])) return TRUE;
+	if(obj->oartifact && is_quest_artifact(obj) && (mon->mtyp == urole.ldrnum)) return TRUE;
 	else if(Race_if(PM_ELF)){
 		if((obj->oartifact == ART_PALANTIR_OF_WESTERNESSE || obj->oartifact == ART_BELTHRONDING) &&
 			(mon->mtyp == PM_CELEBORN || mon->mtyp == PM_GALADRIEL)

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -604,18 +604,18 @@ struct monst *mon;
 	if(obj->oartifact && is_quest_artifact(obj) && (mon->data == &mons[urole.ldrnum])) return TRUE;
 	else if(Race_if(PM_ELF)){
 		if((obj->oartifact == ART_PALANTIR_OF_WESTERNESSE || obj->oartifact == ART_BELTHRONDING) &&
-			(mon->data == &mons[PM_CELEBORN] || mon->data == &mons[PM_GALADRIEL])
+			(mon->mtyp == PM_CELEBORN || mon->mtyp == PM_GALADRIEL)
 		) return TRUE;
 	} else if(Race_if(PM_DROW)){
 		if(((obj->oartifact == ART_SILVER_STARLIGHT || obj->oartifact == ART_WRATHFUL_SPIDER) &&
-			(flags.initgend && mon->data == &mons[PM_ECLAVDRA])) || 
+			(flags.initgend && mon->mtyp == PM_ECLAVDRA)) || 
 			((obj->oartifact == ART_DARKWEAVER_S_CLOAK || obj->oartifact == ART_SPIDERSILK) &&
-			(!flags.initgend && mon->data == &mons[PM_ECLAVDRA])) ||
+			(!flags.initgend && mon->mtyp == PM_ECLAVDRA)) ||
 			
 			((obj->oartifact == ART_TENTACLE_ROD || obj->oartifact == ART_CRESCENT_BLADE) &&
-			(flags.initgend && mon->data == &mons[PM_SEYLL_AUZKOVYN])) ||
+			(flags.initgend && mon->mtyp == PM_SEYLL_AUZKOVYN)) ||
 			((obj->oartifact == ART_TENTACLE_ROD || obj->oartifact == ART_WEBWEAVER_S_CROOK) &&
-			(!flags.initgend && mon->data == &mons[PM_DARUTH_XAXOX]))
+			(!flags.initgend && mon->mtyp == PM_DARUTH_XAXOX))
 		) return TRUE;
 	}
 	return FALSE;

--- a/src/eat.c
+++ b/src/eat.c
@@ -3693,7 +3693,7 @@ doeat()		/* generic "eat" command funtion (see cmd.c) */
 					if (u.ulycn >= LOW_PM && !Race_if(PM_HUMAN_WEREWOLF)) {
 					You("forget your affinity to %s!",
 							makeplural(mons[u.ulycn].mname));
-					if (youracedata == &mons[u.ulycn])
+					if (youracedata->mtyp == u.ulycn)
 						you_unwere(FALSE);
 					u.ulycn = NON_PM;	/* cure lycanthropy */
 					}

--- a/src/eat.c
+++ b/src/eat.c
@@ -364,14 +364,14 @@ struct obj *food;
 boolean the_pfx;
 {
 	const char *result;
-	int mnum = food->corpsenm;
+	int mtyp = food->corpsenm;
 
-	if (food->otyp == CORPSE && (mons[mnum].geno & G_UNIQ)) {
+	if (food->otyp == CORPSE && (mons[mtyp].geno & G_UNIQ)) {
 	    /* grab xname()'s modifiable return buffer for our own use */
 	    char *bufp = xname(food);
 	    Sprintf(bufp, "%s%s corpse",
-		    (the_pfx && !type_is_pname(&mons[mnum])) ? "the " : "",
-		    s_suffix(mons[mnum].mname));
+			(the_pfx && !type_is_pname(&mons[mtyp])) ? "the " : "",
+			s_suffix(mons[mtyp].mname));
 	    result = bufp;
 	} else {
 	    /* the ordinary case */
@@ -1955,25 +1955,25 @@ STATIC_OVL int
 eatcorpse(otmp)		/* called when a corpse is selected as food */
 	register struct obj *otmp;
 {
-	int tp = 0, mnum = otmp->corpsenm;
+	int tp = 0, mtyp = otmp->corpsenm;
 	long rotted = 0L;
-	boolean uniq = !!(mons[mnum].geno & G_UNIQ);
+	boolean uniq = !!(mons[mtyp].geno & G_UNIQ);
 	int retcode = 0;
-	boolean stoneable = (touch_petrifies(&mons[mnum]) && !Stone_resistance &&
+	boolean stoneable = (touch_petrifies(&mons[mtyp]) && !Stone_resistance &&
 				!poly_when_stoned(youracedata));
 
 	/* KMH, conduct */
-	if (!vegan(&mons[mnum])) u.uconduct.unvegan++;
-	if (!vegetarian(&mons[mnum])){
+	if (!vegan(&mons[mtyp])) u.uconduct.unvegan++;
+	if (!vegetarian(&mons[mtyp])){
 		violated_vegetarian();
 	} else {
 		if(roll_madness(MAD_CANNIBALISM)){
-			make_vomiting((3 + (mons[mnum].cwt >> 6))+rn1(15,10), TRUE);
+			make_vomiting((3 + (mons[mtyp].cwt >> 6))+rn1(15,10), TRUE);
 		}
 	}
 
-	if (mnum != PM_LIZARD && mnum != PM_SMALL_CAVE_LIZARD && mnum != PM_CAVE_LIZARD 
-		&& mnum != PM_LARGE_CAVE_LIZARD && mnum != PM_LICHEN && mnum != PM_BEHOLDER
+	if (mtyp != PM_LIZARD && mtyp != PM_SMALL_CAVE_LIZARD && mtyp != PM_CAVE_LIZARD 
+		&& mtyp != PM_LARGE_CAVE_LIZARD && mtyp != PM_LICHEN && mtyp != PM_BEHOLDER
 	) {
 		long age = peek_at_iced_corpse_age(otmp);
 
@@ -2003,8 +2003,8 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 		    Sprintf(buf, "%s", the(corpse_xname(otmp,TRUE)));
 		else
 		    Sprintf(buf, "%s%s corpse",
-			    !type_is_pname(&mons[mnum]) ? "the " : "",
-			    s_suffix(mons[mnum].mname));
+			    !type_is_pname(&mons[mtyp]) ? "the " : "",
+			    s_suffix(mons[mtyp].mname));
 
 	    	pline("You drain the blood from %s.", buf);
 		otmp->odrained = 1;
@@ -2017,22 +2017,22 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 	    otmp->odrained = 0;
 
 	/* Very rotten corpse will make you sick unless you are a ghoul or a ghast or bound to Chupoclops */
-	if (mnum != PM_ACID_BLOB && !stoneable && rotted > 5L) {
-		boolean cannibal = maybe_cannibal(mnum, FALSE);
+	if (mtyp != PM_ACID_BLOB && !stoneable && rotted > 5L) {
+		boolean cannibal = maybe_cannibal(mtyp, FALSE);
 	    if (u.umonnum == PM_GHOUL) {
 	    	pline("Yum - that %s was well aged%s!",
-		      mons[mnum].mlet == S_PLANT ? "vegetation" :
-		      mons[mnum].mlet == S_FUNGUS ? "fungoid vegetation" :
-		      !vegetarian(&mons[mnum]) ? "meat" : "protoplasm",
+		      mons[mtyp].mlet == S_PLANT ? "vegetation" :
+		      mons[mtyp].mlet == S_FUNGUS ? "fungoid vegetation" :
+		      !vegetarian(&mons[mtyp]) ? "meat" : "protoplasm",
 		      cannibal ? ", cannibal" : "");
 	    } else if(u.sealsActive&SEAL_CHUPOCLOPS){
-		boolean cannibal = maybe_cannibal(mnum, FALSE);
+		boolean cannibal = maybe_cannibal(mtyp, FALSE);
 			pline("The corpse liquefies into a putrid broth, and you slurp it down%s!",
 			cannibal ? ", cannibal" : "");
 		} else {
 		pline("Ulch - that %s was tainted%s!",
-		      mons[mnum].mlet == S_FUNGUS ? "fungoid vegetation" :
-		      !vegetarian(&mons[mnum]) ? "meat" : "protoplasm",
+		      mons[mtyp].mlet == S_FUNGUS ? "fungoid vegetation" :
+		      !vegetarian(&mons[mtyp]) ? "meat" : "protoplasm",
 		      cannibal ? ", cannibal" : "");
 		if (Sick_resistance) {
 			pline("It doesn't seem at all sickening, though...");
@@ -2048,8 +2048,8 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 			    Sprintf(buf, "rotted %s", corpse_xname(otmp,TRUE));
 			else
 			    Sprintf(buf, "%s%s rotted corpse",
-				    !type_is_pname(&mons[mnum]) ? "the " : "",
-				    s_suffix(mons[mnum].mname));
+				    !type_is_pname(&mons[mtyp]) ? "the " : "",
+				    s_suffix(mons[mtyp].mname));
 			make_sick(sick_time, buf, TRUE, SICK_VOMITABLE);
 		}
 		if (carried(otmp)) useup(otmp);
@@ -2059,20 +2059,20 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 	} else if (youracedata == &mons[PM_GHOUL]) {
 		pline ("This corpse is too fresh!");
 		return 3;
-	} else if (acidic(&mons[mnum]) && !Acid_resistance) {
+	} else if (acidic(&mons[mtyp]) && !Acid_resistance) {
 		tp++;
 		You("have a very bad case of stomach acid."); /* not body_part() */
 		losehp(rnd(15), "acidic corpse", KILLED_BY_AN);
-	} if (freezing(&mons[mnum]) && !Cold_resistance) {
+	} if (freezing(&mons[mtyp]) && !Cold_resistance) {
 		tp++;
 		You("feel your stomach freeze!"); /* not body_part() */
 		roll_frigophobia();
 		losehp(rnd(12) + rnd(12), "cryonic corpse", KILLED_BY_AN);
-	} if (burning(&mons[mnum]) && !Fire_resistance) {
+	} if (burning(&mons[mtyp]) && !Fire_resistance) {
 		tp++;
 		You("feel your stomach boil!"); /* not body_part() */
 		losehp(rnd(20), "boiling hot corpse", KILLED_BY_AN);
-	} if (poisonous(&mons[mnum]) && rn2(5)) {
+	} if (poisonous(&mons[mtyp]) && rn2(5)) {
 		tp++;
 		pline("Ecch - that must have been poisonous!");
 		if(!Poison_resistance) {
@@ -2080,8 +2080,8 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 			losehp(rnd(15), "poisonous corpse", KILLED_BY_AN);
 		} else	You("seem unaffected by the poison.");
 	/* now any corpse left too long will make you mildly ill */
-	} if ( !(poisonous(&mons[mnum]) || burning(&mons[mnum]) ||
-			 freezing(&mons[mnum])  || acidic(&mons[mnum])) &&
+	} if ( !(poisonous(&mons[mtyp]) || burning(&mons[mtyp]) ||
+			 freezing(&mons[mtyp])  || acidic(&mons[mtyp])) &&
 			(rotted > 5L || (rotted > 3L && rn2(5)))
 					&& !(Sick_resistance || u.sealsActive&SEAL_CHUPOCLOPS)) {
 		tp++;
@@ -2090,11 +2090,11 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 	}
 
 	/* delay is weight dependent */
-	victual.reqtime = (u.sealsActive&SEAL_AHAZU) ? 1 : (3 + (mons[mnum].cwt >> 6));
+	victual.reqtime = (u.sealsActive&SEAL_AHAZU) ? 1 : (3 + (mons[mtyp].cwt >> 6));
 	if (otmp->odrained) victual.reqtime = (u.sealsActive&SEAL_AHAZU) ? 1 : rounddiv(victual.reqtime, 5);
 
-	if (!tp && mnum != PM_LIZARD && mnum != PM_SMALL_CAVE_LIZARD && mnum != PM_CAVE_LIZARD 
-		&& mnum != PM_LARGE_CAVE_LIZARD && mnum != PM_LICHEN && mnum != PM_BEHOLDER &&
+	if (!tp && mtyp != PM_LIZARD && mtyp != PM_SMALL_CAVE_LIZARD && mtyp != PM_CAVE_LIZARD 
+		&& mtyp != PM_LARGE_CAVE_LIZARD && mtyp != PM_LICHEN && mtyp != PM_BEHOLDER &&
 			(otmp->orotten || !rn2(7))) {
 	    if ( (monstermoves - peek_at_iced_corpse_age(otmp)) > 5 && rottenfood(otmp)) {
 		otmp->orotten = TRUE;
@@ -2114,21 +2114,21 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 				otmp->oeaten = drainlevel(otmp);
 		}
 	} else if (!is_vampire(youracedata)) {
-		if(is_rat(&mons[mnum]) && Race_if(PM_DWARF)){
+		if(is_rat(&mons[mtyp]) && Race_if(PM_DWARF)){
 			if(u.uconduct.ratseaten<SIZE(eatrat)) pline("%s", eatrat[u.uconduct.ratseaten++]);
 			else{
 				u.uconduct.ratseaten++;
 				pline("%s", eatrat[SIZE(eatrat)-1]);
 			}
-		} else if(mnum == PM_LONG_WORM){
+		} else if(mtyp == PM_LONG_WORM){
 			pline("This tastes spicy!");
-		} else if(mnum == PM_CROW){
+		} else if(mtyp == PM_CROW){
 			You("eat crow!");
 		} else {
 		    pline("%s%s %s!",
-			  !uniq ? "This " : !type_is_pname(&mons[mnum]) ? "The " : "",
+			  !uniq ? "This " : !type_is_pname(&mons[mtyp]) ? "The " : "",
 			  food_xname(otmp, FALSE),
-			  (vegan(&mons[mnum]) ?
+			  (vegan(&mons[mtyp]) ?
 			   (!(carnivorous(youracedata) || (uarmg && uarmg->oartifact == ART_GREAT_CLAWS_OF_URDLEN)) && herbivorous(youracedata)) :
 			   ((carnivorous(youracedata) || (uarmg && uarmg->oartifact == ART_GREAT_CLAWS_OF_URDLEN)) && !herbivorous(youracedata)))
 			  ? "is delicious" : "tastes terrible");
@@ -2703,7 +2703,7 @@ struct obj *otmp;
 	boolean cadaver = (otmp->otyp == CORPSE),
 		stoneorslime = FALSE;
 	int material = otmp->obj_material,
-	    mnum = otmp->corpsenm;
+	    mtyp = otmp->corpsenm;
 	long rotted = 0L;
 
 	Strcpy(foodsmell, Tobjnam(otmp, "smell"));
@@ -2713,16 +2713,16 @@ struct obj *otmp;
 
 	if (cadaver || otmp->otyp == EGG || otmp->otyp == TIN) {
 		/* These checks must match those in eatcorpse() */
-		stoneorslime = (touch_petrifies(&mons[mnum]) &&
+		stoneorslime = (touch_petrifies(&mons[mtyp]) &&
 				!Stone_resistance &&
 				!poly_when_stoned(youracedata));
 
-		if (mnum == PM_GREEN_SLIME || mnum == PM_FLUX_SLIME)
+		if (mtyp == PM_GREEN_SLIME || mtyp == PM_FLUX_SLIME)
 		    stoneorslime = (!Unchanging && !flaming(youracedata) &&
 			youracedata != &mons[PM_GREEN_SLIME]);
 
-		if (cadaver && mnum != PM_LIZARD && mnum != PM_SMALL_CAVE_LIZARD && mnum != PM_CAVE_LIZARD 
-		&& mnum != PM_LARGE_CAVE_LIZARD && mnum != PM_LICHEN && mnum != PM_BEHOLDER ) {
+		if (cadaver && mtyp != PM_LIZARD && mtyp != PM_SMALL_CAVE_LIZARD && mtyp != PM_CAVE_LIZARD 
+		&& mtyp != PM_LARGE_CAVE_LIZARD && mtyp != PM_LICHEN && mtyp != PM_BEHOLDER ) {
 			long age = peek_at_iced_corpse_age(otmp);
 			/* worst case rather than random
 			   in this calculation to force prompt */
@@ -2737,7 +2737,7 @@ struct obj *otmp;
 	 * order from most detrimental to least detrimental.
 	 */
 
-	if (cadaver && mnum != PM_ACID_BLOB && rotted > 5L && !(Sick_resistance || u.sealsActive&SEAL_CHUPOCLOPS)) {
+	if (cadaver && mtyp != PM_ACID_BLOB && rotted > 5L && !(Sick_resistance || u.sealsActive&SEAL_CHUPOCLOPS)) {
 		/* Tainted meat */
 		Sprintf(buf, "%s like %s could be tainted! %s",
 			foodsmell, it_or_they, eat_it_anyway);
@@ -2764,21 +2764,21 @@ struct obj *otmp;
 		if (yn_function(buf,ynchars,'n')=='n') return 1;
 		else return 2;
 	}
-	if (cadaver && poisonous(&mons[mnum]) && !Poison_resistance) {
+	if (cadaver && poisonous(&mons[mtyp]) && !Poison_resistance) {
 		/* poisonous */
 		Sprintf(buf, "%s like %s might be poisonous! %s",
 			foodsmell, it_or_they, eat_it_anyway);
 		if (yn_function(buf,ynchars,'n')=='n') return 1;
 		else return 2;
 	}
-	if (cadaver && !vegetarian(&mons[mnum]) &&
+	if (cadaver && !vegetarian(&mons[mtyp]) &&
 	    !u.uconduct.unvegetarian && Role_if(PM_MONK)) {
 		Sprintf(buf, "%s unhealthy. %s",
 			foodsmell, eat_it_anyway);
 		if (yn_function(buf,ynchars,'n')=='n') return 1;
 		else return 2;
 	}
-	if (cadaver && acidic(&mons[mnum]) && !Acid_resistance) {
+	if (cadaver && acidic(&mons[mtyp]) && !Acid_resistance) {
 		Sprintf(buf, "%s rather acidic. %s",
 			foodsmell, eat_it_anyway);
 		if (yn_function(buf,ynchars,'n')=='n') return 1;
@@ -2800,7 +2800,7 @@ struct obj *otmp;
 	    ((material == LEATHER || material == BONE ||
 	      material == EYEBALL || material == SEVERED_HAND ||
 	      material == DRAGON_HIDE || material == WAX) ||
-	     (cadaver && !vegan(&mons[mnum])))) {
+	     (cadaver && !vegan(&mons[mtyp])))) {
 		Sprintf(buf, "%s foul and unfamiliar to you. %s",
 			foodsmell, eat_it_anyway);
 		if (yn_function(buf,ynchars,'n')=='n') return 1;
@@ -2810,14 +2810,14 @@ struct obj *otmp;
 	    ((material == LEATHER || material == BONE ||
 	      material == EYEBALL || material == SEVERED_HAND ||
 	      material == DRAGON_HIDE) ||
-	     (cadaver && !vegetarian(&mons[mnum])))) {
+	     (cadaver && !vegetarian(&mons[mtyp])))) {
 		Sprintf(buf, "%s unfamiliar to you. %s",
 			foodsmell, eat_it_anyway);
 		if (yn_function(buf,ynchars,'n')=='n') return 1;
 		else return 2;
 	}
 
-	if (cadaver && mnum != PM_ACID_BLOB && rotted > 5L && (Sick_resistance || u.sealsActive&SEAL_CHUPOCLOPS)) {
+	if (cadaver && mtyp != PM_ACID_BLOB && rotted > 5L && (Sick_resistance || u.sealsActive&SEAL_CHUPOCLOPS)) {
 		/* Tainted meat with Sick_resistance */
 		Sprintf(buf, "%s like %s could be tainted! %s",
 			foodsmell, it_or_they, eat_it_anyway);

--- a/src/eat.c
+++ b/src/eat.c
@@ -212,7 +212,7 @@ register struct obj *obj;
 			(obj->obj_material == VEGGY || obj->obj_material == FLESH))); /*Processed foods only*/
 	
 	if (metallivorous(youracedata) && is_metallic(obj) &&
-	    (youracedata != &mons[PM_RUST_MONSTER] || is_rustprone(obj)))
+	    (youracedata->mtyp != PM_RUST_MONSTER || is_rustprone(obj)))
 		return TRUE;
 	if (u.umonnum == PM_GELATINOUS_CUBE && is_organic(obj) &&
 		/* [g.cubes can eat containers and retain all contents
@@ -753,7 +753,7 @@ BOOLEAN_P bld, nobadeffects;
 	    case PM_FLUX_SLIME:
 		if (!nobadeffects && !Slimed && !Unchanging 
 			&& !GoodHealth && !flaming(youracedata) 
-			&& youracedata != &mons[PM_GREEN_SLIME]
+			&& youracedata->mtyp != PM_GREEN_SLIME
 		) {
 		    You("don't feel very well.");
 		    Slimed = 10L;
@@ -823,9 +823,9 @@ struct monst *mon;
 	case PM_GREEN_SLIME:
 	case PM_FLUX_SLIME:
 	    if (!Unchanging && !GoodHealth &&
-				youracedata != &mons[PM_FIRE_VORTEX] &&
-			    youracedata != &mons[PM_FIRE_ELEMENTAL] &&
-			    youracedata != &mons[PM_GREEN_SLIME]) {
+				youracedata->mtyp != PM_FIRE_VORTEX &&
+			    youracedata->mtyp != PM_FIRE_ELEMENTAL &&
+			    youracedata->mtyp != PM_GREEN_SLIME) {
 		You("don't feel very well.");
 		Slimed = 10L;
 	    }
@@ -1000,14 +1000,14 @@ boolean drained;
 			chance = 0;//skip roll, give atribute.
 		break;
 		case POISON_RES:
-			if ((ptr == &mons[PM_KILLER_BEE] ||
-					ptr == &mons[PM_SCORPION]) && !rn2(4))
+			if ((ptr->mtyp == PM_KILLER_BEE ||
+					ptr->mtyp == PM_SCORPION) && !rn2(4))
 				chance = 1;
 			else
 				chance = 15;
 			break;
 		case DISPLACED:
-			chance = ptr == &mons[PM_SHIMMERING_DRAGON] ? 0 : 10;
+			chance = ptr->mtyp == PM_SHIMMERING_DRAGON ? 0 : 10;
 			break;
 		case TELEPORT:
 			chance = 10;
@@ -2056,7 +2056,7 @@ eatcorpse(otmp)		/* called when a corpse is selected as food */
 		else useupf(otmp, 1L);
 		return(2);
 	    }
-	} else if (youracedata == &mons[PM_GHOUL]) {
+	} else if (youracedata->mtyp == PM_GHOUL) {
 		pline ("This corpse is too fresh!");
 		return 3;
 	} else if (acidic(&mons[mtyp]) && !Acid_resistance) {
@@ -2719,7 +2719,7 @@ struct obj *otmp;
 
 		if (mtyp == PM_GREEN_SLIME || mtyp == PM_FLUX_SLIME)
 		    stoneorslime = (!Unchanging && !flaming(youracedata) &&
-			youracedata != &mons[PM_GREEN_SLIME]);
+			youracedata->mtyp != PM_GREEN_SLIME);
 
 		if (cadaver && mtyp != PM_LIZARD && mtyp != PM_SMALL_CAVE_LIZARD && mtyp != PM_CAVE_LIZARD 
 		&& mtyp != PM_LARGE_CAVE_LIZARD && mtyp != PM_LICHEN && mtyp != PM_BEHOLDER ) {
@@ -4593,7 +4593,7 @@ floorfood(verb,corpsecheck)	/* get food from floor or pack */
 		}
 	    }
 
-	    if (youracedata != &mons[PM_RUST_MONSTER] &&
+	    if (youracedata->mtyp != PM_RUST_MONSTER &&
 			!(uclockwork && u.clockworkUpgrades&SCRAP_MAW) &&
 		(gold = g_at(u.ux, u.uy)) != 0) {
 		if (gold->quan == 1L)

--- a/src/end.c
+++ b/src/end.c
@@ -1051,17 +1051,17 @@ die:
 		u.ugrave_arise = (NON_PM - 4);	/* statue instead of corpse */
 	    else if (u.ugrave_arise == NON_PM &&
 		     !(mvitals[u.umonnum].mvflags & G_NOCORPSE)) {
-		int mnum = u.umonnum;
+		int mtyp = u.umonnum;
 
 		if (!Upolyd) {
 		    /* Base corpse on race when not poly'd since original
 		     * u.umonnum is based on role, and all role monsters
 		     * are human.
 		     */
-		    mnum = (flags.female && urace.femalenum != NON_PM) ?
+		    mtyp = (flags.female && urace.femalenum != NON_PM) ?
 			urace.femalenum : urace.malenum;
 		}
-		corpse = mk_named_object(CORPSE, &mons[mnum],
+		corpse = mk_named_object(CORPSE, &mons[mtyp],
 				       u.ux, u.uy, plname);
 		Sprintf(pbuf, "%s, %s%s", plname,
 			killer_format == NO_KILLER_PREFIX ? "" :

--- a/src/end.c
+++ b/src/end.c
@@ -395,14 +395,14 @@ register struct monst *mtmp;
 	killer_format = KILLED_BY_AN;
 	/* "killed by the high priest of Crom" is okay, "killed by the high
 	   priest" alone isn't */
-	if ((mtmp->data->geno & G_UNIQ) != 0 && !( (mtmp->data == &mons[PM_HIGH_PRIEST] || 
-												mtmp->data == &mons[PM_ELDER_PRIEST]) && !mtmp->ispriest)) {
+	if ((mtmp->data->geno & G_UNIQ) != 0 && !( (mtmp->mtyp == PM_HIGH_PRIEST || 
+												mtmp->mtyp == PM_ELDER_PRIEST) && !mtmp->ispriest)) {
 	    if (!type_is_pname(mtmp->data))
 		Strcat(buf, "the ");
 	    killer_format = KILLED_BY;
 	}
 	/* _the_ <invisible> <distorted> ghost of Dudley */
-	if ((mtmp->data == &mons[PM_GHOST] || mtmp->data == &mons[PM_SHADE] || mtmp->data == &mons[PM_BROKEN_SHADOW]) && mtmp->mnamelth) {
+	if ((mtmp->mtyp == PM_GHOST || mtmp->mtyp == PM_SHADE || mtmp->mtyp == PM_BROKEN_SHADOW) && mtmp->mnamelth) {
 		Strcat(buf, "the ");
 		killer_format = KILLED_BY;
 	}
@@ -411,13 +411,13 @@ register struct monst *mtmp;
 	if (distorted)
 		Strcat(buf, "hallucinogen-distorted ");
 
-	if(mtmp->data == &mons[PM_GHOST]) {
+	if(mtmp->mtyp == PM_GHOST) {
 		Strcat(buf, "ghost");
 		if (mtmp->mnamelth) Sprintf(eos(buf), " of %s", NAME(mtmp));
-	} else if(mtmp->data == &mons[PM_BROKEN_SHADOW]) {
+	} else if(mtmp->mtyp == PM_BROKEN_SHADOW) {
 		Strcat(buf, "broken shadow");
 		if (mtmp->mnamelth) Sprintf(eos(buf), " of %s", NAME(mtmp));
-	} else if(mtmp->data == &mons[PM_SHADE]) {
+	} else if(mtmp->mtyp == PM_SHADE) {
 		Strcat(buf, "shade");
 		if (mtmp->mnamelth) Sprintf(eos(buf), " of %s", NAME(mtmp));
 	} else if(mtmp->isshk) {
@@ -445,43 +445,43 @@ register struct monst *mtmp;
 	if(!uclockwork && !uandroid && !nonliving(youracedata)){
 		if (mtmp->data->mlet == S_WRAITH)
 			u.ugrave_arise = PM_WRAITH;
-		else if (mtmp->data == &mons[PM_SHADE])
+		else if (mtmp->mtyp == PM_SHADE)
 			u.ugrave_arise = PM_SHADE;
-		else if (mtmp->data == &mons[PM_BROKEN_SHADOW])
+		else if (mtmp->mtyp == PM_BROKEN_SHADOW)
 			u.ugrave_arise = PM_BROKEN_SHADOW;
 		else if (mtmp->data->mlet == S_MUMMY && urace.mummynum != NON_PM)
 			u.ugrave_arise = urace.mummynum;
 		else if ((mtmp->data->mlet == S_VAMPIRE || mtmp->mfaction == VAMPIRIC) && (Race_if(PM_HUMAN) || Race_if(PM_INHERITOR)))
 			u.ugrave_arise = PM_VAMPIRE;
-		else if (mtmp->data == &mons[PM_GHOUL] || mtmp->data == &mons[PM_GNOLL_GHOUL])
+		else if (mtmp->mtyp == PM_GHOUL || mtmp->mtyp == PM_GNOLL_GHOUL)
 			u.ugrave_arise = PM_GHOUL;
-		else if (mtmp->data == &mons[PM_DREADBLOSSOM_SWARM])
+		else if (mtmp->mtyp == PM_DREADBLOSSOM_SWARM)
 			u.ugrave_arise = PM_DREADBLOSSOM_SWARM;
-		else if (mtmp->data == &mons[PM_DREAD_SERAPH] || mtmp->mfaction == SKELIFIED)
+		else if (mtmp->mtyp == PM_DREAD_SERAPH || mtmp->mfaction == SKELIFIED)
 			u.ugrave_arise = PM_SKELETON;
 		else if (mtmp->data->mlet == S_ZOMBIE || mtmp->mfaction == ZOMBIFIED)
 			u.ugrave_arise = PM_ZOMBIE;
-		else if (mtmp->data == &mons[PM_BAALPHEGOR] || mtmp->mfaction == CRYSTALFIED)
+		else if (mtmp->mtyp == PM_BAALPHEGOR || mtmp->mfaction == CRYSTALFIED)
 			u.ugrave_arise = PM_BAALPHEGOR;
 	} else if(uandroid){
-		if (mtmp->data == &mons[PM_BROKEN_SHADOW])
+		if (mtmp->mtyp == PM_BROKEN_SHADOW)
 			u.ugrave_arise = PM_BROKEN_SHADOW;
 		else if (mtmp->data->mlet == S_MUMMY && urace.mummynum != NON_PM)
 			u.ugrave_arise = urace.mummynum;
 		// else if (mtmp->data->mlet == S_VAMPIRE || mtmp->mfaction == VAMPIRIC)
 			// u.ugrave_arise = PM_VAMPIRIC_DOLL;
-		else if (mtmp->data == &mons[PM_DREAD_SERAPH] || mtmp->mfaction == SKELIFIED)
+		else if (mtmp->mtyp == PM_DREAD_SERAPH || mtmp->mfaction == SKELIFIED)
 			u.ugrave_arise = PM_FLAYED_ANDROID;
 		else if (mtmp->data->mlet == S_ZOMBIE || mtmp->mfaction == ZOMBIFIED)
 			u.ugrave_arise = PM_FLAYED_ANDROID;
-		else if (mtmp->data == &mons[PM_BAALPHEGOR] || mtmp->mfaction == CRYSTALFIED)
+		else if (mtmp->mtyp == PM_BAALPHEGOR || mtmp->mfaction == CRYSTALFIED)
 			u.ugrave_arise = PM_BAALPHEGOR;
 	} else { //clockwork or other nonliving
-		if (mtmp->data == &mons[PM_BROKEN_SHADOW])
+		if (mtmp->mtyp == PM_BROKEN_SHADOW)
 			u.ugrave_arise = PM_BROKEN_SHADOW;
-		else if (mtmp->data == &mons[PM_DREADBLOSSOM_SWARM] && !uclockwork && !is_naturally_unalive(youracedata))
+		else if (mtmp->mtyp == PM_DREADBLOSSOM_SWARM && !uclockwork && !is_naturally_unalive(youracedata))
 			u.ugrave_arise = PM_DREADBLOSSOM_SWARM;
-		else if (mtmp->data == &mons[PM_BAALPHEGOR] || mtmp->mfaction == CRYSTALFIED)
+		else if (mtmp->mtyp == PM_BAALPHEGOR || mtmp->mfaction == CRYSTALFIED)
 			u.ugrave_arise = PM_BAALPHEGOR;
 	}
 	if (u.ugrave_arise >= LOW_PM &&
@@ -1007,7 +1007,7 @@ die:
 	{
 		struct monst *mtmp;
 		for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
-			if(mtmp->data == &mons[PM_OONA] && mtmp->mtame)
+			if(mtmp->mtyp == PM_OONA && mtmp->mtame)
 				achieve.get_keys |= (1 << (ART_THIRD_KEY_OF_LAW - ART_FIRST_KEY_OF_LAW));
 				
 		}

--- a/src/exper.c
+++ b/src/exper.c
@@ -62,7 +62,7 @@ experience(mtmp, nk)	/* return # of exp points for mtmp after nk killed */
 	register struct permonst *ptr = mtmp->data;
 	int	i, tmp, tmp2;
 	
-	if(mtmp->data == &mons[PM_DANCING_BLADE] || mtmp->data == &mons[PM_LONG_SINUOUS_TENTACLE] || mtmp->data == &mons[PM_SWARM_OF_SNAKING_TENTACLES] || mtmp->data == &mons[PM_WIDE_CLUBBED_TENTACLE]) return 0;
+	if(mtmp->mtyp == PM_DANCING_BLADE || mtmp->mtyp == PM_LONG_SINUOUS_TENTACLE || mtmp->mtyp == PM_SWARM_OF_SNAKING_TENTACLES || mtmp->mtyp == PM_WIDE_CLUBBED_TENTACLE) return 0;
 	
 /*	Dungeon fern spores give no experience */
 	if(is_fern_spore(mtmp->data)) return 0;
@@ -116,7 +116,7 @@ experience(mtmp, nk)	/* return # of exp points for mtmp after nk killed */
 
 #ifdef MAIL
 	/* Mail daemons put up no fight. */
-	if(mtmp->data == &mons[PM_MAIL_DAEMON]) tmp = 1;
+	if(mtmp->mtyp == PM_MAIL_DAEMON) tmp = 1;
 #endif
 
 	return(tmp);
@@ -128,7 +128,7 @@ ptrexperience(ptr)	/* return # of exp points for mtmp after nk killed */
 {
 	int	i, tmp, tmp2;
 	
-	if(ptr == &mons[PM_DANCING_BLADE] || ptr == &mons[PM_LONG_SINUOUS_TENTACLE] || ptr == &mons[PM_SWARM_OF_SNAKING_TENTACLES] || ptr == &mons[PM_WIDE_CLUBBED_TENTACLE]) return 0;
+	if(ptr->mtyp == PM_DANCING_BLADE || ptr->mtyp == PM_LONG_SINUOUS_TENTACLE || ptr->mtyp == PM_SWARM_OF_SNAKING_TENTACLES || ptr->mtyp == PM_WIDE_CLUBBED_TENTACLE) return 0;
 	
 /*	Dungeon fern spores give no experience */
 	if(is_fern_spore(ptr)) return 0;
@@ -180,7 +180,7 @@ ptrexperience(ptr)	/* return # of exp points for mtmp after nk killed */
 
 #ifdef MAIL
 	/* Mail daemons put up no fight. */
-	if(ptr == &mons[PM_MAIL_DAEMON]) tmp = 1;
+	if(ptr->mtyp == PM_MAIL_DAEMON) tmp = 1;
 #endif
 
 	return(tmp);

--- a/src/explode.c
+++ b/src/explode.c
@@ -323,10 +323,10 @@ boolean yours; /* is it your fault (for killing monsters) */
 		    if (mtmp->mhp < 1) explmask = 2;
 		    else switch(adtyp) {
 			case AD_PHYS:
-				if(mtmp->data == &mons[PM_LICH__THE_FIEND_OF_EARTH] || 
-				   mtmp->data == &mons[PM_BURNING_FERN_SPROUT] ||
-				   mtmp->data == &mons[PM_BURNING_FERN] ||
-				   mtmp->data == &mons[PM_CHAOS]
+				if(mtmp->mtyp == PM_LICH__THE_FIEND_OF_EARTH || 
+				   mtmp->mtyp == PM_BURNING_FERN_SPROUT ||
+				   mtmp->mtyp == PM_BURNING_FERN ||
+				   mtmp->mtyp == PM_CHAOS
 				) explmask |= TRUE;
 				break;
 			case AD_MAGM:
@@ -510,10 +510,10 @@ boolean yours; /* is it your fault (for killing monsters) */
 			    mdam /= 6;
 			}
 			if(yours && (is_spider(mtmp->data) 
-				|| mtmp->data == &mons[PM_SPROW]
-				|| mtmp->data == &mons[PM_DRIDER]
-				|| mtmp->data == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-				|| mtmp->data == &mons[PM_AVATAR_OF_LOLTH]
+				|| mtmp->mtyp == PM_SPROW
+				|| mtmp->mtyp == PM_DRIDER
+				|| mtmp->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+				|| mtmp->mtyp == PM_AVATAR_OF_LOLTH
 			) && roll_madness(MAD_ARACHNOPHOBIA)){
 			    mdam /= 4;
 			}

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -157,8 +157,8 @@ boolean isyou;
 			/* Warn about future fountain use. */
 			for(mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 			    if (DEADMONSTER(mtmp)) continue;
-			    if ((mtmp->data == &mons[PM_WATCHMAN] ||
-				mtmp->data == &mons[PM_WATCH_CAPTAIN]) &&
+			    if ((mtmp->mtyp == PM_WATCHMAN ||
+				mtmp->mtyp == PM_WATCH_CAPTAIN) &&
 			       couldsee(mtmp->mx, mtmp->my) &&
 			       mtmp->mpeaceful) {
 				pline("%s yells:", Amonnam(mtmp));

--- a/src/hack.c
+++ b/src/hack.c
@@ -614,7 +614,7 @@ int mode;
 			dmgtype(youracedata, AD_CORR))) {
 			You("eat through the bars.");
 			dissolve_bars(x,y);
-			if(youracedata == &mons[PM_RUST_MONSTER])
+			if(youracedata->mtyp == PM_RUST_MONSTER)
 				lesshungry(objects[BAR].oc_nutrition);
 	    }
 	    if (!(Passes_walls || passes_bars(&youmonst)))
@@ -1508,7 +1508,7 @@ domove()
 		    break;
 		case 2:
 		    u.uconduct.killer++;
-			if(mtmp->data == &mons[PM_CROW] && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
+			if(mtmp->mtyp == PM_CROW && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
 		    break;
 	    }
 	}
@@ -1593,7 +1593,7 @@ domove()
 		     * minliquid and mintrap don't know to do this
 		     */
 		    u.uconduct.killer++;
-			if(mtmp->data == &mons[PM_CROW] && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
+			if(mtmp->mtyp == PM_CROW && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
 		    break;
 		default:
 		    pline("that's strange, unknown mintrap result!");

--- a/src/invent.c
+++ b/src/invent.c
@@ -994,7 +994,7 @@ register const char *let,*word;
 	/* Equivalent of an "ugly check" for gold */
 	if (usegold && !strcmp(word, "eat") &&
 	    (!metallivorous(youracedata)
-	     || youracedata == &mons[PM_RUST_MONSTER]))
+	     || youracedata->mtyp == PM_RUST_MONSTER))
 #ifndef GOLDOBJ
 		usegold = allowgold = FALSE;
 #else

--- a/src/lock.c
+++ b/src/lock.c
@@ -497,7 +497,7 @@ pick_lock(pick) /* pick a lock with a given object */
 			&& mtmp->m_ap_type != M_AP_OBJECT) {
 #ifdef TOURIST
 		if (picktyp == CREDIT_CARD &&
-		    (mtmp->isshk || mtmp->data == &mons[PM_ORACLE]))
+		    (mtmp->isshk || mtmp->mtyp == PM_ORACLE))
 		    verbalize("No checks, no credit, no problem.");
 		else
 #endif
@@ -711,7 +711,7 @@ doforce()		/* try to force a chest with your weapon */
 			&& mtmp->m_ap_type != M_AP_FURNITURE
 			&& mtmp->m_ap_type != M_AP_OBJECT) {
 
-		if (mtmp->isshk || mtmp->data == &mons[PM_ORACLE])		
+		if (mtmp->isshk || mtmp->mtyp == PM_ORACLE)		
 		    verbalize("What do you think you are, a Jedi?"); /* Phantom Menace */
 		else
 		    pline("I don't think %s would appreciate that.", mon_nam(mtmp));

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -7492,7 +7492,7 @@ register int	mmflags;
 	mtmp->mblinded = mtmp->mfrozen = mtmp->mlaughing = 0;
 	mtmp->mvar1 = mtmp->mvar2 = mtmp->mvar3 = 0;
 	mtmp->mtyp = mndx;
-	set_mon_data(mtmp, mndx, 0);
+	set_mon_data(mtmp, mndx);
 	
 	mtmp->mstr = d(3,6);
 	if(strongmonst(mtmp->data)) mtmp->mstr += 10;
@@ -9633,11 +9633,11 @@ struct monst *mtmp, *victim;
 		    pline("As %s grows up into %s, %s %s!", mon_nam(mtmp),
 			an(ptr->mname), mhe(mtmp),
 			nonliving_mon(mtmp) ? "expires" : "dies");
-		set_mon_data(mtmp, newtype, -1);	/* keep mvitals[] accurate */
+		set_mon_data(mtmp, newtype);	/* keep mvitals[] accurate */
 		mondied(mtmp);
 		return (struct permonst *)0;
 	    }
-		set_mon_data(mtmp, newtype, 1);	/* preserve intrinsics */
+		set_mon_data(mtmp, newtype);	/* preserve intrinsics */
 	    newsym(mtmp->mx, mtmp->my);		/* color may change */
 	    lev_limit = (int)mtmp->m_lev;	/* never undo increment */
 		if(newtype == PM_METROID_QUEEN && mtmp->mtame){

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -7491,7 +7491,7 @@ register int	mmflags;
 	mtmp->mcansee = mtmp->mcanhear = mtmp->mcanmove = mtmp->mnotlaugh = TRUE;
 	mtmp->mblinded = mtmp->mfrozen = mtmp->mlaughing = 0;
 	mtmp->mvar1 = mtmp->mvar2 = mtmp->mvar3 = 0;
-	set_mon_data(mtmp, ptr, 0);
+	set_mon_data(mtmp, mndx, 0);
 	
 	mtmp->mstr = d(3,6);
 	if(strongmonst(mtmp->data)) mtmp->mstr += 10;
@@ -9633,11 +9633,11 @@ struct monst *mtmp, *victim;
 		    pline("As %s grows up into %s, %s %s!", mon_nam(mtmp),
 			an(ptr->mname), mhe(mtmp),
 			nonliving_mon(mtmp) ? "expires" : "dies");
-		set_mon_data(mtmp, ptr, -1);	/* keep mvitals[] accurate */
+		set_mon_data(mtmp, newtype, -1);	/* keep mvitals[] accurate */
 		mondied(mtmp);
 		return (struct permonst *)0;
 	    }
-	    set_mon_data(mtmp, ptr, 1);		/* preserve intrinsics */
+		set_mon_data(mtmp, newtype, 1);	/* preserve intrinsics */
 	    newsym(mtmp->mx, mtmp->my);		/* color may change */
 	    lev_limit = (int)mtmp->m_lev;	/* never undo increment */
 		if(newtype == PM_METROID_QUEEN && mtmp->mtame){

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -7552,7 +7552,7 @@ register int	mmflags;
 	if (ptr == &mons[urole.ldrnum])
 	    quest_status.leader_m_id = mtmp->m_id;
 	mtmp->mxlth = xlth;
-	mtmp->mnum = mndx;
+	mtmp->mtyp = mndx;
 	mtmp->m_lev = adj_lev(ptr);
 	float sanlev = ((float)rand()/(float)(RAND_MAX)) * ((float)rand()/(float)(RAND_MAX));
 	mtmp->m_san_level = max(1, (int)(sanlev*100));

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -240,7 +240,7 @@ register struct monst *mtmp;
 #ifdef REINCARNATION
 	if (Is_rogue_level(&u.uz)) return;
 #endif
-	if(mtmp->data == &mons[PM_BLESSED]){
+	if(mtmp->mtyp == PM_BLESSED){
 		//The blessed don't start with weapons.
 		return;
 	}
@@ -661,7 +661,7 @@ register struct monst *mtmp;
 				otmp = oname(otmp, artiname(ART_PROFANED_GREATSCYTHE));
 				fix_object(otmp);
 				(void) mpickobj(mtmp,otmp);
-			} else if(ptr == &mons[PM_CORVIAN_KNIGHT]) {
+			} else if(ptr->mtyp == PM_CORVIAN_KNIGHT) {
 				//Note: monster inventories are last-in-first-out, so the offhand weapon needs to be first
 				switch(rnd(8)){
 					case 1:
@@ -747,7 +747,7 @@ register struct monst *mtmp;
 				otmp->bodytypeflag = MB_LONGHEAD;
 				fix_object(otmp);
 				(void) mpickobj(mtmp,otmp);
-			} else if(ptr == &mons[PM_SHATTERED_ZIGGURAT_CULTIST]) {
+			} else if(ptr->mtyp == PM_SHATTERED_ZIGGURAT_CULTIST) {
 			    otmp = mksobj(TORCH, FALSE, FALSE);
 				otmp->age = (long) rn1(500,1000);
 			    (void) mpickobj(mtmp, otmp);
@@ -755,7 +755,7 @@ register struct monst *mtmp;
 				(void)mongets(mtmp, WHITE_FACELESS_ROBE);
 				(void)mongets(mtmp, LOW_BOOTS);
 			}
-			else if(ptr == &mons[PM_SHATTERED_ZIGGURAT_KNIGHT]) {
+			else if(ptr->mtyp == PM_SHATTERED_ZIGGURAT_KNIGHT) {
 			    otmp = mksobj(SHADOWLANDER_S_TORCH, FALSE, FALSE);
 			    (void) mpickobj(mtmp, otmp);
 				otmp->age = (long) rn1(500,1000);
@@ -766,7 +766,7 @@ register struct monst *mtmp;
 				(void)mongets(mtmp, GLOVES);
 				(void)mongets(mtmp, HIGH_BOOTS);
 			}
-			else if(ptr == &mons[PM_SHATTERED_ZIGGURAT_WIZARD]) {
+			else if(ptr->mtyp == PM_SHATTERED_ZIGGURAT_WIZARD) {
 			    otmp = mksobj(SHADOWLANDER_S_TORCH, FALSE, FALSE);
 				otmp->spe = rnd(3);
 				otmp->age = (long) rn1(1000,2000);
@@ -778,7 +778,7 @@ register struct monst *mtmp;
 				(void)mongets(mtmp, GLOVES);
 				(void)mongets(mtmp, HIGH_BOOTS);
 			}
-			else if(ptr == &mons[PM_AZTEC_WARRIOR]) {
+			else if(ptr->mtyp == PM_AZTEC_WARRIOR) {
 			    otmp = mksobj(TORCH, FALSE, FALSE);
 				otmp->age = (long) rn1(500,1000);
 			    (void) mpickobj(mtmp, otmp);
@@ -792,7 +792,7 @@ register struct monst *mtmp;
 				(void) mpickobj(mtmp,otmp);
 
 			}
-			else if(ptr == &mons[PM_AZTEC_SPEARTHROWER]) {
+			else if(ptr->mtyp == PM_AZTEC_SPEARTHROWER) {
 			    otmp = mksobj(TORCH, FALSE, FALSE);
 				otmp->age = (long) rn1(500,1000);
 			    (void) mpickobj(mtmp, otmp);
@@ -807,7 +807,7 @@ register struct monst *mtmp;
 				otmp->obj_material = WOOD;
 				(void) mpickobj(mtmp,otmp);
 			}
-			else if(ptr == &mons[PM_AZTEC_PRIEST]) {
+			else if(ptr->mtyp == PM_AZTEC_PRIEST) {
 			    otmp = mksobj(TORCH, FALSE, FALSE);
 				otmp->spe = rnd(3);
 				otmp->age = (long) rn1(1000,2000);
@@ -1385,7 +1385,7 @@ register struct monst *mtmp;
 					(void)mongets(mtmp, DROVEN_CROSSBOW);
 					m_initthrow(mtmp, DROVEN_BOLT, 24);
 				}
-			} else if (is_elf(ptr) && ptr != &mons[PM_HALF_ELF_RANGER]) {
+			} else if (is_elf(ptr) && ptr->mtyp != PM_HALF_ELF_RANGER) {
 				if(mm == PM_GALADRIEL){
 					/*Dress*/
 					otmp = mksobj(ELVEN_TOGA, TRUE, FALSE);
@@ -1635,7 +1635,7 @@ register struct monst *mtmp;
 				if(!rn2(2)) curse(otmp);
 				(void) mpickobj(mtmp, otmp);
 				}
-			} else if(ptr == &mons[PM_APPRENTICE_WITCH]){
+			} else if(ptr->mtyp == PM_APPRENTICE_WITCH){
 				struct monst *familliar;
 				familliar = makemon(&mons[PM_WITCH_S_FAMILIAR], mtmp->mx, mtmp->my, MM_ADJACENTOK|MM_NOCOUNTBIRTH);
 				if(familliar){
@@ -1649,7 +1649,7 @@ register struct monst *mtmp;
 				mongets(mtmp, BLACK_DRESS);
 				mongets(mtmp, WITCH_HAT);
 				mongets(mtmp, KNIFE);
-			} else if(ptr == &mons[PM_WITCH]){
+			} else if(ptr->mtyp == PM_WITCH){
 				struct monst *familliar;
 				familliar = makemon(&mons[PM_WITCH_S_FAMILIAR], mtmp->mx, mtmp->my, MM_ADJACENTOK|MM_NOCOUNTBIRTH);
 				if(familliar){
@@ -1665,7 +1665,7 @@ register struct monst *mtmp;
 				mongets(mtmp, GLOVES);
 				mongets(mtmp, WITCH_HAT);
 				mongets(mtmp, rn2(10) ? STILETTO : ATHAME);
-			} else if(ptr == &mons[PM_COVEN_LEADER]){
+			} else if(ptr->mtyp == PM_COVEN_LEADER){
 				struct monst *familliar;
 				familliar = makemon(&mons[PM_WITCH_S_FAMILIAR], mtmp->mx, mtmp->my, MM_ADJACENTOK|MM_NOCOUNTBIRTH);
 				if(familliar){
@@ -2398,7 +2398,7 @@ register struct monst *mtmp;
 			}
 		break;}
 	    case S_NEU_OUTSIDER:{
-			if(ptr == &mons[PM_PLUMACH_RILMANI]){
+			if(ptr->mtyp == PM_PLUMACH_RILMANI){
 				if(!rn2(3)) otmp = mksobj(MACE, TRUE, FALSE);
 				else otmp = mksobj(rn2(3) ? AXE : rn2(3) ? SICKLE : SCYTHE, TRUE, FALSE);
 			    otmp->cursed = 0;
@@ -2416,7 +2416,7 @@ register struct monst *mtmp;
 					(void) mpickobj(mtmp, otmp);
 				}
 			}
-			if(ptr == &mons[PM_FERRUMACH_RILMANI]){
+			if(ptr->mtyp == PM_FERRUMACH_RILMANI){
 				otmp = mksobj(rn2(2) ? HALBERD : BATTLE_AXE, TRUE, FALSE);
 				otmp->cursed = 0;
 				otmp->blessed = 0;
@@ -2425,7 +2425,7 @@ register struct monst *mtmp;
 				fix_object(otmp);
 				(void) mpickobj(mtmp, otmp);
 			}
-			if(ptr == &mons[PM_STANNUMACH_RILMANI]){
+			if(ptr->mtyp == PM_STANNUMACH_RILMANI){
 				otmp = mksobj(KHAKKHARA, TRUE, FALSE);
 				otmp->cursed = 0;
 				otmp->blessed = 0;
@@ -2434,7 +2434,7 @@ register struct monst *mtmp;
 				fix_object(otmp);
 				(void) mpickobj(mtmp, otmp);
 			}
-			if(ptr == &mons[PM_CUPRILACH_RILMANI]){
+			if(ptr->mtyp == PM_CUPRILACH_RILMANI){
 				otmp = mksobj(SHORT_SWORD, TRUE, FALSE);
 				otmp->cursed = 0;
 				otmp->blessed = 0;
@@ -2460,7 +2460,7 @@ register struct monst *mtmp;
 					(void) mpickobj(mtmp, otmp);
 				}
 			}
-			if(ptr == &mons[PM_ARGENACH_RILMANI]){
+			if(ptr->mtyp == PM_ARGENACH_RILMANI){
 				otmp = mksobj(rn2(3) ? BROADSWORD : rn2(3) ? BATTLE_AXE : HALBERD, TRUE, FALSE);
 			    otmp->cursed = 0;
 			    otmp->blessed = 0;
@@ -2478,7 +2478,7 @@ register struct monst *mtmp;
 					(void) mpickobj(mtmp, otmp);
 				}
 			}
-			if(ptr == &mons[PM_HYDRARGYRUMACH_RILMANI]){
+			if(ptr->mtyp == PM_HYDRARGYRUMACH_RILMANI){
 				otmp = mksobj(VOULGE, TRUE, FALSE);
 			    otmp->cursed = 0;
 			    otmp->blessed = 0;
@@ -2492,7 +2492,7 @@ register struct monst *mtmp;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
 			}
-			if(ptr == &mons[PM_AURUMACH_RILMANI]){
+			if(ptr->mtyp == PM_AURUMACH_RILMANI){
 				otmp = mksobj(HALBERD, TRUE, FALSE);
 				otmp->objsize = MZ_LARGE;
 			    otmp->cursed = 0;
@@ -2523,7 +2523,7 @@ register struct monst *mtmp;
 					(void) mpickobj(mtmp, otmp);
 				}
 			}
-			if(ptr == &mons[PM_CENTER_OF_ALL]){
+			if(ptr->mtyp == PM_CENTER_OF_ALL){
 				struct obj *otmp = mksobj(BARDICHE, TRUE, FALSE);
 				otmp->objsize = MZ_LARGE;
 				otmp->blessed = FALSE;
@@ -2569,7 +2569,7 @@ register struct monst *mtmp;
 				otmp->oproperties = OPROP_CONC;
 				(void) mpickobj(mtmp, otmp);
 			}
-			if(ptr == &mons[PM_AMM_KAMEREL]){
+			if(ptr->mtyp == PM_AMM_KAMEREL){
 				if(rn2(10)){//Physical fighter, no magic
 					mtmp->mcan = 1;
 					if(rn2(10)){//Warrior
@@ -2719,19 +2719,19 @@ register struct monst *mtmp;
 					}
 				}
 			}
-			if(ptr == &mons[PM_HUDOR_KAMEREL]){
+			if(ptr->mtyp == PM_HUDOR_KAMEREL){
 				otmp = mksobj(MIRROR, FALSE, FALSE);
 				otmp->obj_material = GLASS;
 				fix_object(otmp);
 				(void) mpickobj(mtmp, otmp);
 			}
-			if(ptr == &mons[PM_SHARAB_KAMEREL]){
+			if(ptr->mtyp == PM_SHARAB_KAMEREL){
 				otmp = mksobj(MIRROR, FALSE, FALSE);
 				otmp->obj_material = GLASS;
 				fix_object(otmp);
 				(void) mpickobj(mtmp, otmp);
 			}
-			if(ptr == &mons[PM_ARA_KAMEREL]){
+			if(ptr->mtyp == PM_ARA_KAMEREL){
 				otmp = mksobj(KAMEREL_VAJRA, FALSE, FALSE);
 				otmp->obj_material = GOLD;
 				fix_object(otmp);
@@ -2758,7 +2758,7 @@ register struct monst *mtmp;
 				mtmp->entangled = SHACKLES;
 				return;
 			}
-/*			if(ptr == &mons[PM_DESTROYER]){
+/*			if(ptr->mtyp == PM_DESTROYER){
 				struct obj *otmp = mksobj(BROADSWORD, TRUE, FALSE);
 				otmp->blessed = FALSE;
 				otmp->cursed = TRUE;
@@ -2790,7 +2790,7 @@ register struct monst *mtmp;
 				return;
 
 			}
-			else if(ptr == &mons[PM_DANCER]){
+			else if(ptr->mtyp == PM_DANCER){
 				struct obj *otmp = mksobj(STILETTO, TRUE, FALSE);
 				otmp->blessed = FALSE;
 				otmp->cursed = TRUE;
@@ -2812,11 +2812,11 @@ register struct monst *mtmp;
 
 			}
 */
-			if(ptr == &mons[PM_ARCADIAN_AVENGER]){
+			if(ptr->mtyp == PM_ARCADIAN_AVENGER){
 				(void)mongets(mtmp, SHORT_SWORD);
 				(void)mongets(mtmp, SHORT_SWORD);
 				return;//no random stuff
-			} else if(ptr == &mons[PM_JUSTICE_ARCHON]){
+			} else if(ptr->mtyp == PM_JUSTICE_ARCHON){
 				otmp = mksobj(GENTLEWOMAN_S_DRESS, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->oerodeproof = TRUE;
@@ -2849,9 +2849,9 @@ register struct monst *mtmp;
 			    otmp->oerodeproof = TRUE;
 			    (void) mpickobj(mtmp, otmp);
 				
-			} else if(ptr == &mons[PM_SWORD_ARCHON]){
+			} else if(ptr->mtyp == PM_SWORD_ARCHON){
 					//Nothing
-			} else if(ptr == &mons[PM_SHIELD_ARCHON]){
+			} else if(ptr->mtyp == PM_SHIELD_ARCHON){
 				otmp = mksobj(SCALE_MAIL, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->oerodeproof = TRUE;
@@ -2892,7 +2892,7 @@ register struct monst *mtmp;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
 				
-			} else if(ptr == &mons[PM_TRUMPET_ARCHON]){
+			} else if(ptr->mtyp == PM_TRUMPET_ARCHON){
 				otmp = mksobj(CLOAK, FALSE, FALSE);
 			    bless(otmp);
 				otmp->spe = 3;
@@ -2917,7 +2917,7 @@ register struct monst *mtmp;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
 				
-			} else if(ptr == &mons[PM_THRONE_ARCHON]){
+			} else if(ptr->mtyp == PM_THRONE_ARCHON){
 				int artnum = rn2(8);
 	
 			    /* create minion stuff; can't use mongets */
@@ -2969,7 +2969,7 @@ register struct monst *mtmp;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
 				
-			} else if(ptr == &mons[PM_LIGHT_ARCHON]){
+			} else if(ptr->mtyp == PM_LIGHT_ARCHON){
 				int artnum = rn2(8);
 	
 			    /* create minion stuff; can't use mongets */
@@ -3022,14 +3022,14 @@ register struct monst *mtmp;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
 				
-			} else if(ptr == &mons[PM_MONADIC_DEVA]){
+			} else if(ptr->mtyp == PM_MONADIC_DEVA){
 				otmp = mksobj(TWO_HANDED_SWORD, FALSE, FALSE);
 			    bless(otmp);
 				spe2 = rn2(4);
 			    otmp->oerodeproof = TRUE;
 			    otmp->spe = max(otmp->spe, spe2);
 			    (void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_MOVANIC_DEVA]){
+			} else if(ptr->mtyp == PM_MOVANIC_DEVA){
 				otmp = mksobj(MORNING_STAR, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->oerodeproof = TRUE;
@@ -3042,7 +3042,7 @@ register struct monst *mtmp;
 			    otmp->spe = 0;
 			    (void) mpickobj(mtmp, otmp);
 				(void)mongets(mtmp, ROBE);
-			} else if(ptr == &mons[PM_ASTRAL_DEVA]){
+			} else if(ptr->mtyp == PM_ASTRAL_DEVA){
 				otmp = mksobj(MACE, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->oerodeproof = TRUE;
@@ -3053,7 +3053,7 @@ register struct monst *mtmp;
 			    otmp->oerodeproof = TRUE;
 			    otmp->spe = 7;
 			    (void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_GRAHA_DEVA]){
+			} else if(ptr->mtyp == PM_GRAHA_DEVA){
 				otmp = mksobj(TWO_HANDED_SWORD, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->obj_material = COPPER;
@@ -3083,7 +3083,7 @@ register struct monst *mtmp;
 			    otmp->spe = 1;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_SURYA_DEVA]){
+			} else if(ptr->mtyp == PM_SURYA_DEVA){
 				struct monst *dancer;
 				dancer = makemon(&mons[PM_DANCING_BLADE], mtmp->mx, mtmp->my, MM_ADJACENTOK|MM_NOCOUNTBIRTH);
 				if(dancer){
@@ -3118,7 +3118,7 @@ register struct monst *mtmp;
 				otmp->objsize = MZ_LARGE;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_MAHADEVA]){
+			} else if(ptr->mtyp == PM_MAHADEVA){
 				otmp = mksobj(SCIMITAR, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->oerodeproof = TRUE;
@@ -3154,7 +3154,7 @@ register struct monst *mtmp;
 				otmp->objsize = MZ_LARGE;
 				fix_object(otmp);
 			    (void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_COURE_ELADRIN]){
+			} else if(ptr->mtyp == PM_COURE_ELADRIN){
 				(void)mongets(mtmp, GLOVES);
 				(void)mongets(mtmp, JACKET);
 				(void)mongets(mtmp, LOW_BOOTS);
@@ -3176,14 +3176,14 @@ register struct monst *mtmp;
 					(void)mongets(mtmp, MOON_AXE);
 					break;
 				}
-			} else if(ptr == &mons[PM_NOVIERE_ELADRIN]){
+			} else if(ptr->mtyp == PM_NOVIERE_ELADRIN){
 				(void)mongets(mtmp, GLOVES);
 				(void)mongets(mtmp, JACKET);
 				(void)mongets(mtmp, LOW_BOOTS);
 				(void)mongets(mtmp, LEATHER_HELM);
 				(void)mongets(mtmp, ELVEN_SPEAR);
 				(void)mongets(mtmp, rn2(2) ? ELVEN_SICKLE : RAPIER);
-			} else if(ptr == &mons[PM_BRALANI_ELADRIN]){
+			} else if(ptr->mtyp == PM_BRALANI_ELADRIN){
 				(void)mongets(mtmp, CHAIN_MAIL);
 				(void)mongets(mtmp, CLOAK);
 				(void)mongets(mtmp, HIGH_BOOTS);
@@ -3191,7 +3191,7 @@ register struct monst *mtmp;
 				(void)mongets(mtmp, DWARVISH_SPEAR);
 				(void)mongets(mtmp, DWARVISH_SPEAR);
 				(void)mongets(mtmp, DWARVISH_SHORT_SWORD);
-			} else if(ptr == &mons[PM_FIRRE_ELADRIN]){
+			} else if(ptr->mtyp == PM_FIRRE_ELADRIN){
 				(void)mongets(mtmp, ELVEN_MITHRIL_COAT);
 				(void)mongets(mtmp, ELVEN_SHIELD);
 				(void)mongets(mtmp, ELVEN_CLOAK);
@@ -3199,13 +3199,13 @@ register struct monst *mtmp;
 				(void)mongets(mtmp, ELVEN_HELM);
 				(void)mongets(mtmp, ELVEN_SPEAR);
 				(void)mongets(mtmp, ELVEN_BROADSWORD);
-			} else if(ptr == &mons[PM_SHIERE_ELADRIN]){
+			} else if(ptr->mtyp == PM_SHIERE_ELADRIN){
 				(void)mongets(mtmp, CRYSTAL_PLATE_MAIL);
 				(void)mongets(mtmp, CRYSTAL_SHIELD);
 				(void)mongets(mtmp, CRYSTAL_BOOTS);
 				(void)mongets(mtmp, CRYSTAL_SWORD);
 				(void)mongets(mtmp, WAN_STRIKING);
-			} else if(ptr == &mons[PM_GHAELE_ELADRIN]){
+			} else if(ptr->mtyp == PM_GHAELE_ELADRIN){
 				(void)mongets(mtmp, ARCHAIC_PLATE_MAIL);
 				(void)mongets(mtmp, ROUNDSHIELD);
 				(void)mongets(mtmp, ARCHAIC_BOOTS);
@@ -3213,13 +3213,13 @@ register struct monst *mtmp;
 				otmp = mksobj(LONG_SWORD, TRUE, FALSE);
 				otmp->obj_material = COPPER;
 			    (void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_TULANI_ELADRIN]){
+			} else if(ptr->mtyp == PM_TULANI_ELADRIN){
 				(void)mongets(mtmp, CRYSTAL_PLATE_MAIL);
 				(void)mongets(mtmp, ELVEN_CLOAK);
 				(void)mongets(mtmp, CRYSTAL_BOOTS);
 				(void)mongets(mtmp, CRYSTAL_GAUNTLETS);
 				(void)mongets(mtmp, CRYSTAL_HELM);
-			} else if(ptr == &mons[PM_GAE_ELADRIN]){
+			} else if(ptr->mtyp == PM_GAE_ELADRIN){
 				switch(rnd(5)){
 					case 1:
 					otmp = mksobj(CRYSTAL_PLATE_MAIL, TRUE, FALSE);
@@ -3290,7 +3290,7 @@ register struct monst *mtmp;
 					case 5:
 					break;
 				}
-			} else if(ptr == &mons[PM_POLYPOID_BEING]){
+			} else if(ptr->mtyp == PM_POLYPOID_BEING){
 				int masktypes[] = {PM_ELVENKING, PM_ELVENQUEEN, PM_ALABASTER_ELF_ELDER, PM_GROVE_GUARDIAN, 
 								   PM_TULANI_ELADRIN, PM_GAE_ELADRIN, PM_LILLEND, 
 								   PM_DARK_YOUNG, PM_GOAT_SPAWN, PM_TITAN};
@@ -3303,11 +3303,11 @@ register struct monst *mtmp;
 					bless(otmp);
 					(void) mpickobj(mtmp, otmp);
 				}
-			} else if(ptr == &mons[PM_GWYNHARWYF]){
+			} else if(ptr->mtyp == PM_GWYNHARWYF){
 				(void)mongets(mtmp, CLOAK);
 				(void)mongets(mtmp, HIGH_BOOTS);
 				(void)mongets(mtmp, SCIMITAR);
-			} else if(ptr == &mons[PM_OONA]){
+			} else if(ptr->mtyp == PM_OONA){
 					//Note: Adjustments to how Oona's melee attacks were handled made her very weak without a weapon
 					//Also note: monster inventories are last-in-first-out, and oproperty weapons are favored, so the offhand weapon needs to be first
 					otmp = mksobj(STILETTO, FALSE, FALSE);
@@ -3348,7 +3348,7 @@ register struct monst *mtmp;
 					otmp->obj_material = METAL;
 					fix_object(otmp);
 					(void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_LILLEND]){
+			} else if(ptr->mtyp == PM_LILLEND){
 				(void)mongets(mtmp, MASK);
 				(void)mongets(mtmp, MASK);
 				(void)mongets(mtmp, MASK);
@@ -4406,7 +4406,7 @@ register struct monst *mtmp;
 		}
 		break;
 	    case S_KOBOLD:
-		if(ptr == &mons[PM_GREAT_HIGH_SHAMAN_OF_KURTULMAK]){
+		if(ptr->mtyp == PM_GREAT_HIGH_SHAMAN_OF_KURTULMAK){
 			(void)mongets(mtmp, CLOAK_OF_MAGIC_RESISTANCE);
 			(void)mongets(mtmp, SHORT_SWORD);
 			(void)mongets(mtmp, BUCKLER);
@@ -4419,7 +4419,7 @@ register struct monst *mtmp;
 		}
 		break;
 	    case S_NYMPH:
-			if(ptr == &mons[PM_THRIAE] || ptr == &mons[PM_OCEANID] || ptr == &mons[PM_SELKIE]){
+			if(ptr->mtyp == PM_THRIAE || ptr->mtyp == PM_OCEANID || ptr->mtyp == PM_SELKIE){
 				switch (rn2(6)) {
 				/* MAJOR fall through ... */
 				case 0: (void) mongets(mtmp, WAN_MAGIC_MISSILE);
@@ -4430,13 +4430,13 @@ register struct monst *mtmp;
 				case 4: (void) mongets(mtmp, POT_HEALING);
 				case 5: (void) mongets(mtmp, POT_EXTRA_HEALING);
 				}
-				if(ptr == &mons[PM_OCEANID]){
+				if(ptr->mtyp == PM_OCEANID){
 					(void)mongets(mtmp, POT_OBJECT_DETECTION);
 					(void)mongets(mtmp, MIRROR);
 				}
-				if(ptr == &mons[PM_THRIAE])
+				if(ptr->mtyp == PM_THRIAE)
 				(void)mongets(mtmp, (rn2(2) ? FLUTE : HARP));
-			} else if(ptr == &mons[PM_INTONER]){
+			} else if(ptr->mtyp == PM_INTONER){
 				switch(rn2(6)){
 					case 0:
 						otmp = mksobj(LONG_SWORD, FALSE, FALSE);
@@ -4559,7 +4559,7 @@ register struct monst *mtmp;
 				otmp->oproperties = OPROP_AXIO|OPROP_REFL;
 				fix_object(otmp);
 				(void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_DEMINYMPH]){
+			} else if(ptr->mtyp == PM_DEMINYMPH){
 				if(In_lost_cities(&u.uz)){
 					//Cultist of the Black Goat
 					otmp = mksobj(VIPERWHIP, FALSE, FALSE);
@@ -4946,7 +4946,7 @@ register struct monst *mtmp;
 			}
 		break;
 	    case S_CENTAUR:
-		if(ptr == &mons[PM_DRIDER]){
+		if(ptr->mtyp == PM_DRIDER){
 			chance = rnd(10);
 			if(chance >= 7) mongets(mtmp, DROVEN_PLATE_MAIL);
 			else if(chance >= 6) mongets(mtmp, ELVEN_MITHRIL_COAT);
@@ -4956,13 +4956,13 @@ register struct monst *mtmp;
 			if(chance >= 5) (void)mongets(mtmp, DROVEN_SHORT_SWORD);
 			(void)mongets(mtmp, DROVEN_CROSSBOW);
 			m_initthrow(mtmp, DROVEN_BOLT, 20);
-		} else if(ptr == &mons[PM_PRIESTESS_OF_GHAUNADAUR]){
+		} else if(ptr->mtyp == PM_PRIESTESS_OF_GHAUNADAUR){
 			chance = rnd(10);
 			if(chance >= 9) mongets(mtmp, CRYSTAL_PLATE_MAIL);
 			else if(chance >= 6) mongets(mtmp, CLOAK_OF_PROTECTION);
 			else if(chance == 5) mongets(mtmp, CONSORT_S_SUIT);
 			(void)mongets(mtmp, CRYSTAL_SWORD);
-		} else if(ptr == &mons[PM_ALIDER]){
+		} else if(ptr->mtyp == PM_ALIDER){
 			otmp = mksobj(WHITE_VIBROZANBATO, TRUE, FALSE);
 			otmp->spe = 8;
 			otmp->ovar1 = 50 + d(5,10);
@@ -4995,20 +4995,20 @@ register struct monst *mtmp;
 			(void)mongets(mtmp, GAUNTLETS_OF_POWER);
 		}
 		if (rn2(2)) {
-		    if(ptr == &mons[PM_FOREST_CENTAUR] || ptr == &mons[PM_PLAINS_CENTAUR]) {
+		    if(ptr->mtyp == PM_FOREST_CENTAUR || ptr->mtyp == PM_PLAINS_CENTAUR) {
 				(void)mongets(mtmp, BOW);
 				m_initthrow(mtmp, ARROW, 12);
-		    } else if(ptr == &mons[PM_MOUNTAIN_CENTAUR]) {
+		    } else if(ptr->mtyp == PM_MOUNTAIN_CENTAUR) {
 				(void)mongets(mtmp, CROSSBOW);
 				m_initthrow(mtmp, CROSSBOW_BOLT, 12);
 		    }
 		}
-		if(ptr == &mons[PM_FOREST_CENTAUR] || ptr == &mons[PM_PLAINS_CENTAUR] || ptr == &mons[PM_PLAINS_CENTAUR]){
+		if(ptr->mtyp == PM_FOREST_CENTAUR || ptr->mtyp == PM_PLAINS_CENTAUR || ptr->mtyp == PM_PLAINS_CENTAUR){
 			if(mtmp->female && In_lost_cities(&u.uz) && u.uinsight > (rnd(10)+rn2(11))){
 				mtmp->mfaction = MISTWEAVER;
 			}
 		}
-		if(ptr == &mons[PM_MOUNTAIN_CENTAUR]){
+		if(ptr->mtyp == PM_MOUNTAIN_CENTAUR){
 			chance = rnd(10);
 			if(chance == 10){
 				mongets(mtmp, CHAIN_MAIL);
@@ -5021,7 +5021,7 @@ register struct monst *mtmp;
 				if(has_head_mon(mtmp)) mongets(mtmp, LEATHER_HELM);
 			} else mongets(mtmp, LEATHER_ARMOR);
 		}
-		if(ptr == &mons[PM_FORMIAN_TASKMASTER]){
+		if(ptr->mtyp == PM_FORMIAN_TASKMASTER){
 			switch (rn2(6)) {
 			/* MAJOR fall through ... */
 			case 0: (void) mongets(mtmp, WAN_MAGIC_MISSILE);
@@ -5496,7 +5496,7 @@ register struct	monst	*mtmp;
 		    }
 			
 			if(In_law(&u.uz) && is_army_pm(monsndx(ptr))){
-				if(ptr == &mons[PM_CAPTAIN] || ptr == &mons[PM_LIEUTENANT]){
+				if(ptr->mtyp == PM_CAPTAIN || ptr->mtyp == PM_LIEUTENANT){
 					mongets(mtmp, HARMONIUM_PLATE);
 					mongets(mtmp, HARMONIUM_HELM);
 					mongets(mtmp, HARMONIUM_GAUNTLETS);
@@ -5548,22 +5548,22 @@ register struct	monst	*mtmp;
 				if (mac < 10 && rn2(2))
 				mac += objects[CLOAK].a_ac + mongets(mtmp, CLOAK);
 			}
-			if(ptr != &mons[PM_GUARD] &&
+			if(ptr->mtyp != PM_GUARD &&
 #ifdef CONVICT
-			ptr != &mons[PM_PRISON_GUARD] &&
+			ptr->mtyp != PM_PRISON_GUARD &&
 #endif /* CONVICT */
-			ptr != &mons[PM_WATCHMAN] &&
-			ptr != &mons[PM_WATCH_CAPTAIN]) {
+			ptr->mtyp != PM_WATCHMAN &&
+			ptr->mtyp != PM_WATCH_CAPTAIN) {
 			if(!(level.flags.has_barracks || In_law(&u.uz) || in_mklev || undeadfaction)){
 				if (!rn2(3)) (void) mongets(mtmp, K_RATION);
 				if (!rn2(2)) (void) mongets(mtmp, C_RATION);
 			}
-			if (ptr != &mons[PM_SOLDIER] && !rn2(3))
+			if (ptr->mtyp != PM_SOLDIER && !rn2(3))
 				(void) mongets(mtmp, BUGLE);
 			} else
-			   if (ptr == &mons[PM_WATCHMAN] && rn2(3))
+			   if (ptr->mtyp == PM_WATCHMAN && rn2(3))
 				(void) mongets(mtmp, WHISTLE);
-		} else if (ptr == &mons[PM_SHOPKEEPER]) {
+		} else if (ptr->mtyp == PM_SHOPKEEPER) {
 		    (void) mongets(mtmp,SKELETON_KEY);
 			if(Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz)){
 				(void) mongets(mtmp, SHOTGUN);
@@ -5595,7 +5595,7 @@ register struct	monst	*mtmp;
 		} else if (quest_mon_represents_role(ptr,PM_MONK)) {
 		    (void) mongets(mtmp, rn2(11) ? ROBE :
 					     CLOAK_OF_MAGIC_RESISTANCE);
-		} else if(ptr == &mons[PM_MEDUSA]){
+		} else if(ptr->mtyp == PM_MEDUSA){
 		 struct engr *oep = engr_at(mtmp->mx,mtmp->my);
 		 int i;
 		 for(i=0; i<3; i++){
@@ -5611,13 +5611,13 @@ register struct	monst	*mtmp;
 			rloc_engr(oep);
 			oep = engr_at(mtmp->mx,mtmp->my);
 		 }
-		} else if(ptr == &mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES] && !(u.uevent.ukilled_illurien)){
+		} else if(ptr->mtyp == PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES && !(u.uevent.ukilled_illurien)){
 			otmp = mksobj(SPE_SECRETS, TRUE, FALSE);
 			otmp->blessed = FALSE;
 			otmp->cursed = FALSE;
 			(void) mpickobj(mtmp, otmp);
 		} else if(is_drow(ptr)){
-			if(ptr == &mons[PM_MINDLESS_THRALL]){
+			if(ptr->mtyp == PM_MINDLESS_THRALL){
 				struct obj *otmp;
 				otmp = mksobj(DROVEN_CLOAK, TRUE, FALSE);
 				otmp->oerodeproof = FALSE;
@@ -5627,7 +5627,7 @@ register struct	monst	*mtmp;
 				otmp->ovar1 = 1;
 				(void) mpickobj(mtmp,otmp);
 			}
-			else if( ptr == &mons[PM_A_GONE] ){
+			else if( ptr->mtyp == PM_A_GONE ){
 				struct obj *otmp;
 				otmp = mksobj(DROVEN_CLOAK, TRUE, FALSE);
 				otmp = oname(otmp, artiname(ART_WEB_OF_THE_CHOSEN));
@@ -5648,19 +5648,19 @@ register struct	monst	*mtmp;
 		case S_ANT:
 			if(In_law(&u.uz)){
 				//Civilized ants
-				if(mtmp->data == &mons[PM_SOLDIER_ANT]){
+				if(mtmp->mtyp == PM_SOLDIER_ANT){
 					chance = rnd(10);
 					if(chance == 10) mongets(mtmp, PLATE_MAIL);
 					else if(chance >= 8) mongets(mtmp, CHAIN_MAIL);
 					else if(chance >= 5) mongets(mtmp, SCALE_MAIL);
 					if(chance >= 5) mongets(mtmp, HELMET);
-				} else if(mtmp->data == &mons[PM_KILLER_BEE]){
+				} else if(mtmp->mtyp == PM_KILLER_BEE){
 					if(!rn2(4)){
 						mongets(mtmp, LEATHER_ARMOR);
 					} else if(!rn2(3)){
 						mongets(mtmp, BLACK_DRESS);
 					}
-				} else if(mtmp->data == &mons[PM_QUEEN_BEE]){
+				} else if(mtmp->mtyp == PM_QUEEN_BEE){
 					chance = rnd(10);
 					if(chance == 10) mongets(mtmp, PLATE_MAIL);
 					else if(chance >= 8) mongets(mtmp, SCALE_MAIL);
@@ -5668,7 +5668,7 @@ register struct	monst	*mtmp;
 					if(chance >= 8) mongets(mtmp, HELMET);
 				}
 			}
-			if(ptr == &mons[PM_VALAVI]){
+			if(ptr->mtyp == PM_VALAVI){
 				switch (rnd(2)) {
 					case 1: (void) mongets(mtmp, POT_EXTRA_HEALING);
 					case 2: (void) mongets(mtmp, POT_HEALING);
@@ -5697,14 +5697,14 @@ register struct	monst	*mtmp;
 		break;
 		case S_DOG:
 			//Escaped war-dog
-			if(mtmp->data == &mons[PM_LARGE_DOG]){
+			if(mtmp->mtyp == PM_LARGE_DOG){
 				chance = rnd(100);
 				if(chance == 100) mongets(mtmp, PLATE_MAIL);
 				else if(chance >= 96) mongets(mtmp, SCALE_MAIL);
 				else if(chance >= 90) mongets(mtmp, LEATHER_ARMOR);
 				if(chance >= 96) mongets(mtmp, HELMET);
 			//Escaped orcish mount
-			} else if(mtmp->data == &mons[PM_WARG]){
+			} else if(mtmp->mtyp == PM_WARG){
 				chance = rnd(10);
 				if(chance == 10) mongets(mtmp, ORCISH_CHAIN_MAIL);
 				else if(chance >= 8) mongets(mtmp, ORCISH_RING_MAIL);
@@ -5720,7 +5720,7 @@ register struct	monst	*mtmp;
 						update_mon_intrinsics(mtmp, otmp, TRUE, TRUE);
 					}
 				}
-			} else if(mtmp->data == &mons[PM_WATCHDOG_OF_THE_BOREAL_VALLEY]){
+			} else if(mtmp->mtyp == PM_WATCHDOG_OF_THE_BOREAL_VALLEY){
 				otmp = mksobj(ARMORED_BOOTS, FALSE, FALSE);
 				otmp->objsize = MZ_HUGE;
 				otmp->obj_material = METAL;
@@ -5751,7 +5751,7 @@ register struct	monst	*mtmp;
 			}
 		case S_QUADRUPED:
 			//Escaped war-elephant
-			if(mtmp->data == &mons[PM_MUMAK]){
+			if(mtmp->mtyp == PM_MUMAK){
 				chance = rnd(100);
 				if(chance == 100) mongets(mtmp, ARCHAIC_PLATE_MAIL);
 				else if(chance >= 96) mongets(mtmp, ORCISH_CHAIN_MAIL);
@@ -5769,13 +5769,13 @@ register struct	monst	*mtmp;
 					}
 				}
 			}
-			if(mtmp->data == &mons[PM_BLESSED]){
+			if(mtmp->mtyp == PM_BLESSED){
 				mongets(mtmp, ROBE);
 			}
 		break;
 		case S_RODENT:
 			//6) There is obviously no "underground kingdom beneath London, inhabited by huge, intelligent rodents."
-			if(mtmp->data == &mons[PM_ENORMOUS_RAT]){
+			if(mtmp->mtyp == PM_ENORMOUS_RAT){
 				chance = rnd(100);
 				if(chance == 100){
 					if(mtmp->female) mongets(mtmp, GENTLEWOMAN_S_DRESS);
@@ -5787,7 +5787,7 @@ register struct	monst	*mtmp;
 		break;
 		case S_SPIDER:
 			//Escaped drow pet
-			if(mtmp->data == &mons[PM_GIANT_SPIDER]){
+			if(mtmp->mtyp == PM_GIANT_SPIDER){
 				chance = rnd(100);
 				if(chance == 100) mongets(mtmp, DROVEN_PLATE_MAIL);
 				else if(chance >= 96) mongets(mtmp, DROVEN_CHAIN_MAIL);
@@ -5809,7 +5809,7 @@ register struct	monst	*mtmp;
 		break;
 		case S_UNICORN:
 			//Escaped warhorse
-			if(mtmp->data == &mons[PM_WARHORSE]){
+			if(mtmp->mtyp == PM_WARHORSE){
 				chance = rnd(10);
 				if(chance == 10) mongets(mtmp, PLATE_MAIL);
 				else if(chance >= 8) mongets(mtmp, CHAIN_MAIL);
@@ -5828,7 +5828,7 @@ register struct	monst	*mtmp;
 			}
 		break;
 		case S_BAT:
-			if(mtmp->data == &mons[PM_CHIROPTERAN]){
+			if(mtmp->mtyp == PM_CHIROPTERAN){
 				chance = rnd(100);
 				if(chance >= 75) mongets(mtmp, STUDDED_LEATHER_ARMOR);
 				else mongets(mtmp, LEATHER_ARMOR);
@@ -5841,7 +5841,7 @@ register struct	monst	*mtmp;
 		break;
 		case S_LIZARD:
 			//Escaped drow pet
-			if(mtmp->data == &mons[PM_CAVE_LIZARD]){
+			if(mtmp->mtyp == PM_CAVE_LIZARD){
 				chance = rnd(100);
 				if(chance == 100) mongets(mtmp, DROVEN_PLATE_MAIL);
 				else if(chance >= 96) mongets(mtmp, DROVEN_CHAIN_MAIL);
@@ -5860,7 +5860,7 @@ register struct	monst	*mtmp;
 					}
 				}
 			//Escaped drow mount
-			} else if(mtmp->data == &mons[PM_LARGE_CAVE_LIZARD]){
+			} else if(mtmp->mtyp == PM_LARGE_CAVE_LIZARD){
 				chance = rnd(100);
 				if(chance == 98) mongets(mtmp, DROVEN_PLATE_MAIL);
 				else if(chance >= 90) mongets(mtmp, DROVEN_CHAIN_MAIL);
@@ -5881,7 +5881,7 @@ register struct	monst	*mtmp;
 			}
 		break;
 	    case S_NYMPH:
-		if(ptr == &mons[PM_NIMUNE]){
+		if(ptr->mtyp == PM_NIMUNE){
 			(void) mongets(mtmp, GENTLEWOMAN_S_DRESS);
 			(void) mongets(mtmp, VICTORIAN_UNDERWEAR);
 			(void) mongets(mtmp, LONG_GLOVES);
@@ -5954,7 +5954,7 @@ register struct	monst	*mtmp;
 		}
 		break;
 	    case S_GIANT:
-		if (ptr == &mons[PM_MINOTAUR]) {
+		if (ptr->mtyp == PM_MINOTAUR) {
 		    if (!rn2(3) || (in_mklev && Is_earthlevel(&u.uz)))
 			(void) mongets(mtmp, WAN_DIGGING);
 		} else if(monsndx(ptr) == PM_DEEPEST_ONE) {
@@ -6115,11 +6115,11 @@ register struct	monst	*mtmp;
 			otmp->cursed = FALSE;
 			fix_object(otmp);
 			(void) mpickobj(mtmp, otmp);
-		} else if(ptr == &mons[PM_GIANT_GOAT_SPAWN]) {
+		} else if(ptr->mtyp == PM_GIANT_GOAT_SPAWN) {
 			if(mtmp->female && In_lost_cities(&u.uz) && u.uinsight > (rnd(10)+rn2(11))){
 				mtmp->mfaction = MISTWEAVER;
 			}
-		} else if(ptr == &mons[PM_LURKING_ONE]) {
+		} else if(ptr->mtyp == PM_LURKING_ONE) {
 			int i;
 			long long oprop;
 			switch(rnd(20)){
@@ -6160,16 +6160,16 @@ register struct	monst	*mtmp;
 			otmp->owt = weight(otmp);
 			(void) mpickobj(mtmp, otmp);
 		    }
-			if(ptr == &mons[PM_GIANT] || ptr == &mons[PM_STONE_GIANT] || ptr == &mons[PM_HILL_GIANT]){
+			if(ptr->mtyp == PM_GIANT || ptr->mtyp == PM_STONE_GIANT || ptr->mtyp == PM_HILL_GIANT){
 				if(!rn2(4)) mongets(mtmp, CLUB);
-			} else if(ptr == &mons[PM_FIRE_GIANT]){
+			} else if(ptr->mtyp == PM_FIRE_GIANT){
 				mongets(mtmp, CLUB);
 				mongets(mtmp, LEATHER_ARMOR);
-			} else if(ptr == &mons[PM_FROST_GIANT]){
+			} else if(ptr->mtyp == PM_FROST_GIANT){
 				mongets(mtmp, BROADSWORD);
 				mongets(mtmp, HELMET);
 				mongets(mtmp, SCALE_MAIL);
-			} else if(ptr == &mons[PM_STORM_GIANT]){
+			} else if(ptr->mtyp == PM_STORM_GIANT){
 				mongets(mtmp, TWO_HANDED_SWORD);
 				mongets(mtmp, HELMET);
 				mongets(mtmp, CHAIN_MAIL);
@@ -6179,13 +6179,13 @@ register struct	monst	*mtmp;
 		} 
 		break;
 	    case S_NAGA:
-			if(ptr == &mons[PM_ANCIENT_NAGA]){
+			if(ptr->mtyp == PM_ANCIENT_NAGA){
 				mongets(mtmp, LONG_SWORD);
 				mongets(mtmp, LONG_SWORD);
 				mongets(mtmp, ARCHAIC_PLATE_MAIL);
 				mongets(mtmp, ARCHAIC_HELM);
 				mongets(mtmp, ARCHAIC_GAUNTLETS);
-			} else if(ptr == &mons[PM_GUARDIAN_NAGA] || ptr == &mons[PM_GUARDIAN_NAGA_HATCHLING]){
+			} else if(ptr->mtyp == PM_GUARDIAN_NAGA || ptr->mtyp == PM_GUARDIAN_NAGA_HATCHLING){
 				chance = rnd(10);
 				if(chance >= 7){
 					mongets(mtmp, ARCHAIC_PLATE_MAIL);
@@ -6194,39 +6194,39 @@ register struct	monst	*mtmp;
 			}
 		break;
 	    case S_WRAITH:
-		if (ptr == &mons[PM_NAZGUL]) {
+		if (ptr->mtyp == PM_NAZGUL) {
 			otmp = mksobj(RIN_INVISIBILITY, FALSE, FALSE);
 			curse(otmp);
 			(void) mpickobj(mtmp, otmp);
 		}
 		break;
 	    case S_LICH:
-		if (ptr == &mons[PM_DEATH_KNIGHT]){
+		if (ptr->mtyp == PM_DEATH_KNIGHT){
 			(void)mongets(mtmp, RUNESWORD);
 			(void)mongets(mtmp, PLATE_MAIL);
-		} else if (ptr == &mons[PM_MASTER_LICH] && !rn2(13))
+		} else if (ptr->mtyp == PM_MASTER_LICH && !rn2(13))
 			(void)mongets(mtmp, (rn2(7) ? ATHAME : WAN_NOTHING));
-		else if (ptr == &mons[PM_ARCH_LICH] && !rn2(3)) {
+		else if (ptr->mtyp == PM_ARCH_LICH && !rn2(3)) {
 			otmp = mksobj(rn2(3) ? ATHAME : QUARTERSTAFF,
 				      TRUE, rn2(13) ? FALSE : TRUE);
 			if (otmp->spe < 2) otmp->spe = rnd(3);
 			if (!rn2(4)) otmp->oerodeproof = 1;
 			(void) mpickobj(mtmp, otmp);
-		} else if(ptr == &mons[PM_ALHOON]){
+		} else if(ptr->mtyp == PM_ALHOON){
 			struct obj *otmp = mksobj(SKELETON_KEY, TRUE, FALSE);
 			otmp = oname(otmp, artiname(ART_SECOND_KEY_OF_NEUTRALITY));
 			if(!otmp->oartifact) otmp = oname(otmp, artiname(ART_THIRD_KEY_OF_NEUTRALITY));
 			otmp->blessed = FALSE;
 			otmp->cursed = FALSE;
 			(void) mpickobj(mtmp,otmp);
-		} else if(ptr == &mons[PM_ACERERAK]){
+		} else if(ptr->mtyp == PM_ACERERAK){
 			struct obj *otmp = mksobj(ATHAME, TRUE, FALSE);
 			otmp = oname(otmp, artiname(ART_PEN_OF_THE_VOID));
 			otmp->blessed = FALSE;
 			otmp->cursed = TRUE;
 			otmp->spe = 5;
 			(void) mpickobj(mtmp,otmp);
-		} else if(ptr == &mons[PM_DOKKALFAR_ETERNAL_MATRIARCH]){
+		} else if(ptr->mtyp == PM_DOKKALFAR_ETERNAL_MATRIARCH){
 			/*Plate Mail*/
 			otmp = mksobj(DROVEN_PLATE_MAIL, TRUE, FALSE);
 			otmp->ohaluengr = TRUE;
@@ -6271,17 +6271,17 @@ register struct	monst	*mtmp;
 		}
 		break;
 	    case S_YETI:
-			if(ptr == &mons[PM_GUG]){
+			if(ptr->mtyp == PM_GUG){
 				mongets(mtmp, CLUB);
 			}
 		break;
 	    case S_MUMMY:
-		if(ptr == &mons[PM_MUMMIFIED_ANDROID] || ptr == &mons[PM_MUMMIFIED_GYNOID]){
+		if(ptr->mtyp == PM_MUMMIFIED_ANDROID || ptr->mtyp == PM_MUMMIFIED_GYNOID){
 			otmp = mksobj(MUMMY_WRAPPING, TRUE, FALSE);
 			otmp->obj_material = LEATHER;
 			fix_object(otmp);
 			(void) mpickobj(mtmp, otmp);
-		} else if(ptr == &mons[PM_NITOCRIS]){
+		} else if(ptr->mtyp == PM_NITOCRIS){
 			otmp = mksobj(MUMMY_WRAPPING, FALSE, FALSE);
 			otmp = oname(otmp, artiname(ART_PRAYER_WARDED_WRAPPINGS_OF));		
 			otmp->blessed = FALSE;
@@ -6290,17 +6290,17 @@ register struct	monst	*mtmp;
 			otmp->oerodeproof = TRUE;
 			(void) mpickobj(mtmp, otmp);
 		} else {
-			(void)mongets(mtmp, ptr == &mons[PM_DROW_MUMMY] ? DROVEN_CLOAK : MUMMY_WRAPPING);
+			(void)mongets(mtmp, ptr->mtyp == PM_DROW_MUMMY ? DROVEN_CLOAK : MUMMY_WRAPPING);
 		}
 		
-		if(ptr == &mons[PM_DROW_MUMMY]){
+		if(ptr->mtyp == PM_DROW_MUMMY){
 			if(!rn2(10)){
 				otmp = mksobj(find_signet_ring(), FALSE, FALSE);
 				otmp->ohaluengr = TRUE;
 				otmp->oward = mtmp->mfaction;
 				(void) mpickobj(mtmp, otmp);
 			}
-		} else if(ptr == &mons[PM_PHARAOH]){
+		} else if(ptr->mtyp == PM_PHARAOH){
 			otmp = mksobj(FLAIL, TRUE, FALSE);
 			if (otmp->spe < 2) otmp->spe = rnd(3);
 			otmp->obj_material = GOLD;
@@ -6328,7 +6328,7 @@ register struct	monst	*mtmp;
 			fix_object(otmp);
 			curse(otmp);
 			(void) mpickobj(mtmp, otmp);
-		} else if(ptr == &mons[PM_NITOCRIS]){
+		} else if(ptr->mtyp == PM_NITOCRIS){
 			otmp = mksobj(SCALE_MAIL, FALSE, FALSE);
 			otmp->spe = 9;
 			otmp->obj_material = GOLD;
@@ -6379,7 +6379,7 @@ register struct	monst	*mtmp;
 			curse(otmp);
 			(void) mpickobj(mtmp, otmp);
 			return; //no random junk
-		} else if(ptr == &mons[PM_ALABASTER_MUMMY]){
+		} else if(ptr->mtyp == PM_ALABASTER_MUMMY){
 			otmp = mksobj(MASK, TRUE, FALSE);
 			otmp->corpsenm = PM_ALABASTER_ELF;
 			otmp->obj_material = MINERAL;
@@ -6411,12 +6411,12 @@ register struct	monst	*mtmp;
 		}
 		break;
 		case S_ZOMBIE:
-			if(ptr == &mons[PM_HEDROW_ZOMBIE] && !rn2(10)){
+			if(ptr->mtyp == PM_HEDROW_ZOMBIE && !rn2(10)){
 				otmp = mksobj(find_signet_ring(), FALSE, FALSE);
 				otmp->ohaluengr = TRUE;
 				otmp->oward = mtmp->mfaction;
 				(void) mpickobj(mtmp, otmp);
-			} else if(ptr == &mons[PM_HUNGRY_DEAD]){
+			} else if(ptr->mtyp == PM_HUNGRY_DEAD){
 				/* create an attached blob of preserved organs. Killing the blob will kill this hungry dead */
 				struct monst *blbtmp;
 				if (blbtmp = makemon(&mons[PM_BLOB_OF_PRESERVED_ORGANS], mtmp->mx, mtmp->my, MM_ADJACENTOK | MM_NOCOUNTBIRTH)) {
@@ -6447,7 +6447,7 @@ register struct	monst	*mtmp;
 		case S_LAW_ANGEL:
 		case S_NEU_ANGEL:
 		case S_CHA_ANGEL:
-			if(ptr == &mons[PM_WARDEN_ARCHON]){
+			if(ptr->mtyp == PM_WARDEN_ARCHON){
 				otmp = mksobj(PLATE_MAIL, FALSE, FALSE);
 			    bless(otmp);
 			    otmp->oerodeproof = TRUE;
@@ -7082,7 +7082,7 @@ register struct	monst	*mtmp;
 			break;
 		}
 		case S_EYE:
-			if(ptr == &mons[PM_AXUS]){
+			if(ptr->mtyp == PM_AXUS){
 				struct obj *otmp = mksobj(SKELETON_KEY, TRUE, FALSE);
 				otmp = oname(otmp, artiname(ART_FIRST_KEY_OF_LAW));
 				otmp->blessed = FALSE;
@@ -7091,7 +7091,7 @@ register struct	monst	*mtmp;
 			}
 		break;
 		case S_GOLEM:
-			if(ptr == &mons[PM_ARSENAL]){
+			if(ptr->mtyp == PM_ARSENAL){
 				struct obj *otmp = mksobj(SKELETON_KEY, TRUE, FALSE);
 				otmp = oname(otmp, artiname(ART_SECOND_KEY_OF_LAW));
 				otmp->blessed = FALSE;
@@ -7104,7 +7104,7 @@ register struct	monst	*mtmp;
 	}
 
 	/* ordinary soldiers rarely have access to magic (or gold :-) */
-	if (ptr == &mons[PM_SOLDIER] && rn2(13)) return;
+	if (ptr->mtyp == PM_SOLDIER && rn2(13)) return;
 
 	if ((int) mtmp->m_lev > rn2(50))
 		(void) mongets(mtmp, rnd_defensive_item(mtmp));
@@ -7333,7 +7333,7 @@ register int	mmflags;
 	boolean unsethouse = FALSE;
 	
 	if(Race_if(PM_DROW) && in_mklev && Is_qstart(&u.uz) && 
-		(ptr == &mons[PM_SPROW] || ptr == &mons[PM_DRIDER] || ptr == &mons[PM_CAVE_LIZARD] || ptr == &mons[PM_LARGE_CAVE_LIZARD])
+		(ptr->mtyp == PM_SPROW || ptr->mtyp == PM_DRIDER || ptr->mtyp == PM_CAVE_LIZARD || ptr->mtyp == PM_LARGE_CAVE_LIZARD)
 	)
 		mmflags |= MM_EDOG;
 
@@ -7509,11 +7509,11 @@ register int	mmflags;
 	mtmp->mwis = d(3,6);
 	mtmp->mcha = d(3,6);
 	if(mtmp->data->mlet == S_NYMPH){
-		if(mtmp->data == &mons[PM_DEMINYMPH]) mtmp->mcha = (mtmp->mcha + 25)/2;
+		if(mtmp->mtyp == PM_DEMINYMPH) mtmp->mcha = (mtmp->mcha + 25)/2;
 		else mtmp->mcha = 25;
 	}
 	
-	if(Race_if(PM_DROW) && in_mklev && Is_qstart(&u.uz) && (ptr == &mons[PM_SPROW] || ptr == &mons[PM_DRIDER] || ptr == &mons[PM_CAVE_LIZARD] || ptr == &mons[PM_LARGE_CAVE_LIZARD])){
+	if(Race_if(PM_DROW) && in_mklev && Is_qstart(&u.uz) && (ptr->mtyp == PM_SPROW || ptr->mtyp == PM_DRIDER || ptr->mtyp == PM_CAVE_LIZARD || ptr->mtyp == PM_LARGE_CAVE_LIZARD)){
 		struct obj *otmp = mksobj(SADDLE, TRUE, FALSE);
 		initedog(mtmp);
 		EDOG(mtmp)->loyal = TRUE;
@@ -7525,7 +7525,7 @@ register int	mmflags;
 			otmp->leashmon = mtmp->m_id;
 			update_mon_intrinsics(mtmp, otmp, TRUE, TRUE);
 		}
-		if(ptr == &mons[PM_SPROW] || ptr == &mons[PM_DRIDER]){
+		if(ptr->mtyp == PM_SPROW || ptr->mtyp == PM_DRIDER){
 			otmp = mksobj(DROVEN_PLATE_MAIL, TRUE, FALSE);
 			otmp->oward = (long)u.start_house;
 			otmp->oerodeproof = TRUE;
@@ -7558,16 +7558,16 @@ register int	mmflags;
 	mtmp->m_san_level = max(1, (int)(sanlev*100));
 	mtmp->m_insight_level = 0;
 	
-	if(mtmp->data == &mons[PM_LIVING_DOLL] || mtmp->data->msound == MS_GLYPHS)
+	if(mtmp->mtyp == PM_LIVING_DOLL || mtmp->data->msound == MS_GLYPHS)
 		mtmp->m_san_level = 1;
 		
-	if(mtmp->data == &mons[PM_LURKING_ONE])
+	if(mtmp->mtyp == PM_LURKING_ONE)
 		mtmp->m_insight_level = 20+rn2(21);
-	else if(mtmp->data == &mons[PM_BLASPHEMOUS_LURKER])
+	else if(mtmp->mtyp == PM_BLASPHEMOUS_LURKER)
 		mtmp->m_insight_level = 40;
-	else if(mtmp->data == &mons[PM_PARASITIZED_DOLL])
+	else if(mtmp->mtyp == PM_PARASITIZED_DOLL)
 		mtmp->m_insight_level = rnd(20);
-	else if(mtmp->data == &mons[PM_LIVING_DOLL]){
+	else if(mtmp->mtyp == PM_LIVING_DOLL){
 		int i, j;
 		long tmp;
 		long dolltypes[] = {
@@ -7601,65 +7601,65 @@ register int	mmflags;
 		mtmp->m_insight_level = rnd(20);
 	}
 	
-	else if(mtmp->data == &mons[PM_BESTIAL_DERVISH])
+	else if(mtmp->mtyp == PM_BESTIAL_DERVISH)
 		mtmp->m_insight_level = 20+rn2(10);
-	else if(mtmp->data == &mons[PM_ETHEREAL_DERVISH])
+	else if(mtmp->mtyp == PM_ETHEREAL_DERVISH)
 		mtmp->m_insight_level = 20+rn2(10);
-	else if(mtmp->data == &mons[PM_SPARKLING_LAKE])
+	else if(mtmp->mtyp == PM_SPARKLING_LAKE)
 		mtmp->m_insight_level = 18+rn2(9);
-	else if(mtmp->data == &mons[PM_FLASHING_LAKE])
+	else if(mtmp->mtyp == PM_FLASHING_LAKE)
 		mtmp->m_insight_level = 16+rn2(8);
-	else if(mtmp->data == &mons[PM_SMOLDERING_LAKE])
+	else if(mtmp->mtyp == PM_SMOLDERING_LAKE)
 		mtmp->m_insight_level = 11+rn2(6);
-	else if(mtmp->data == &mons[PM_FROSTED_LAKE])
+	else if(mtmp->mtyp == PM_FROSTED_LAKE)
 		mtmp->m_insight_level = 12+rn2(6);
-	else if(mtmp->data == &mons[PM_BLOOD_SHOWER])
+	else if(mtmp->mtyp == PM_BLOOD_SHOWER)
 		mtmp->m_insight_level = 14+rn2(7);
-	else if(mtmp->data == &mons[PM_MANY_TALONED_THING])
+	else if(mtmp->mtyp == PM_MANY_TALONED_THING)
 		mtmp->m_insight_level = 16+rn2(8);
-	else if(mtmp->data == &mons[PM_DEEP_BLUE_CUBE])
+	else if(mtmp->mtyp == PM_DEEP_BLUE_CUBE)
 		mtmp->m_insight_level = 10+rn2(5);
-	else if(mtmp->data == &mons[PM_PITCH_BLACK_CUBE])
+	else if(mtmp->mtyp == PM_PITCH_BLACK_CUBE)
 		mtmp->m_insight_level = 22+rn2(11);
-	else if(mtmp->data == &mons[PM_PRAYERFUL_THING])
+	else if(mtmp->mtyp == PM_PRAYERFUL_THING)
 		mtmp->m_insight_level = 25+rn2(13);
-	else if(mtmp->data == &mons[PM_HEMORRHAGIC_THING])
+	else if(mtmp->mtyp == PM_HEMORRHAGIC_THING)
 		mtmp->m_insight_level = 15+rn2(8);
-	else if(mtmp->data == &mons[PM_MANY_EYED_SEEKER])
+	else if(mtmp->mtyp == PM_MANY_EYED_SEEKER)
 		mtmp->m_insight_level = 17+rn2(9);
-	else if(mtmp->data == &mons[PM_VOICE_IN_THE_DARK])
+	else if(mtmp->mtyp == PM_VOICE_IN_THE_DARK)
 		mtmp->m_insight_level = 19+rn2(10);
-	else if(mtmp->data == &mons[PM_TINY_BEING_OF_LIGHT])
+	else if(mtmp->mtyp == PM_TINY_BEING_OF_LIGHT)
 		mtmp->m_insight_level = 13+rn2(7);
-	else if(mtmp->data == &mons[PM_MAN_FACED_MILLIPEDE])
+	else if(mtmp->mtyp == PM_MAN_FACED_MILLIPEDE)
 		mtmp->m_insight_level = 5+rn2(3);
-	else if(mtmp->data == &mons[PM_MIRRORED_MOONFLOWER])
+	else if(mtmp->mtyp == PM_MIRRORED_MOONFLOWER)
 		mtmp->m_insight_level = 10+rn2(5);
-	else if(mtmp->data == &mons[PM_CRIMSON_WRITHER])
+	else if(mtmp->mtyp == PM_CRIMSON_WRITHER)
 		mtmp->m_insight_level = 14+rn2(7);
-	else if(mtmp->data == &mons[PM_RADIANT_PYRAMID])
+	else if(mtmp->mtyp == PM_RADIANT_PYRAMID)
 		mtmp->m_insight_level = 12+rn2(6);
 	
-	else if(mtmp->data == &mons[PM_BRIGHT_WALKER])
+	else if(mtmp->mtyp == PM_BRIGHT_WALKER)
 		mtmp->m_insight_level = 10;
 	
-	else if(mtmp->data == &mons[PM_KUKER])
+	else if(mtmp->mtyp == PM_KUKER)
 		mtmp->m_insight_level = rnd(20)+rn2(21);
 	
-	else if(mtmp->data == &mons[PM_BLESSED])
+	else if(mtmp->mtyp == PM_BLESSED)
 		mtmp->m_insight_level = 40;
 
-	else if(mtmp->data == &mons[PM_MOUTH_OF_THE_GOAT])
+	else if(mtmp->mtyp == PM_MOUTH_OF_THE_GOAT)
 		mtmp->m_insight_level = 60;
-	else if(mtmp->data == &mons[PM_THE_GOOD_NEIGHBOR])
+	else if(mtmp->mtyp == PM_THE_GOOD_NEIGHBOR)
 		mtmp->m_insight_level = 40;
-	else if(mtmp->data == &mons[PM_HMNYW_PHARAOH])
-		mtmp->m_insight_level = 40;
-	
-	else if(mtmp->data == &mons[PM_POLYPOID_BEING])
+	else if(mtmp->mtyp == PM_HMNYW_PHARAOH)
 		mtmp->m_insight_level = 40;
 	
-	if(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH])
+	else if(mtmp->mtyp == PM_POLYPOID_BEING)
+		mtmp->m_insight_level = 40;
+	
+	if(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH)
 		mtmp->m_lev += u.chokhmah;
 	if (is_golem(ptr)) {
 	    mtmp->mhpmax = mtmp->mhp = golemhp(mndx);
@@ -7696,7 +7696,7 @@ register int	mmflags;
 
 	// if (ptr == &mons[urole.ldrnum])		/* leader knows about portal */
 	    // mtmp->mtrapseen |= (1L << (MAGIC_PORTAL-1));
-	// if (ptr == &mons[PM_OONA])  /* don't trigger statue traps */
+	// if (ptr->mtyp == PM_OONA)  /* don't trigger statue traps */
 		// mtmp->mtrapseen |= (1L << (STATUE_TRAP-1));
 	if (In_sokoban(&u.uz) && !mindless(ptr))  /* know about traps here */
 	    mtmp->mtrapseen = (1L << (PIT - 1)) | (1L << (HOLE - 1));
@@ -7721,42 +7721,42 @@ register int	mmflags;
 	   and then unset after this creature's armor is created. */
 	if(is_drow(ptr)){
 		if(!curhouse){
-			if((ptr == &mons[urole.ldrnum] && ptr != &mons[PM_ECLAVDRA]) || 
-				(ptr == &mons[urole.guardnum] && ptr != &mons[PM_DROW_MATRON_MOTHER] && ptr != &mons[PM_HEDROW_MASTER_WIZARD])
+			if((ptr == &mons[urole.ldrnum] && ptr->mtyp != PM_ECLAVDRA) || 
+				(ptr == &mons[urole.guardnum] && ptr->mtyp != PM_DROW_MATRON_MOTHER && ptr->mtyp != PM_HEDROW_MASTER_WIZARD)
 			){
 				if(Race_if(PM_DROW) && !Role_if(PM_EXILE)) curhouse = u.start_house;
 				else curhouse = LOLTH_SYMBOL;
 			} else if(Is_lolth_level(&u.uz)){
 				curhouse = LOLTH_SYMBOL;
-			} else if(ptr == &mons[PM_MINDLESS_THRALL] || ptr == &mons[PM_A_GONE] || ptr == &mons[PM_PEASANT]){
+			} else if(ptr->mtyp == PM_MINDLESS_THRALL || ptr->mtyp == PM_A_GONE || ptr->mtyp == PM_PEASANT){
 				curhouse = PEN_A_SYMBOL;
-			} else if(ptr == &mons[PM_DOKKALFAR_ETERNAL_MATRIARCH]){
+			} else if(ptr->mtyp == PM_DOKKALFAR_ETERNAL_MATRIARCH){
 				curhouse = LOST_HOUSE;
-			} else if(ptr == &mons[PM_ECLAVDRA] || ptr == &mons[PM_AVATAR_OF_LOLTH] || is_yochlol(ptr)){
+			} else if(ptr->mtyp == PM_ECLAVDRA || ptr->mtyp == PM_AVATAR_OF_LOLTH || is_yochlol(ptr)){
 				curhouse = LOLTH_SYMBOL;
-			} else if(ptr == &mons[PM_DROW_MATRON_MOTHER]){
+			} else if(ptr->mtyp == PM_DROW_MATRON_MOTHER){
 				if(Race_if(PM_DROW) && !Role_if(PM_EXILE)) curhouse = (Role_if(PM_NOBLEMAN) && !flags.initgend) ? (((u.start_house-FIRST_FALLEN_HOUSE+1)%(LAST_HOUSE-FIRST_HOUSE+1))+FIRST_HOUSE) : LOLTH_SYMBOL;
 				else curhouse = LOLTH_SYMBOL;
-			} else if(ptr == &mons[PM_SEYLL_AUZKOVYN] || ptr == &mons[PM_STJARNA_ALFR]){
+			} else if(ptr->mtyp == PM_SEYLL_AUZKOVYN || ptr->mtyp == PM_STJARNA_ALFR){
 				curhouse = EILISTRAEE_SYMBOL;
-			} else if(ptr == &mons[PM_PRIESTESS_OF_GHAUNADAUR]){
+			} else if(ptr->mtyp == PM_PRIESTESS_OF_GHAUNADAUR){
 				curhouse = GHAUNADAUR_SYMBOL;
-			} else if(ptr == &mons[PM_DARUTH_XAXOX] || ptr == &mons[PM_DROW_ALIENIST]){
+			} else if(ptr->mtyp == PM_DARUTH_XAXOX || ptr->mtyp == PM_DROW_ALIENIST){
 				curhouse = XAXOX;
-			} else if(ptr == &mons[PM_EMBRACED_DROWESS] || (ptr == &mons[PM_DROW_MUMMY] && In_quest(&u.uz) && !flags.initgend)){
+			} else if(ptr->mtyp == PM_EMBRACED_DROWESS || (ptr->mtyp == PM_DROW_MUMMY && In_quest(&u.uz) && !flags.initgend)){
 				curhouse = EDDER_SYMBOL;
-			} else if(ptr == &mons[PM_A_SALOM]){
+			} else if(ptr->mtyp == PM_A_SALOM){
 				curhouse = VER_TAS_SYMBOL;
-			} else if(ptr == &mons[PM_GROMPH]){
+			} else if(ptr->mtyp == PM_GROMPH){
 				curhouse = SORCERE;
-			} else if(ptr == &mons[PM_DANTRAG]){
+			} else if(ptr->mtyp == PM_DANTRAG){
 				curhouse = MAGTHERE;
-			} else if(ptr == &mons[PM_HEDROW_BLADEMASTER]){
+			} else if(ptr->mtyp == PM_HEDROW_BLADEMASTER){
 				curhouse = MAGTHERE;
-			} else if(ptr == &mons[PM_HEDROW_MASTER_WIZARD]){
+			} else if(ptr->mtyp == PM_HEDROW_MASTER_WIZARD){
 				curhouse = SORCERE;
-			} else if(ptr->mlet != S_HUMAN && !((ptr == &mons[PM_SPROW] || ptr == &mons[PM_DRIDER]) && in_mklev && In_quest(&u.uz) && Is_qstart(&u.uz))){
-				if(ptr == &mons[PM_DROW_MUMMY]){
+			} else if(ptr->mlet != S_HUMAN && !((ptr->mtyp == PM_SPROW || ptr->mtyp == PM_DRIDER) && in_mklev && In_quest(&u.uz) && Is_qstart(&u.uz))){
+				if(ptr->mtyp == PM_DROW_MUMMY){
 					if(!(rn2(10))){
 						if(!rn2(6)) curhouse = LOLTH_SYMBOL;
 						else if(rn2(5) < 2) curhouse = EILISTRAEE_SYMBOL;
@@ -7764,7 +7764,7 @@ register int	mmflags;
 					} else if(!(rn2(4))) curhouse = rn2(LAST_HOUSE+1-FIRST_HOUSE)+FIRST_HOUSE;
 					else curhouse = rn2(LAST_FALLEN_HOUSE+1-FIRST_FALLEN_HOUSE)+FIRST_FALLEN_HOUSE;
 				}
-				else if(ptr == &mons[PM_HEDROW_ZOMBIE]){
+				else if(ptr->mtyp == PM_HEDROW_ZOMBIE){
 					if(!rn2(6)) curhouse = SORCERE;
 					else if(!rn2(5)) curhouse = MAGTHERE;
 					else if(!(rn2(4))) curhouse = rn2(LAST_HOUSE+1-FIRST_HOUSE)+FIRST_HOUSE;
@@ -7803,23 +7803,23 @@ register int	mmflags;
 			unsethouse = TRUE;
 			skeletpm = -1;
 		}
-	} else if(In_quest(&u.uz) && urole.neminum == PM_NECROMANCER && mtmp->data == &mons[PM_ELF]){
+	} else if(In_quest(&u.uz) && urole.neminum == PM_NECROMANCER && mtmp->mtyp == PM_ELF){
 		undeadfaction = ZOMBIFIED;
 		unsethouse = TRUE;
 		m_initlgrp(mtmp, mtmp->mx, mtmp->my);
-	} else if(mtmp->data == &mons[PM_ECHO]){
+	} else if(mtmp->mtyp == PM_ECHO){
 		undeadfaction = SKELIFIED;
 		unsethouse = TRUE;
 	} else if(!undeadfaction && (mtmp->data->geno&G_HELL) == 0 && Is_mephisto_level(&u.uz)){
 		undeadfaction = CRYSTALFIED;
 		unsethouse = TRUE;
 	} else if(is_kamerel(mtmp->data)){
-		if(level.flags.has_kamerel_towers && (mtmp->data != &mons[PM_ARA_KAMEREL] || rn2(2))){
+		if(level.flags.has_kamerel_towers && (mtmp->mtyp != PM_ARA_KAMEREL || rn2(2))){
 			undeadfaction = FRACTURED;
 			unsethouse = TRUE;
-		} else if(!level.flags.has_minor_spire && mtmp->data != &mons[PM_ARA_KAMEREL]
-			&& (mtmp->data != &mons[PM_HUDOR_KAMEREL] || rn2(2))
-			&& (mtmp->data != &mons[PM_SHARAB_KAMEREL] || !rn2(4))
+		} else if(!level.flags.has_minor_spire && mtmp->mtyp != PM_ARA_KAMEREL
+			&& (mtmp->mtyp != PM_HUDOR_KAMEREL || rn2(2))
+			&& (mtmp->mtyp != PM_SHARAB_KAMEREL || !rn2(4))
 		){
 			undeadfaction = FRACTURED;
 			unsethouse = TRUE;
@@ -7859,7 +7859,7 @@ register int	mmflags;
 	}
 	
 	if(Race_if(PM_DROW) && in_mklev && Is_qstart(&u.uz) && 
-		(ptr == &mons[PM_SPROW] || ptr == &mons[PM_DRIDER] || ptr == &mons[PM_CAVE_LIZARD] || ptr == &mons[PM_LARGE_CAVE_LIZARD])
+		(ptr->mtyp == PM_SPROW || ptr->mtyp == PM_DRIDER || ptr->mtyp == PM_CAVE_LIZARD || ptr->mtyp == PM_LARGE_CAVE_LIZARD)
 	) mtmp->mpeaceful = TRUE;
 	else mtmp->mpeaceful = (mmflags & MM_ANGRY) ? FALSE : (peace_minded(ptr) && !is_derived_undead_mon(mtmp));
 	
@@ -7885,11 +7885,11 @@ register int	mmflags;
 			set_mimic_sym(mtmp);
 			break;
 		case S_QUADRUPED:
-			if(mtmp->data == &mons[PM_DARK_YOUNG]) set_mimic_sym(mtmp);
+			if(mtmp->mtyp == PM_DARK_YOUNG) set_mimic_sym(mtmp);
 			break;
 		case S_SPIDER:
 		case S_SNAKE:
-			if(in_mklev && ptr != &mons[PM_YURIAN] && ptr != &mons[PM_FIRST_WRAITHWORM])
+			if(in_mklev && ptr->mtyp != PM_YURIAN && ptr->mtyp != PM_FIRST_WRAITHWORM)
 			    if(x && y)
 				(void) mkobj_at(0, x, y, TRUE);
 			if(hides_under(ptr) && OBJ_AT(x, y))
@@ -7970,7 +7970,7 @@ register int	mmflags;
 					if(u.uevent.invoked) m_initlgrp(mtmp, 0, 0);
 					else mtmp->mvar3 = 1; //Set to 1 to initiallize
 				}
-			} else if(mtmp->data == &mons[PM_ARCADIAN_AVENGER]){
+			} else if(mtmp->mtyp == PM_ARCADIAN_AVENGER){
 				if(anymon){
 					tmpm = makemon(&mons[PM_ARCADIAN_AVENGER], mtmp->mx, mtmp->my, MM_ADJACENTOK|MM_NOCOUNTBIRTH);
 					if(tmpm) m_initsgrp(tmpm, mtmp->mx, mtmp->my);
@@ -8808,7 +8808,7 @@ rndmonst()
 	}
 
 	if (u.uz.dnum == quest_dnum && !undeadfaction && (ptr = qt_montype()) != 0){
-		if(ptr == &mons[PM_LONG_WORM_TAIL]) return (struct permonst *) 0;
+		if(ptr->mtyp == PM_LONG_WORM_TAIL) return (struct permonst *) 0;
 	    else if(Role_if(PM_ANACHRONONAUT) || rn2(7)) return ptr;
 		//else continue to random generation
 	}
@@ -9437,7 +9437,7 @@ register struct permonst *ptr;
 {
 	int	tmp, tmp2;
 
-	if (ptr == &mons[PM_WIZARD_OF_YENDOR]) {
+	if (ptr->mtyp == PM_WIZARD_OF_YENDOR) {
 		/* does not depend on other strengths, but does get stronger
 		 * every time he is killed
 		 */
@@ -9521,7 +9521,7 @@ struct monst *mtmp, *victim;
 		}
 	}
 	
-	if(mtmp->m_lev > 50 || ptr == &mons[PM_CHAOS]) return ptr;
+	if(mtmp->m_lev > 50 || ptr->mtyp == PM_CHAOS) return ptr;
 	/* note:  none of the monsters with special hit point calculations
 	   have both little and big forms */
 	oldtype = monsndx(ptr);
@@ -9541,25 +9541,25 @@ struct monst *mtmp, *victim;
 	    else if (is_golem(ptr))	/* strange creatures */
 		hp_threshold = ((mtmp->mhpmax / 10) + 1) * 10 - 1;
 	    else if (is_home_elemental(ptr) || 
-			ptr == &mons[PM_DARKNESS_GIVEN_HUNGER] ||
-			ptr == &mons[PM_WATCHER_IN_THE_WATER] ||
-			ptr == &mons[PM_KETO] ||
-			ptr == &mons[PM_DRACAE_ELADRIN] ||
-			ptr == &mons[PM_MOTHERING_MASS] ||
-			ptr == &mons[PM_DURIN_S_BANE] ||
-			ptr == &mons[PM_LUNGORTHIN] ||
-			ptr == &mons[PM_CHROMATIC_DRAGON] ||
-			ptr == &mons[PM_BOLG] ||
-			ptr == &mons[PM_PRIEST_OF_GHAUNADAUR] ||
-			ptr == &mons[PM_SHOGGOTH]
+			ptr->mtyp == PM_DARKNESS_GIVEN_HUNGER ||
+			ptr->mtyp == PM_WATCHER_IN_THE_WATER ||
+			ptr->mtyp == PM_KETO ||
+			ptr->mtyp == PM_DRACAE_ELADRIN ||
+			ptr->mtyp == PM_MOTHERING_MASS ||
+			ptr->mtyp == PM_DURIN_S_BANE ||
+			ptr->mtyp == PM_LUNGORTHIN ||
+			ptr->mtyp == PM_CHROMATIC_DRAGON ||
+			ptr->mtyp == PM_BOLG ||
+			ptr->mtyp == PM_PRIEST_OF_GHAUNADAUR ||
+			ptr->mtyp == PM_SHOGGOTH
 		) hp_threshold *= 3;
-	    else if (ptr == &mons[PM_RAZORVINE]) hp_threshold *= .5;
-		else if(ptr == &mons[PM_CHAOS]) hp_threshold *= 15;
-		else if(ptr == &mons[PM_KARY__THE_FIEND_OF_FIRE]) hp_threshold *= 10;
-		else if(ptr == &mons[PM_LICH__THE_FIEND_OF_EARTH]) hp_threshold *= 10;
-		else if(ptr == &mons[PM_KRAKEN__THE_FIEND_OF_WATER]) hp_threshold *= 10;
-		else if(ptr == &mons[PM_TIAMAT__THE_FIEND_OF_WIND]) hp_threshold *= 10;
-		else if(ptr == &mons[PM_CHOKHMAH_SEPHIRAH]) hp_threshold *= u.chokhmah;
+	    else if (ptr->mtyp == PM_RAZORVINE) hp_threshold *= .5;
+		else if(ptr->mtyp == PM_CHAOS) hp_threshold *= 15;
+		else if(ptr->mtyp == PM_KARY__THE_FIEND_OF_FIRE) hp_threshold *= 10;
+		else if(ptr->mtyp == PM_LICH__THE_FIEND_OF_EARTH) hp_threshold *= 10;
+		else if(ptr->mtyp == PM_KRAKEN__THE_FIEND_OF_WATER) hp_threshold *= 10;
+		else if(ptr->mtyp == PM_TIAMAT__THE_FIEND_OF_WIND) hp_threshold *= 10;
+		else if(ptr->mtyp == PM_CHOKHMAH_SEPHIRAH) hp_threshold *= u.chokhmah;
 	    lev_limit = 3 * (int)ptr->mlevel / 2;	/* same as adj_lev() */
 	    /* If they can grow up, be sure the level is high enough for that */
 	    if (oldtype != newtype && mons[newtype].mlevel > lev_limit)
@@ -9588,7 +9588,7 @@ struct monst *mtmp, *victim;
 			cur_increase = 0;
 		}
 		//Gynoid pets recover from kills
-		if(mtmp->data == &mons[PM_GYNOID] && mtmp->mhp < mtmp->mhpmax){
+		if(mtmp->mtyp == PM_GYNOID && mtmp->mhp < mtmp->mhpmax){
 			mtmp->mhp += victim->m_lev;
 			if(mtmp->mhp > mtmp->mhpmax) mtmp->mhp = mtmp->mhpmax;
 		}
@@ -9606,21 +9606,21 @@ struct monst *mtmp, *victim;
 	if (mtmp->mhpmax <= hp_threshold)
 	    return ptr;		/* doesn't gain a level */
 
-	if (is_mplayer(ptr) || ptr == &mons[PM_BYAKHEE] || ptr == &mons[PM_LILLEND] || ptr == &mons[PM_ERINYS] || ptr == &mons[PM_MAID]
-	|| ptr == &mons[PM_CROW_WINGED_HALF_DRAGON] || ptr == &mons[PM_BASTARD_OF_THE_BOREAL_VALLEY]
-	|| ptr == &mons[PM_UNDEAD_KNIGHT] || ptr == &mons[PM_WARRIOR_OF_SUNLIGHT]
-	|| ptr == &mons[PM_FORMIAN_CRUSHER]
-	|| ptr == &mons[PM_DRIDER] || ptr == &mons[PM_SPROW]
-	|| ptr == &mons[PM_DROW_MATRON] || ptr == &mons[PM_DROW_MATRON_MOTHER]
-	|| ptr == &mons[PM_ELVENKING] || ptr == &mons[PM_ELVENQUEEN]
-	|| ptr == &mons[PM_CUPRILACH_RILMANI] || ptr == &mons[PM_STANNUMACH_RILMANI]
-	|| ptr == &mons[PM_ARGENACH_RILMANI] || ptr == &mons[PM_AURUMACH_RILMANI]
-	|| ptr == &mons[PM_ANDROID] || ptr == &mons[PM_GYNOID] || ptr == &mons[PM_OPERATOR] || ptr == &mons[PM_COMMANDER]
+	if (is_mplayer(ptr) || ptr->mtyp == PM_BYAKHEE || ptr->mtyp == PM_LILLEND || ptr->mtyp == PM_ERINYS || ptr->mtyp == PM_MAID
+	|| ptr->mtyp == PM_CROW_WINGED_HALF_DRAGON || ptr->mtyp == PM_BASTARD_OF_THE_BOREAL_VALLEY
+	|| ptr->mtyp == PM_UNDEAD_KNIGHT || ptr->mtyp == PM_WARRIOR_OF_SUNLIGHT
+	|| ptr->mtyp == PM_FORMIAN_CRUSHER
+	|| ptr->mtyp == PM_DRIDER || ptr->mtyp == PM_SPROW
+	|| ptr->mtyp == PM_DROW_MATRON || ptr->mtyp == PM_DROW_MATRON_MOTHER
+	|| ptr->mtyp == PM_ELVENKING || ptr->mtyp == PM_ELVENQUEEN
+	|| ptr->mtyp == PM_CUPRILACH_RILMANI || ptr->mtyp == PM_STANNUMACH_RILMANI
+	|| ptr->mtyp == PM_ARGENACH_RILMANI || ptr->mtyp == PM_AURUMACH_RILMANI
+	|| ptr->mtyp == PM_ANDROID || ptr->mtyp == PM_GYNOID || ptr->mtyp == PM_OPERATOR || ptr->mtyp == PM_COMMANDER
 	) lev_limit = 30;	/* same as player */
-	else if (ptr == &mons[PM_PLUMACH_RILMANI] || ptr == &mons[PM_FERRUMACH_RILMANI]) lev_limit = 20;
+	else if (ptr->mtyp == PM_PLUMACH_RILMANI || ptr->mtyp == PM_FERRUMACH_RILMANI) lev_limit = 20;
 	else if (is_eladrin(ptr) && ptr->mlevel <= 20) lev_limit = 30;
-	else if (ptr == &mons[PM_OONA]) lev_limit = 60;
-	else if (ptr == &mons[PM_ANCIENT_OF_ICE] || ptr == &mons[PM_ANCIENT_OF_DEATH]) lev_limit = 45;
+	else if (ptr->mtyp == PM_OONA) lev_limit = 60;
+	else if (ptr->mtyp == PM_ANCIENT_OF_ICE || ptr->mtyp == PM_ANCIENT_OF_DEATH) lev_limit = 45;
 	else if (lev_limit < 5) lev_limit = 5;	/* arbitrary */
 	else if (lev_limit > 49) lev_limit = (ptr->mlevel > 49 ? ptr->mlevel : 49);
 
@@ -9683,7 +9683,7 @@ register int otyp;
 	otmp = mksobj(otyp, TRUE, FALSE);
 	if (otmp) {
 		/*Size and shape it to owner*/
-		if((otmp->oclass == ARMOR_CLASS || otmp->oclass == WEAPON_CLASS) && mtmp->data != &mons[PM_HOBBIT])
+		if((otmp->oclass == ARMOR_CLASS || otmp->oclass == WEAPON_CLASS) && mtmp->mtyp != PM_HOBBIT)
 			otmp->objsize = mtmp->data->msize;
 		if(otmp->otyp == BULLWHIP && is_drow(mtmp->data) && mtmp->female)
 			otmp->obj_material = SILVER;
@@ -9695,17 +9695,17 @@ register int otyp;
 		
 		if(mtmp->data->mlet == S_GOLEM){
 			if(otmp->oclass == WEAPON_CLASS || otmp->oclass == ARMOR_CLASS){
-				if(mtmp->data == &mons[PM_GOLD_GOLEM]){
+				if(mtmp->mtyp == PM_GOLD_GOLEM){
 					otmp->obj_material = GOLD;
-				} else if(mtmp->data == &mons[PM_TREASURY_GOLEM]){
+				} else if(mtmp->mtyp == PM_TREASURY_GOLEM){
 					otmp->obj_material = GOLD;
-				} else if(mtmp->data == &mons[PM_GLASS_GOLEM]){
+				} else if(mtmp->mtyp == PM_GLASS_GOLEM){
 					otmp->obj_material = GLASS;
-				} else if(mtmp->data == &mons[PM_GROVE_GUARDIAN]){
+				} else if(mtmp->mtyp == PM_GROVE_GUARDIAN){
 					otmp->obj_material = SILVER;
-				} else if(mtmp->data == &mons[PM_IRON_GOLEM]){
+				} else if(mtmp->mtyp == PM_IRON_GOLEM){
 					otmp->obj_material = IRON;
-				} else if(mtmp->data == &mons[PM_ARGENTUM_GOLEM]){
+				} else if(mtmp->mtyp == PM_ARGENTUM_GOLEM){
 					otmp->obj_material = SILVER;
 				}
 			}
@@ -9713,7 +9713,7 @@ register int otyp;
 		if (is_demon(mtmp->data)) {
 			/* demons never get blessed objects */
 			if (otmp->blessed) curse(otmp);
-			if(mtmp->data == &mons[PM_MARILITH] && otmp->oclass == WEAPON_CLASS){
+			if(mtmp->mtyp == PM_MARILITH && otmp->oclass == WEAPON_CLASS){
 				int roll = rnd(3);
 				otmp->spe = max(otmp->spe, roll);
 				
@@ -9883,7 +9883,7 @@ register struct permonst *ptr;
 	
 	if(u.uhouse &&
 		(u.uhouse == XAXOX || u.uhouse == EDDER_SYMBOL)
-		&& ptr == &mons[PM_EDDERKOP]
+		&& ptr->mtyp == PM_EDDERKOP
 	) return TRUE;
 	
 	if(u.uhouse &&
@@ -9894,7 +9894,7 @@ register struct permonst *ptr;
 	
 	if(u.uhouse &&
 		u.uhouse == GHAUNADAUR_SYMBOL
-		&& (ptr == &mons[PM_SHOGGOTH] || ptr == &mons[PM_PRIEST_OF_GHAUNADAUR] || ptr == &mons[PM_PRIESTESS_OF_GHAUNADAUR])
+		&& (ptr->mtyp == PM_SHOGGOTH || ptr->mtyp == PM_PRIEST_OF_GHAUNADAUR || ptr->mtyp == PM_PRIESTESS_OF_GHAUNADAUR)
 	) return TRUE;
 	
 	if (ptr == &mons[urole.ldrnum] || ptr->msound == MS_GUARDIAN)
@@ -10038,13 +10038,13 @@ register struct monst *mtmp;
 #endif
 	else	rt = 0;	/* roomno < 0 case for GCC_WARN */
 
-	if (mtmp->data == &mons[PM_DARK_YOUNG]) {
+	if (mtmp->mtyp == PM_DARK_YOUNG) {
 		ap_type = M_AP_FURNITURE;
 		appear = S_deadtree;
-	} else if (mtmp->data == &mons[PM_SHARAB_KAMEREL]) {
+	} else if (mtmp->mtyp == PM_SHARAB_KAMEREL) {
 		ap_type = M_AP_FURNITURE;
 		appear = S_puddle;
-	} else if (mtmp->data == &mons[PM_LIVING_MIRAGE]) {
+	} else if (mtmp->mtyp == PM_LIVING_MIRAGE) {
 		ap_type = M_AP_FURNITURE;
 		appear = S_puddle;
 	} else if (OBJ_AT(mx, my)) {

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -8459,7 +8459,7 @@ register int	mmflags;
 			mtmp->cham = CHAM_ORDINARY;
 		else {
 			mtmp->cham = mcham;
-			(void) newcham(mtmp, rndmonst(), FALSE, FALSE);
+			(void)newcham(mtmp, select_newcham_form(mtmp), FALSE, FALSE);
 		}
 	} else if (mndx == PM_WIZARD_OF_YENDOR) {
 		mtmp->iswiz = TRUE;

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -27,7 +27,7 @@ cursetxt(mtmp, undirected)
 struct monst *mtmp;
 boolean undirected;
 {
-	if(mtmp->data == &mons[PM_HOUND_OF_TINDALOS])
+	if(mtmp->mtyp == PM_HOUND_OF_TINDALOS)
 		return;
 	if (canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my)) {
 	    const char *point_msg;  /* spellcasting monsters are impolite */
@@ -1386,7 +1386,7 @@ castmu(mtmp, mattk, thinks_it_foundyou, foundyou)
 	int dmd, dmn;
 	struct obj *mirror;
 
-	if(mtmp->data == &mons[PM_NITOCRIS] && !mtmp->mspec_used && which_armor(mtmp, W_ARMC) && which_armor(mtmp, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF){
+	if(mtmp->mtyp == PM_NITOCRIS && !mtmp->mspec_used && which_armor(mtmp, W_ARMC) && which_armor(mtmp, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF){
 		if(canseemon(mtmp)) pline("Dark water churns around Nitocris!");
 	}
 	else if(mon_resistance(mtmp, NULLMAGIC)) return 0;
@@ -1409,8 +1409,8 @@ castmu(mtmp, mattk, thinks_it_foundyou, foundyou)
 	if ((mattk->adtyp == AD_SPEL || mattk->adtyp == AD_CLRC || mattk->adtyp == AD_PSON) && ml) {
 	    int cnt = 40;
 		
-		// if(Race_if(PM_DROW) && mtmp->data == &mons[PM_AVATAR_OF_LOLTH] && !Role_if(PM_EXILE) && !mtmp->mpeaceful){
-		if(mtmp->data == &mons[PM_AVATAR_OF_LOLTH] && !mtmp->mpeaceful && !strcmp(urole.cgod,"Lolth")){
+		// if(Race_if(PM_DROW) && mtmp->mtyp == PM_AVATAR_OF_LOLTH && !Role_if(PM_EXILE) && !mtmp->mpeaceful){
+		if(mtmp->mtyp == PM_AVATAR_OF_LOLTH && !mtmp->mpeaceful && !strcmp(urole.cgod,"Lolth")){
 			u.ugangr[Align2gangr(A_CHAOTIC)]++;
 			angrygods(A_CHAOTIC);
 			return 1;
@@ -1441,7 +1441,7 @@ castmu(mtmp, mattk, thinks_it_foundyou, foundyou)
 	}
 
 	if ((mattk->adtyp == AD_SPEL || mattk->adtyp == AD_CLRC) && !nospellcooldowns_mon(mtmp)) {
-	    if(mtmp->data == &mons[PM_HEDROW_WARRIOR]) mtmp->mspec_used = d(4,4);
+	    if(mtmp->mtyp == PM_HEDROW_WARRIOR) mtmp->mspec_used = d(4,4);
 		else mtmp->mspec_used = 10 - mtmp->m_lev;
 	    if (mtmp->mspec_used < 2) mtmp->mspec_used = 2;
 	}
@@ -1452,7 +1452,7 @@ castmu(mtmp, mattk, thinks_it_foundyou, foundyou)
 	if (!foundyou && thinks_it_foundyou &&
 		!is_undirected_spell(spellnum) &&
 		!is_aoe_spell(spellnum)) {
-		if(mtmp->data == &mons[PM_HOUND_OF_TINDALOS])
+		if(mtmp->mtyp == PM_HOUND_OF_TINDALOS)
 			return 0;
 	    pline("%s casts a spell at %s!",
 		canseemon(mtmp) ? Monnam(mtmp) : "Something",
@@ -1488,7 +1488,7 @@ castmu(mtmp, mattk, thinks_it_foundyou, foundyou)
 			return(0);
 		}
 	}
-	if(mtmp->data != &mons[PM_HOUND_OF_TINDALOS]){
+	if(mtmp->mtyp != PM_HOUND_OF_TINDALOS){
 		if (canspotmon(mtmp) || !is_undirected_spell(spellnum)) {
 		    pline("%s casts a spell%s!",
 			  canspotmon(mtmp) ? Monnam(mtmp) : "Something",
@@ -2282,7 +2282,7 @@ int spellnum;
 			flags.cth_attk=TRUE;//state machine stuff.
 			create_fog_cloud(mtmp->mux, mtmp->muy, 3, 8);
 			flags.cth_attk=FALSE;
-			if(mtmp->data == &mons[PM_PLUMACH_RILMANI]) mtmp->mcan = 1;
+			if(mtmp->mtyp == PM_PLUMACH_RILMANI) mtmp->mcan = 1;
 		}
 		dmg = 0;
 		stop_occupation();
@@ -2296,7 +2296,7 @@ int spellnum;
 			// pline("%s blurs with speed!", Monnam(mtmp));
 		// mtmp->movement += (extraturns)*12;
 		// for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
-			// if(tmpm->data == &mons[PM_UVUUDAUM] && tmpm != mtmp){
+			// if(tmpm->mtyp == PM_UVUUDAUM && tmpm != mtmp){
 				// tmpm->movement += (extraturns)*12;
 				// if(canseemon(tmpm))
 					// pline("%s blurs with speed!", Monnam(tmpm));
@@ -3567,7 +3567,7 @@ castmm(mtmp, mdef, mattk)
 	}
 	/* monster unable to cast spells? */
 	if(mtmp->mcan || (mtmp->mspec_used && !nospellcooldowns_mon(mtmp)) || !ml || needs_familiar(mtmp)) {
-		if(mtmp->data == &mons[PM_HOUND_OF_TINDALOS])
+		if(mtmp->mtyp == PM_HOUND_OF_TINDALOS)
 			return 0;
 	    if (canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my))
 	    {
@@ -3616,7 +3616,7 @@ castmm(mtmp, mdef, mattk)
 			return(0);
 		}
 	}
-	if(mtmp->data != &mons[PM_HOUND_OF_TINDALOS]){ //skip messages
+	if(mtmp->mtyp != PM_HOUND_OF_TINDALOS){ //skip messages
 		if (cansee(mtmp->mx, mtmp->my) ||
 		    canseemon(mtmp) ||
 		    (!is_undirected_spell(spellnum) &&
@@ -4292,7 +4292,7 @@ int spellnum;
 				stackobj(otmp);
 			}
        }
-       if(haseyes(mtmp->data) && mattk && mattk->data != &mons[PM_DEMOGORGON] && rn2(3)) {
+       if(haseyes(mtmp->data) && mattk && mattk->mtyp != PM_DEMOGORGON && rn2(3)) {
 			mtmp->mcansee = 0;
 			mtmp->mblinded = max(mtmp->mblinded, rn1(20, 9));
        }
@@ -5155,7 +5155,7 @@ uspsibolt:
 			flags.cth_attk=TRUE;//state machine stuff.
 			create_fog_cloud(mtmp->mx, mtmp->my, 3, 8);
 			flags.cth_attk=FALSE;
-			if(mattk && mattk->data == &mons[PM_PLUMACH_RILMANI]) mattk->mcan = 1;
+			if(mattk && mattk->mtyp == PM_PLUMACH_RILMANI) mattk->mcan = 1;
 		} else {
 			create_fog_cloud(mtmp->mx, mtmp->my, 3, 8);
 		}
@@ -5339,7 +5339,7 @@ struct monst *mon;
 	if(!is_witch_mon(mon))
 		return FALSE;
 	for(mtmp = fmon; mtmp; mtmp = mtmp->nmon)
-		if(mtmp->data == &mons[PM_WITCH_S_FAMILIAR] && mtmp->mvar_witchID == (long)mon->m_id)
+		if(mtmp->mtyp == PM_WITCH_S_FAMILIAR && mtmp->mvar_witchID == (long)mon->m_id)
 			return FALSE;
 	return TRUE;
 }

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -4312,7 +4312,7 @@ int spellnum;
 	break;
      case TURN_TO_STONE:
 		if(!mtmp) break;
-        if (!(poly_when_stoned(mtmp->data) && newcham(mtmp, &mons[PM_STONE_GOLEM], FALSE, TRUE))) {
+        if (!(poly_when_stoned(mtmp->data) && newcham(mtmp, PM_STONE_GOLEM, FALSE, TRUE))) {
            if(!resists_ston(mtmp) && !rn2(10) ){
 			if (!munstone(mtmp, yours))
 				minstapetrify(mtmp, yours);

--- a/src/minion.c
+++ b/src/minion.c
@@ -116,7 +116,7 @@ aligntyp alignment;
 boolean talk;
 {
     const int *minions = god_minions(gptr);
-    int mnum=NON_PM, mlev, num = 0, first, last;
+    int mtyp=NON_PM, mlev, num = 0, first, last;
 	struct monst *mon;
 
 	mlev = level_difficulty();
@@ -125,7 +125,7 @@ boolean talk;
 	    if (!(mvitals[minions[first]].mvflags & G_GONE && !In_quest(&u.uz)) && monstr[minions[first]] > mlev/2) break;
 	if(minions[first] == NON_PM){ //All minions too weak, or no minions
 		if(first == 0) return (struct monst *) 0;
-		else mnum = minions[first-1];
+		else mtyp = minions[first-1];
 	}
 	else for (last = first; minions[last] != NON_PM; last++)
 	    if (!(mvitals[minions[last]].mvflags & G_GONE && !In_quest(&u.uz))) {
@@ -136,7 +136,7 @@ boolean talk;
 
 	if(!num){ //All minions too strong, or gap between weak and strong minions
 		if(first == 0) return (struct monst *) 0;
-		else mnum = minions[first-1];
+		else mtyp = minions[first-1];
 	}
 /*	Assumption:	minions are presented in ascending order of strength. */
 	else{
@@ -150,27 +150,27 @@ boolean talk;
 			}
 	    }
 		first--; /* correct an off-by-one error */
-		mnum = minions[first];
+		mtyp = minions[first];
 	}
 
 
-    if (mnum == NON_PM) {
+    if (mtyp == NON_PM) {
 		mon = (struct monst *)0;
-    } else if (mons[mnum].pxlth == 0) {
-		struct permonst *pm = &mons[mnum];
+    } else if (mons[mtyp].pxlth == 0) {
+		struct permonst *pm = &mons[mtyp];
 		mon = makemon(pm, u.ux, u.uy, MM_EMIN);
 		if (mon) {
 			mon->isminion = TRUE;
 			EMIN(mon)->min_align = alignment;
 		}
-    } else if (mnum == PM_ANGEL) {
-		mon = makemon(&mons[mnum], u.ux, u.uy, NO_MM_FLAGS);
+    } else if (mtyp == PM_ANGEL) {
+		mon = makemon(&mons[mtyp], u.ux, u.uy, NO_MM_FLAGS);
 		if (mon) {
 			mon->isminion = TRUE;
 			EPRI(mon)->shralign = alignment;	/* always A_LAWFUL here */
 		}
     } else
-		mon = makemon(&mons[mnum], u.ux, u.uy, NO_MM_FLAGS);
+		mon = makemon(&mons[mtyp], u.ux, u.uy, NO_MM_FLAGS);
     if (mon) {
 		if (talk) {
 			pline_The("voice of %s booms:", align_gname(alignment));
@@ -217,45 +217,45 @@ boolean devils;
 boolean angels;
 {
     register struct monst *mon;
-    int mnum;
+    int mtyp;
 
     switch ((int)alignment) {
 	case A_LAWFUL:
 	case A_VOID:
-	    mnum = devils ? ndemon(alignment) : lminion();
+	    mtyp = devils ? ndemon(alignment) : lminion();
 	    break;
 	case A_NEUTRAL:
-	    mnum = angels ? nminion() : (PM_AIR_ELEMENTAL + rn2(8));
+	    mtyp = angels ? nminion() : (PM_AIR_ELEMENTAL + rn2(8));
 	    break;
 	case A_CHAOTIC:
-	    mnum = angels ? cminion() : ndemon(alignment);
+	    mtyp = angels ? cminion() : ndemon(alignment);
 	    break;
 	case A_NONE:
-	    mnum = angels ? PM_FALLEN_ANGEL : ndemon(alignment);
+	    mtyp = angels ? PM_FALLEN_ANGEL : ndemon(alignment);
 	    break;
 	default:
 //	    impossible("unaligned player?");
 		pline("Odd alignment in minion summoning: %d",(int)alignment);
-	    mnum = ndemon(A_NONE);
+	    mtyp = ndemon(A_NONE);
 	    break;
     }
-    if (mnum == NON_PM) {
+    if (mtyp == NON_PM) {
 		mon = 0;
-    } else if (mons[mnum].pxlth == 0) {
-		struct permonst *pm = &mons[mnum];
+    } else if (mons[mtyp].pxlth == 0) {
+		struct permonst *pm = &mons[mtyp];
 		mon = makemon(pm, u.ux, u.uy, MM_EMIN);
 		if (mon) {
 			mon->isminion = TRUE;
 			EMIN(mon)->min_align = alignment;
 		}
-    } else if (mnum == PM_ANGEL) {
-		mon = makemon(&mons[mnum], u.ux, u.uy, NO_MM_FLAGS);
+    } else if (mtyp == PM_ANGEL) {
+		mon = makemon(&mons[mtyp], u.ux, u.uy, NO_MM_FLAGS);
 		if (mon) {
 			mon->isminion = TRUE;
 			EPRI(mon)->shralign = alignment;	/* always A_LAWFUL here */
 		}
     } else
-		mon = makemon(&mons[mnum], u.ux, u.uy, NO_MM_FLAGS);
+		mon = makemon(&mons[mtyp], u.ux, u.uy, NO_MM_FLAGS);
     if (mon) {
 	if (talk) {
 	    pline_The("voice of %s booms:", align_gname(alignment));

--- a/src/minion.c
+++ b/src/minion.c
@@ -188,7 +188,7 @@ boolean talk;
 			int faction = god_faction(gptr);
 			struct obj *otmp;
 
-			mon->mfaction = faction;
+			set_faction(mon, faction);
 			
 			for(otmp = mon->minvent; otmp; otmp = otmp->nobj){
 				if(otmp->otyp == find_signet_ring() || otmp->otyp == DROVEN_CHAIN_MAIL || otmp->otyp == DROVEN_PLATE_MAIL || otmp->otyp == NOBLE_S_DRESS){
@@ -198,7 +198,7 @@ boolean talk;
 		}
 		
 		if(gptr == DreadFracture && mon->mfaction != FRACTURED){
-			mon->mfaction = FRACTURED;
+			set_faction(mon, FRACTURED);
 			mon->m_lev += 4;
 			mon->mhpmax = d(mon->m_lev, 8);
 			mon->mhp = mon->mhpmax;

--- a/src/minion.c
+++ b/src/minion.c
@@ -30,23 +30,23 @@ struct monst *mon;
 	if (mon) {
 	    ptr = mon->data;
 	    atyp = (ptr->maligntyp==A_NONE) ? A_NONE : sgn(ptr->maligntyp);
-	    if (mon->ispriest || mon->data == &mons[PM_ALIGNED_PRIEST]
-		|| mon->data == &mons[PM_ANGEL])
+	    if (mon->ispriest || mon->mtyp == PM_ALIGNED_PRIEST
+		|| mon->mtyp == PM_ANGEL)
 		atyp = EPRI(mon)->shralign;
 	} else {
 	    ptr = &mons[PM_WIZARD_OF_YENDOR];
 	    atyp = (ptr->maligntyp==A_NONE) ? A_NONE : sgn(ptr->maligntyp);
 	}
-	if(ptr == &mons[PM_SHAKTARI]) {
+	if(ptr->mtyp == PM_SHAKTARI) {
 	    dtype = PM_MARILITH;
 		cnt = d(1,6);
-	} else if(ptr == &mons[PM_BAALPHEGOR] && rn2(4)) {
+	} else if(ptr->mtyp == PM_BAALPHEGOR && rn2(4)) {
 	    dtype = rn2(4) ? PM_METAMORPHOSED_NUPPERIBO : PM_ANCIENT_NUPPERIBO;
 		cnt = d(4,4);
-	} else if(ptr == &mons[PM_ANCIENT_OF_ICE] || ptr == &mons[PM_ANCIENT_OF_DEATH]) {
+	} else if(ptr->mtyp == PM_ANCIENT_OF_ICE || ptr->mtyp == PM_ANCIENT_OF_DEATH) {
 	    dtype = rn2(4) ? PM_METAMORPHOSED_NUPPERIBO : PM_ANCIENT_NUPPERIBO;
 		cnt = d(1,4);
-	} else if (is_dprince(ptr) || (ptr == &mons[PM_WIZARD_OF_YENDOR])) {
+	} else if (is_dprince(ptr) || (ptr->mtyp == PM_WIZARD_OF_YENDOR)) {
 	    dtype = (!rn2(20)) ? dprince(ptr, atyp) :
 				 (!rn2(4)) ? dlord(ptr, atyp) : ndemon(atyp);
 	    cnt = (!rn2(4) && is_ndemon(&mons[dtype])) ? 2 : 1;
@@ -60,7 +60,7 @@ struct monst *mon;
 	    cnt = 1;
 	} else if (is_lminion(mon)) {
 		if(is_keter(mon->data)){
-			if(mon->data == &mons[PM_MALKUTH_SEPHIRAH] && rn2(8)) return;
+			if(mon->mtyp == PM_MALKUTH_SEPHIRAH && rn2(8)) return;
 			dtype = PM_MALKUTH_SEPHIRAH;
 			cnt = (!rn2(4) && !is_lord(&mons[dtype])) ? 2 : 1;
 		} else if(In_endgame(&u.uz)){
@@ -75,7 +75,7 @@ struct monst *mon;
 	} else if (is_cminion(mon) && In_endgame(&u.uz)) {
 	    dtype = (is_lord(ptr) && !rn2(20)) ? clord() : cminion();
 	    cnt = (!rn2(4) && !is_lord(&mons[dtype])) ? 2 : 1;
-	} else if (ptr == &mons[PM_ANGEL]) {
+	} else if (ptr->mtyp == PM_ANGEL) {
 	    if (rn2(6)) {
 			(void) summon_god_minion(align_gname_full(atyp), atyp, FALSE);
 	    } else {
@@ -313,7 +313,7 @@ register struct monst *mtmp;
 	    set_malign(mtmp);
 	    return 0;
 	} else {
-		if(mtmp->data == &mons[PM_ASMODEUS] && demand < 9000) demand = 9000 + rn2(1000);
+		if(mtmp->mtyp == PM_ASMODEUS && demand < 9000) demand = 9000 + rn2(1000);
 		else if(demand < 2000) demand = max(1000+rnd(1000), demand); //demons can't be bribed with chump change.
 	    /* make sure that the demand is unmeetable if the monster
 	       has the Amulet, preventing monster from being satisified
@@ -404,13 +404,13 @@ aligntyp atyp;
 	int tryct, pm;
 	
 	/*Specific aliances go here*/
-	if(ptr == &mons[PM_BAPHOMET] && !(mvitals[PM_PALE_NIGHT].mvflags & G_GONE))
+	if(ptr->mtyp == PM_BAPHOMET && !(mvitals[PM_PALE_NIGHT].mvflags & G_GONE))
 		return PM_PALE_NIGHT;
-	if(ptr == &mons[PM_PALE_NIGHT] && !(mvitals[PM_ASCODEL].mvflags & G_GONE) && !rn2(4))
+	if(ptr->mtyp == PM_PALE_NIGHT && !(mvitals[PM_ASCODEL].mvflags & G_GONE) && !rn2(4))
 		return PM_ASCODEL;
-	if(ptr == &mons[PM_PALE_NIGHT] && !(mvitals[PM_GRAZ_ZT].mvflags & G_GONE))
+	if(ptr->mtyp == PM_PALE_NIGHT && !(mvitals[PM_GRAZ_ZT].mvflags & G_GONE))
 		return PM_GRAZ_ZT;
-	if(ptr == &mons[PM_DEMOGORGON] && !(mvitals[PM_DAGON].mvflags & G_GONE))
+	if(ptr->mtyp == PM_DEMOGORGON && !(mvitals[PM_DAGON].mvflags & G_GONE))
 		return PM_DAGON;
 
 	if(atyp == A_NONE) atyp = !rn2(3) ? A_LAWFUL : A_CHAOTIC;
@@ -422,12 +422,12 @@ aligntyp atyp;
 		for (tryct = 0; tryct < 20; tryct++) {
 			pm = demonPrinces[rn2(SIZE(demonPrinces))];
 			if (!(mvitals[pm].mvflags & G_GONE
-				|| (ptr == &mons[PM_GRAZ_ZT] && pm == PM_MALCANTHET)
-				|| (ptr == &mons[PM_MALCANTHET] && pm == PM_GRAZ_ZT)
-				|| (ptr == &mons[PM_OBOX_OB] && pm == PM_DEMOGORGON)
-				|| (ptr == &mons[PM_DEMOGORGON] && pm == PM_OBOX_OB)
-				|| (ptr == &mons[PM_LAMASHTU] && pm == PM_DEMOGORGON)
-				|| (ptr == &mons[PM_DEMOGORGON] && pm == PM_LAMASHTU)
+				|| (ptr->mtyp == PM_GRAZ_ZT && pm == PM_MALCANTHET)
+				|| (ptr->mtyp == PM_MALCANTHET && pm == PM_GRAZ_ZT)
+				|| (ptr->mtyp == PM_OBOX_OB && pm == PM_DEMOGORGON)
+				|| (ptr->mtyp == PM_DEMOGORGON && pm == PM_OBOX_OB)
+				|| (ptr->mtyp == PM_LAMASHTU && pm == PM_DEMOGORGON)
+				|| (ptr->mtyp == PM_DEMOGORGON && pm == PM_LAMASHTU)
 			))
 				return(pm);
 		}
@@ -464,22 +464,22 @@ aligntyp atyp;
 	int tryct, pm;
 	
 	/*Specific aliances go here*/
-	if(ptr == &mons[PM_MEPHISTOPHELES] && !(mvitals[PM_BAALPHEGOR].mvflags & G_GONE))
+	if(ptr->mtyp == PM_MEPHISTOPHELES && !(mvitals[PM_BAALPHEGOR].mvflags & G_GONE))
 		return PM_BAALPHEGOR;
-	if(ptr == &mons[PM_CRONE_LILITH] && !(mvitals[PM_MOTHER_LILITH].mvflags & G_GONE))
+	if(ptr->mtyp == PM_CRONE_LILITH && !(mvitals[PM_MOTHER_LILITH].mvflags & G_GONE))
 		return PM_MOTHER_LILITH;
-	if(ptr == &mons[PM_CRONE_LILITH] && !(mvitals[PM_DAUGHTER_LILITH].mvflags & G_GONE))
+	if(ptr->mtyp == PM_CRONE_LILITH && !(mvitals[PM_DAUGHTER_LILITH].mvflags & G_GONE))
 		return PM_DAUGHTER_LILITH;
-	if(ptr == &mons[PM_MOTHER_LILITH] && !(mvitals[PM_DAUGHTER_LILITH].mvflags & G_GONE))
+	if(ptr->mtyp == PM_MOTHER_LILITH && !(mvitals[PM_DAUGHTER_LILITH].mvflags & G_GONE))
 		return PM_DAUGHTER_LILITH;
-	if(ptr == &mons[PM_BELIAL] && !(mvitals[PM_FIERNA].mvflags & G_GONE))
+	if(ptr->mtyp == PM_BELIAL && !(mvitals[PM_FIERNA].mvflags & G_GONE))
 		return PM_FIERNA;
-	if(ptr == &mons[PM_MAMMON] && !(mvitals[PM_GLASYA].mvflags & G_GONE) && !rn2(20))
+	if(ptr->mtyp == PM_MAMMON && !(mvitals[PM_GLASYA].mvflags & G_GONE) && !rn2(20))
 		return PM_GLASYA;
 	
-	if(ptr == &mons[PM_PALE_NIGHT] && !(mvitals[PM_BAPHOMET].mvflags & G_GONE))
+	if(ptr->mtyp == PM_PALE_NIGHT && !(mvitals[PM_BAPHOMET].mvflags & G_GONE))
 		return PM_BAPHOMET;
-	if(ptr == &mons[PM_OBOX_OB] && !(mvitals[PM_ALDINACH].mvflags & G_GONE))
+	if(ptr->mtyp == PM_OBOX_OB && !(mvitals[PM_ALDINACH].mvflags & G_GONE))
 		return PM_ALDINACH;
 
 	if(atyp == A_NONE) atyp = rn2(2) ? A_LAWFUL : A_CHAOTIC;
@@ -489,8 +489,8 @@ aligntyp atyp;
 			pm = lordsOfTheNine[rn2(SIZE(lordsOfTheNine))];
 			if(pm == PM_CRONE_LILITH) pm = !rn2(3) ? PM_CRONE_LILITH : !rn2(2) ? PM_MOTHER_LILITH : PM_DAUGHTER_LILITH;
 			if (!(mvitals[pm].mvflags & G_GONE
-				|| (ptr == &mons[PM_MEPHISTOPHELES] && pm == PM_BAALZEBUB)
-				|| (ptr == &mons[PM_BAALZEBUB] && pm == PM_MEPHISTOPHELES)
+				|| (ptr->mtyp == PM_MEPHISTOPHELES && pm == PM_BAALZEBUB)
+				|| (ptr->mtyp == PM_BAALZEBUB && pm == PM_MEPHISTOPHELES)
 			)){
 				if(pm == PM_CREATURE_IN_THE_ICE){
 					mvitals[pm].mvflags |= G_GONE;
@@ -503,10 +503,10 @@ aligntyp atyp;
 		for (tryct = 0; tryct < 20; tryct++) {
 			pm = demonLords[rn2(SIZE(demonLords))];
 			if (!(mvitals[pm].mvflags & G_GONE
-				|| (ptr == &mons[PM_BAPHOMET] && pm == PM_YEENOGHU)
-				|| (ptr == &mons[PM_YEENOGHU] && pm == PM_BAPHOMET)
-				|| (ptr == &mons[PM_ZUGGTMOY] && pm == PM_JUIBLEX)
-				|| (ptr == &mons[PM_JUIBLEX] && pm == PM_ZUGGTMOY)
+				|| (ptr->mtyp == PM_BAPHOMET && pm == PM_YEENOGHU)
+				|| (ptr->mtyp == PM_YEENOGHU && pm == PM_BAPHOMET)
+				|| (ptr->mtyp == PM_ZUGGTMOY && pm == PM_JUIBLEX)
+				|| (ptr->mtyp == PM_JUIBLEX && pm == PM_ZUGGTMOY)
 			))
 				return(pm);
 		}

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1242,7 +1242,7 @@ skip0:
 		if(u.uhave.amulet || !rn2(3)) {
 		    x = somex(croom); y = somey(croom);
 		    tmonst = makemon((struct permonst *) 0, x,y,NO_MM_FLAGS);
-		    if (tmonst && tmonst->data == &mons[PM_GIANT_SPIDER] &&
+		    if (tmonst && tmonst->mtyp == PM_GIANT_SPIDER &&
 			    !occupied(x, y))
 			(void) maketrap(x, y, WEB);
 		}

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2930,7 +2930,7 @@ add_to_minv(mon, obj)
     if (obj->where != OBJ_FREE)
 	panic("add_to_minv: obj not free");
 
-	if(mon->data == &mons[PM_MAID] && maid_clean(mon, obj) ) return 1; /*destroyed by maid*/
+	if(mon->mtyp == PM_MAID && maid_clean(mon, obj) ) return 1; /*destroyed by maid*/
 
     /* merge if possible */
     for (otmp = mon->minvent; otmp; otmp = otmp->nobj)

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2480,7 +2480,7 @@ struct monst *mtmp;
 	otmp = realloc_obj(obj, lth, (genericptr_t) mtmp, namelth, ONAME(obj));
 	if (otmp && otmp->oxlth) {
 		struct monst *mtmp2 = (struct monst *)otmp->oextra;
-		if (mtmp->data) mtmp2->mnum = monsndx(mtmp->data);
+		if (mtmp->data) mtmp2->mtyp = monsndx(mtmp->data);
 		/* invalidate pointers */
 		/* m_id is needed to know if this is a revived quest leader */
 		/* but m_id must be cleared when loading bones */

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -267,8 +267,8 @@ mkmivault()
 			ptr = mivaultmon();
 			mon = makemon(ptr, x+rnd(2)+1, y+rnd(2)+1, 0);
 			// lovecraft monsters
-			if (ptr == &mons[PM_SHOGGOTH] || ptr == &mons[PM_NIGHTGAUNT]
-					|| ptr == &mons[PM_DARK_YOUNG] || ptr == &mons[PM_HUNTING_HORROR] || ptr == &mons[PM_HUNTING_HORROR_TAIL]){
+			if (ptr->mtyp == PM_SHOGGOTH || ptr->mtyp == PM_NIGHTGAUNT
+					|| ptr->mtyp == PM_DARK_YOUNG || ptr->mtyp == PM_HUNTING_HORROR || ptr->mtyp == PM_HUNTING_HORROR_TAIL){
 				otmp2 = mksobj(FIGURINE, TRUE, FALSE);
 				switch(rn2(4)){
 					case 0:					
@@ -294,10 +294,10 @@ mkmivault()
 				add_to_container(otmp, otmp2);
 			}
 			// clockworks
-			else if (ptr == &mons[PM_JUGGERNAUT] || ptr == &mons[PM_ID_JUGGERNAUT] 
-					|| ptr == &mons[PM_SCRAP_TITAN] || ptr == &mons[PM_HELLFIRE_COLOSSUS]){
+			else if (ptr->mtyp == PM_JUGGERNAUT || ptr->mtyp == PM_ID_JUGGERNAUT 
+					|| ptr->mtyp == PM_SCRAP_TITAN || ptr->mtyp == PM_HELLFIRE_COLOSSUS){
 				if (rn2(2)){
-					add_to_container(otmp, mksobj(ptr == &mons[PM_ID_JUGGERNAUT] ? SUBETHAIC_COMPONENT : HELLFIRE_COMPONENT, TRUE, FALSE));
+					add_to_container(otmp, mksobj(ptr->mtyp == PM_ID_JUGGERNAUT ? SUBETHAIC_COMPONENT : HELLFIRE_COMPONENT, TRUE, FALSE));
 				} else {
 					add_to_container(otmp, mksobj(SCRAP, TRUE, FALSE));
 				}
@@ -312,9 +312,9 @@ mkmivault()
 				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
 			}
 			// spellcasters
-			else if (ptr == &mons[PM_TITAN] || ptr == &mons[PM_EYE_OF_DOOM] 
-					|| ptr == &mons[PM_PRIEST_OF_GHAUNADAUR] || ptr == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-						|| ptr == &mons[PM_SERPENT_MAN_OF_YOTH]){
+			else if (ptr->mtyp == PM_TITAN || ptr->mtyp == PM_EYE_OF_DOOM 
+					|| ptr->mtyp == PM_PRIEST_OF_GHAUNADAUR || ptr->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+						|| ptr->mtyp == PM_SERPENT_MAN_OF_YOTH){
 				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
 				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
 				if (rn2(2)) add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
@@ -407,8 +407,8 @@ mkmivaultlolth()
 			ptr = mivaultmon();
 			mon = makemon(ptr, x+rnd(2), y+rnd(2), 0);
 			// lovecraft monsters
-			if (ptr == &mons[PM_SHOGGOTH] || ptr == &mons[PM_NIGHTGAUNT] 
-				|| ptr == &mons[PM_DARK_YOUNG] || ptr == &mons[PM_HUNTING_HORROR] || ptr == &mons[PM_HUNTING_HORROR_TAIL]){
+			if (ptr->mtyp == PM_SHOGGOTH || ptr->mtyp == PM_NIGHTGAUNT 
+				|| ptr->mtyp == PM_DARK_YOUNG || ptr->mtyp == PM_HUNTING_HORROR || ptr->mtyp == PM_HUNTING_HORROR_TAIL){
 				otmp2 = mksobj(FIGURINE, TRUE, FALSE);
 				switch(rn2(4)){
 					case 0:					
@@ -434,10 +434,10 @@ mkmivaultlolth()
 				add_to_container(otmp, otmp2);
 			}
 			// clockworks
-			else if (ptr == &mons[PM_JUGGERNAUT] || ptr == &mons[PM_ID_JUGGERNAUT] 
-					|| ptr == &mons[PM_SCRAP_TITAN] || ptr == &mons[PM_HELLFIRE_COLOSSUS]){
+			else if (ptr->mtyp == PM_JUGGERNAUT || ptr->mtyp == PM_ID_JUGGERNAUT 
+					|| ptr->mtyp == PM_SCRAP_TITAN || ptr->mtyp == PM_HELLFIRE_COLOSSUS){
 				if (rn2(2)){
-					add_to_container(otmp, mksobj(ptr == &mons[PM_ID_JUGGERNAUT] ? SUBETHAIC_COMPONENT : HELLFIRE_COMPONENT, TRUE, FALSE));
+					add_to_container(otmp, mksobj(ptr->mtyp == PM_ID_JUGGERNAUT ? SUBETHAIC_COMPONENT : HELLFIRE_COMPONENT, TRUE, FALSE));
 				} else {
 					add_to_container(otmp, mksobj(SCRAP, TRUE, FALSE));
 				}
@@ -452,9 +452,9 @@ mkmivaultlolth()
 				add_to_container(otmp, mksobj(CLOCKWORK_COMPONENT, TRUE, FALSE));
 			}
 			// spellcasters
-			else if (ptr == &mons[PM_TITAN] || ptr == &mons[PM_EYE_OF_DOOM] 
-					|| ptr == &mons[PM_PRIEST_OF_GHAUNADAUR] || ptr == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-						|| ptr == &mons[PM_SERPENT_MAN_OF_YOTH]){
+			else if (ptr->mtyp == PM_TITAN || ptr->mtyp == PM_EYE_OF_DOOM 
+					|| ptr->mtyp == PM_PRIEST_OF_GHAUNADAUR || ptr->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+						|| ptr->mtyp == PM_SERPENT_MAN_OF_YOTH){
 				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
 				add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));
 				if (rn2(2)) add_to_container(otmp, mkobj(SPBOOK_CLASS, FALSE));

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -532,7 +532,7 @@ void
 mklolthgnoll()
 {
 	int x,y,tries=0;
-	int i,j, rmnumb = nroom+ROOMOFFSET, trycount, madedoor;
+	int i,j, rmtypb = nroom+ROOMOFFSET, trycount, madedoor;
 	struct obj *otmp;
 	struct monst *mon;
 	boolean good=FALSE,okspot;
@@ -546,7 +546,7 @@ mklolthgnoll()
 			good = TRUE;
 			for(i=0;i<10;i++) for(j=0;j<10;j++){
 				levl[x+i][y+j].typ = CORR;
-				levl[x+i][y+j].roomno = rmnumb;
+				levl[x+i][y+j].roomno = rmtypb;
 			}
 			for(i=0;i<10;i++){
 				levl[x][y+i].edge = 1;
@@ -675,7 +675,7 @@ void
 mklolthgarden()
 {
 	int x,y,tries=0, width= rn1(4,5), height=rn1(4,5);
-	int i,j, rmnumb = nroom+ROOMOFFSET, trycount, madedoor;
+	int i,j, rmtypb = nroom+ROOMOFFSET, trycount, madedoor;
 	struct obj *otmp;
 	struct monst *mon;
 	boolean good=FALSE,okspot;
@@ -805,7 +805,7 @@ void
 mklolthtroll()
 {
 	int x,y,tries=0, width= 6, height=6;
-	int i,j, rmnumb = nroom+ROOMOFFSET, trycount, madedoor;
+	int i,j, rmtypb = nroom+ROOMOFFSET, trycount, madedoor;
 	struct obj *otmp;
 	struct monst *mon;
 	boolean good=FALSE,okspot;
@@ -924,7 +924,7 @@ void
 mklolthtreasure()
 {
 	int x,y,tries=0, width= 5, height=5;
-	int i,j, rmnumb = nroom+ROOMOFFSET, trycount, madedoor;
+	int i,j, rmtypb = nroom+ROOMOFFSET, trycount, madedoor;
 	struct obj *otmp, *container;
 	struct monst *mon;
 	boolean good=FALSE,okspot;
@@ -1971,7 +1971,7 @@ void
 mkfishinghut(left)
 	int left;
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j, pathto = 0;
 	boolean good=FALSE, okspot, accessible;
 	struct obj *otmp;
@@ -2081,7 +2081,7 @@ void
 mkwell(left)
 	int left;
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j, pathto = 0;
 	boolean good=FALSE, okspot, accessible;
 	struct obj *otmp;
@@ -2147,7 +2147,7 @@ STATIC_OVL
 void
 mkpluhomestead()
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j, pathto = 0;
 	boolean good=FALSE, okspot, accessible;
 	while(!good && tries < 500){
@@ -2207,7 +2207,7 @@ void
 mkelfhut(left)
 int left;
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j, pathto = 0;
 	boolean good=FALSE, okspot, accessible;
 	while(!good && tries < 500){
@@ -2286,7 +2286,7 @@ void
 mkwraithclearing(right)
 int right;
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j;
 	boolean good=FALSE, okspot, accessible;
 	while(!good && tries < 500){
@@ -2351,7 +2351,7 @@ STATIC_OVL
 void
 mkstonepillars()
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j;
 	boolean good=FALSE, okspot;
 	while(!good && tries < 500){
@@ -2434,7 +2434,7 @@ void
 mkcamp(type)
 	int type;
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int r = 4;
 	int i,j, pathto = 0;
 	boolean good=FALSE, okspot, accessible;
@@ -2528,7 +2528,7 @@ STATIC_OVL
 void
 mkpluvillage()
 {
-	int x,y,tries=0, roomnumb;
+	int x,y,tries=0, roomtypb;
 	int i,j, n,ni;
 	int nshacks, sizebig1, sizebig2, sizetot;
 	struct obj *otmp;
@@ -2573,7 +2573,7 @@ mkpluvillage()
 				}
 			
 			//Make left-hand big building
-			roomnumb = nroom;
+			roomtypb = nroom;
 			
 			levl[x+sizebig1-1][y+4+3].typ = BRCORNER;
 			levl[x+sizebig1-1][y+4+3].lit = 1;
@@ -2689,8 +2689,8 @@ mkpluvillage()
 					add_room(x+1, y+4, x+sizebig1-2, y+6, TRUE, OROOM, TRUE);
 				break;
 			}
-			add_door(x+sizebig1-1,y+5,&rooms[roomnumb]);
-			fill_room(&rooms[roomnumb], FALSE);
+			add_door(x+sizebig1-1,y+5,&rooms[roomtypb]);
+			fill_room(&rooms[roomtypb], FALSE);
 			
 			//Make north and south shacks
 			for(n = 0; n<nshacks; n++){
@@ -2755,7 +2755,7 @@ mkpluvillage()
 			}
 			
 			//Make right big building
-			roomnumb = nroom;
+			roomtypb = nroom;
 			
 			levl[x+sizetot][y+4+3].typ = BRCORNER;
 			levl[x+sizetot][y+4+3].lit = 1;
@@ -2874,8 +2874,8 @@ mkpluvillage()
 					add_room(x+sizetot-sizebig2+1, y+4, x+sizetot-1, y+6, TRUE, OROOM, TRUE);
 				break;
 			}
-			add_door(x+sizetot-sizebig2,y+5,&rooms[roomnumb]);
-			fill_room(&rooms[roomnumb], FALSE);
+			add_door(x+sizetot-sizebig2,y+5,&rooms[roomtypb]);
+			fill_room(&rooms[roomtypb], FALSE);
 		}
 	}
 }
@@ -3282,7 +3282,7 @@ STATIC_OVL
 void
 mkferrutower()
 {
-	int x,y,tries=0, roomnumb = nroom;
+	int x,y,tries=0, roomtypb = nroom;
 	int i,j;
 	boolean good=FALSE, okspot, accessible;
 	int size = 8;
@@ -3349,8 +3349,8 @@ mkferrutower()
 		flood_fill_rm(x+size/2, y+size/2,
 			  nroom+ROOMOFFSET, TRUE, TRUE);
 		add_room(x+2, y+2, x+size-3, y+size-3, TRUE, BARRACKS, TRUE);
-		add_door(x+i,y+j,&rooms[roomnumb]);
-		fill_room(&rooms[roomnumb], FALSE);
+		add_door(x+i,y+j,&rooms[roomtypb]);
+		fill_room(&rooms[roomtypb], FALSE);
 	}
 }
 
@@ -3358,7 +3358,7 @@ STATIC_OVL
 void
 mkinvertzigg()
 {
-	int x,y,tries=0, roomnumb = nroom;
+	int x,y,tries=0, roomtypb = nroom;
 	int i,j;
 	boolean good=FALSE, okspot, accessible;
 	int size = 15;

--- a/src/mon.c
+++ b/src/mon.c
@@ -61,11 +61,11 @@ static const char *nyar_name[] = {
 #define LEVEL_SPECIFIC_NOCORPSE(mdat) \
 	 ((Is_rogue_level(&u.uz) || \
 	   (level.flags.graveyard && is_undead(mdat) && rn2(3))) \
-	   && mdat!=&mons[PM_GARO] && mdat!=&mons[PM_GARO_MASTER])
+	   && mdat->mtyp!=PM_GARO && mdat->mtyp!=PM_GARO_MASTER)
 #else
 #define LEVEL_SPECIFIC_NOCORPSE(mdat) \
 	   (level.flags.graveyard && is_undead(mdat) && rn2(3) \
-	   && mdat!=&mons[PM_GARO] && mdat!=&mons[PM_GARO_MASTER])
+	   && mdat->mtyp!=PM_GARO && mdat->mtyp!=PM_GARO_MASTER)
 #endif
 
 
@@ -232,13 +232,13 @@ STATIC_VAR int cham_to_pm[] = {
 			 ((mon)->mfaction) ||			\
 			 ((mon)->ispolyp) ||			\
 			 ((mon)->zombify) ||			\
-			 ((mon)->data == &mons[PM_UNDEAD_KNIGHT]) ||			\
-			 ((mon)->data == &mons[PM_WARRIOR_OF_SUNLIGHT]) ||			\
-			 ((mon)->data == &mons[PM_LIVING_DOLL]) ||			\
-			 ((mon)->data == &mons[PM_ANDROID]) ||			\
-			 ((mon)->data == &mons[PM_GYNOID]) ||			\
-			 ((mon)->data == &mons[PM_COMMANDER]) ||			\
-			 ((mon)->data == &mons[PM_OPERATOR]) ||			\
+			 ((mon)->mtyp == PM_UNDEAD_KNIGHT) ||			\
+			 ((mon)->mtyp == PM_WARRIOR_OF_SUNLIGHT) ||			\
+			 ((mon)->mtyp == PM_LIVING_DOLL) ||			\
+			 ((mon)->mtyp == PM_ANDROID) ||			\
+			 ((mon)->mtyp == PM_GYNOID) ||			\
+			 ((mon)->mtyp == PM_COMMANDER) ||			\
+			 ((mon)->mtyp == PM_OPERATOR) ||			\
 			 /* normally leader the will be unique, */	\
 			 /* but he might have been polymorphed  */	\
 			 (mon)->m_id == quest_status.leader_m_id ||	\
@@ -1299,12 +1299,12 @@ register struct monst *mtmp;
      * keep going down, and when it gets to 1 hit point the clone
      * function will fail.
      */
-    if (mtmp->data == &mons[PM_GREMLIN] && (inpool || infountain || inshallow) && rn2(3)) {
+    if (mtmp->mtyp == PM_GREMLIN && (inpool || infountain || inshallow) && rn2(3)) {
 	if (split_mon(mtmp, (struct monst *)0))
 	    dryup(mtmp->mx, mtmp->my, FALSE);
 	if (inpool) water_damage(mtmp->minvent, FALSE, FALSE, level.flags.lethe, mtmp);
 	return (0);
-    } else if ((mtmp->data == &mons[PM_IRON_GOLEM] || mtmp->data == &mons[PM_CHAIN_GOLEM]) && ((inpool && !rn2(5)) || inshallow)) {
+    } else if ((mtmp->mtyp == PM_IRON_GOLEM || mtmp->mtyp == PM_CHAIN_GOLEM) && ((inpool && !rn2(5)) || inshallow)) {
 	/* rusting requires oxygen and water, so it's faster for shallow water */
 	int dam = d(2,6);
 	if (cansee(mtmp->mx,mtmp->my))
@@ -1335,7 +1335,7 @@ register struct monst *mtmp;
 	    if (!resists_fire(mtmp)) {
 		if (cansee(mtmp->mx,mtmp->my))
 		    pline("%s %s.", Monnam(mtmp),
-			  mtmp->data == &mons[PM_WATER_ELEMENTAL] ?
+			  mtmp->mtyp == PM_WATER_ELEMENTAL ?
 			  "boils away" : "burns to a crisp");
 		mondead(mtmp);
 	    }
@@ -1364,7 +1364,7 @@ register struct monst *mtmp;
 	if (!is_clinger(mtmp->data)
 	    && !mon_resistance(mtmp,SWIMMING) && !amphibious_mon(mtmp)) {
 	    if (cansee(mtmp->mx,mtmp->my)) {
-		    if(mtmp->data == &mons[PM_ACID_PARAELEMENTAL]){
+		    if(mtmp->mtyp == PM_ACID_PARAELEMENTAL){
 				int tx = mtmp->mx, ty = mtmp->my, dn = mtmp->m_lev;
 				pline("%s explodes.", Monnam(mtmp));
 				mondead(mtmp);
@@ -1419,15 +1419,15 @@ struct monst *mon;
 		mmove *= 2;
 	}
 	
-	if(isdark(mon->mx, mon->my) && mon->data == &mons[PM_GRUE]){
+	if(isdark(mon->mx, mon->my) && mon->mtyp == PM_GRUE){
 		mmove *= 2;
 	}
 	
-	if(is_pool(mon->mx, mon->my, FALSE) && mon->data == &mons[PM_DEEP_DWELLER]){
+	if(is_pool(mon->mx, mon->my, FALSE) && mon->mtyp == PM_DEEP_DWELLER){
 		mmove = mmove*12/7;
 	}
 	
-	if(mon->data == &mons[PM_PYTHON] && !no_upos(mon) && 
+	if(mon->mtyp == PM_PYTHON && !no_upos(mon) && 
 		dist2(mon->mx, mon->my, mon->mux, mon->muy) <= 8)
 		mmove *= 4;
 	
@@ -1438,11 +1438,11 @@ struct monst *mon;
 			mmove -= 2;
 	}
 	
-	if(mon->data == &mons[PM_CHOKHMAH_SEPHIRAH])
+	if(mon->mtyp == PM_CHOKHMAH_SEPHIRAH)
 		mmove += u.chokhmah;
-	if(mon->data == &mons[PM_BANDERSNATCH] && mon->mflee)
+	if(mon->mtyp == PM_BANDERSNATCH && mon->mflee)
 		mmove += 12;
-	if(mon->data == &mons[PM_UVUUDAUM] && mon->mpeaceful)
+	if(mon->mtyp == PM_UVUUDAUM && mon->mpeaceful)
 		mmove /= 4;
     /* Note: MSLOW's `+ 1' prevents slowed speed 1 getting reduced to 0;
      *	     MFAST's `+ 2' prevents hasted speed 1 from becoming a no-op;
@@ -1489,13 +1489,13 @@ mcalcdistress()
 	    if (minliquid(mtmp)) continue;
 	}
 
-	if(mtmp->data == &mons[PM_HEZROU] && !(mtmp->mtrapped && t_at(mtmp->mx, mtmp->my) && t_at(mtmp->mx, mtmp->my)->ttyp == VIVI_TRAP)){
+	if(mtmp->mtyp == PM_HEZROU && !(mtmp->mtrapped && t_at(mtmp->mx, mtmp->my) && t_at(mtmp->mx, mtmp->my)->ttyp == VIVI_TRAP)){
 		flags.cth_attk=TRUE;//state machine stuff.
 		create_gas_cloud(mtmp->mx+rn2(3)-1, mtmp->my+rn2(3)-1, rnd(3), rnd(3)+1);
 		flags.cth_attk=FALSE;
 	}
 	
-	if(mtmp->data == &mons[PM_FIRST_WRAITHWORM] && distmin(u.ux, u.uy, mtmp->mx, mtmp->my) < 6){
+	if(mtmp->mtyp == PM_FIRST_WRAITHWORM && distmin(u.ux, u.uy, mtmp->mx, mtmp->my) < 6){
 		struct monst *tmpm;
 		You("are thrown by a blast of wind!");
 		hurtle(rn2(3)-1, rn2(3)-1, rnd(6), FALSE);
@@ -1506,7 +1506,7 @@ mcalcdistress()
 		}
 	}
 	
-	if(mtmp->data == &mons[PM_ANCIENT_OF_ICE]){
+	if(mtmp->mtyp == PM_ANCIENT_OF_ICE){
 		struct monst *tmpm;
 		int targets = 0, damage = 0;
 		for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -1624,7 +1624,7 @@ mcalcdistress()
 		}
 	}
 	
-	if(mtmp->data == &mons[PM_ANCIENT_OF_DEATH]){
+	if(mtmp->mtyp == PM_ANCIENT_OF_DEATH){
 		struct monst *tmpm;
 		int targets = 0, damage = 0;
 		for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -1657,13 +1657,13 @@ mcalcdistress()
 				pline("Motes of light dance in the air above %s.", mon_nam(tmpm));
 				pline("%s suddenly seems weaker!", Monnam(tmpm));
 				if(resists_drain(tmpm) && has_head_mon(tmpm)) pline("%s looks very surprised!", Monnam(tmpm));
-				pline("The motes are drawn into the %s of %s.", mtmp->data == &mons[PM_BAALPHEGOR] ? "open mouth" : "ghostly hood", mon_nam(mtmp));
+				pline("The motes are drawn into the %s of %s.", mtmp->mtyp == PM_BAALPHEGOR ? "open mouth" : "ghostly hood", mon_nam(mtmp));
 			} else if(canseemon(tmpm)){
 				pline("Motes of light dance in the air above %s.", mon_nam(tmpm));
 				pline("%s suddenly seems weaker!", Monnam(tmpm));
 				if(resists_drain(tmpm) && has_head_mon(tmpm)) pline("%s looks very surprised!", Monnam(tmpm));
 			} else if(canseemon(mtmp)){
-				pline("Motes of light are drawn into the %s of %s.", mtmp->data == &mons[PM_BAALPHEGOR] ? "open mouth" : "ghostly hood", mon_nam(mtmp));
+				pline("Motes of light are drawn into the %s of %s.", mtmp->mtyp == PM_BAALPHEGOR ? "open mouth" : "ghostly hood", mon_nam(mtmp));
 			}
 			damage = d(min(10, (mtmp->m_lev)/3), 4);
 			tmpm->mhp -= damage;
@@ -1692,7 +1692,7 @@ mcalcdistress()
 			pline("Motes of light dance in the air above you.");
 			pline("You suddenly feel weaker!");
 			if(canseemon(mtmp)){
-				pline("The motes are drawn into the %s of %s.", mtmp->data == &mons[PM_BAALPHEGOR] ? "open mouth" : "ghostly hood", mon_nam(mtmp));
+				pline("The motes are drawn into the %s of %s.", mtmp->mtyp == PM_BAALPHEGOR ? "open mouth" : "ghostly hood", mon_nam(mtmp));
 			}
 			damage = d(min(10, (mtmp->m_lev)/3), 4);
 			losehp(damage, "life-force theft", KILLED_BY);
@@ -1787,7 +1787,7 @@ mcalcdistress()
 		}
 	}
 	
-	if(mtmp->data == &mons[PM_BAALPHEGOR] && mtmp->mhp < mtmp->mhpmax/2){
+	if(mtmp->mtyp == PM_BAALPHEGOR && mtmp->mhp < mtmp->mhpmax/2){
 		struct monst *tmpm;
 		int targets = 0, damage = 0;
 		for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -2066,7 +2066,7 @@ struct monst *mtmp;
 		}
 	}
 	
-	if(!mtmp->mcansee && (mtmp->data == &mons[PM_SHOGGOTH] || mtmp->data == &mons[PM_PRIEST_OF_GHAUNADAUR])){
+	if(!mtmp->mcansee && (mtmp->mtyp == PM_SHOGGOTH || mtmp->mtyp == PM_PRIEST_OF_GHAUNADAUR)){
 		if(canspotmon(mtmp)) pline("%s forms new eyes!",Monnam(mtmp));
 		mtmp->mblinded = 1;
 	}
@@ -2139,7 +2139,7 @@ movemon()
 				mtmp->mvar3 = 0; //Quantum Lock status will be reset below.
 				m_initgrp(mtmp, 0, 0, 10);
 			}
-		} else if(mtmp->data == &mons[PM_RAZORVINE] && 
+		} else if(mtmp->mtyp == PM_RAZORVINE && 
 				  mtmp->mhp == mtmp->mhpmax && 
 				  !mtmp->mcan && 
 				  !((monstermoves + mtmp->m_id) % (30-depth(&u.uz)/2)) && 
@@ -2219,7 +2219,7 @@ movemon()
 		
 	}
 	
-	if(mtmp->data == &mons[PM_METROID_QUEEN]){
+	if(mtmp->mtyp == PM_METROID_QUEEN){
 		if(mtmp->mtame){
 			struct monst *baby;
 			int tnum = d(1,6);
@@ -2261,7 +2261,7 @@ movemon()
 		mtmp->mpeaceful = 0;
 		mtmp->mtame = 0;
 	}
-	if(mtmp->data == &mons[PM_UVUUDAUM]){
+	if(mtmp->mtyp == PM_UVUUDAUM){
 		if(u.uevent.invoked 
 		|| (Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz))
 		|| mtmp->mhp < mtmp->mhpmax
@@ -2286,7 +2286,7 @@ movemon()
 			set_malign(mtmp);
 		}
 	}
-	if(mtmp->data == &mons[PM_DREAD_SERAPH] && 
+	if(mtmp->mtyp == PM_DREAD_SERAPH && 
 		mtmp->mhp == mtmp->mhpmax && 
 		!(mtmp->mstrategy&STRAT_WAITMASK) && 
 		!(u.uevent.invoked || (Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz)))
@@ -2372,11 +2372,11 @@ meatmetal(mtmp)
 	/* Eats topmost metal object if it is there */
 	for (otmp = level.objects[mtmp->mx][mtmp->my];
 						otmp; otmp = otmp->nexthere) {
-	    if (mtmp->data == &mons[PM_RUST_MONSTER] && !is_rustprone(otmp))
+	    if (mtmp->mtyp == PM_RUST_MONSTER && !is_rustprone(otmp))
 		continue;
 	    if (is_metallic(otmp) && !obj_resists(otmp, 0, 95) &&
 		touch_artifact(otmp, mtmp, FALSE)) {
-		if (mtmp->data == &mons[PM_RUST_MONSTER] && otmp->oerodeproof) {
+		if (mtmp->mtyp == PM_RUST_MONSTER && otmp->oerodeproof) {
 		    if (canseemon(mtmp) && flags.verbose) {
 			pline("%s eats %s!",
 				Monnam(mtmp),
@@ -2510,7 +2510,7 @@ meatobj(mtmp)		/* for gelatinous cubes */
 		    mtmp->mhp = mtmp->mhpmax;
 		}
 		/* in case it polymorphed or died */
-		if (ptr != &mons[PM_GELATINOUS_CUBE])
+		if (ptr->mtyp != PM_GELATINOUS_CUBE)
 		    return !ptr ? 2 : 1;
 	    } else if (otmp->oclass != ROCK_CLASS && !(otmp->otyp == MAGIC_CHEST && otmp->obolted) &&
 				    otmp != uball && otmp != uchain) {
@@ -2660,13 +2660,13 @@ mon_can_see_mon(looker, lookie)
 	boolean catsightdark = !(levl[looker->mx][looker->my].lit || (viz_array[looker->my][looker->mx]&TEMP_LIT1 && !(viz_array[looker->my][looker->mx]&TEMP_DRK1))) ||
 							(!levl[looker->mx][looker->my].lit && !(viz_array[looker->my][looker->mx]&TEMP_DRK1 && !(viz_array[looker->my][looker->mx]&TEMP_LIT1)));
 	
-	if(looker->data == &mons[PM_DREADBLOSSOM_SWARM]){
-		if(lookie->data == &mons[PM_DREADBLOSSOM_SWARM]) return FALSE;
+	if(looker->mtyp == PM_DREADBLOSSOM_SWARM){
+		if(lookie->mtyp == PM_DREADBLOSSOM_SWARM) return FALSE;
 		else return mon_can_see_mon(lookie, looker);
 	}
-	if(looker->data == &mons[PM_SWARM_OF_SNAKING_TENTACLES] || looker->data == &mons[PM_LONG_SINUOUS_TENTACLE]){
+	if(looker->mtyp == PM_SWARM_OF_SNAKING_TENTACLES || looker->mtyp == PM_LONG_SINUOUS_TENTACLE){
 		struct monst *witw;
-		for(witw = fmon; witw; witw = witw->nmon) if(witw->data == &mons[PM_WATCHER_IN_THE_WATER]) break;
+		for(witw = fmon; witw; witw = witw->nmon) if(witw->mtyp == PM_WATCHER_IN_THE_WATER) break;
 		if(witw){
 			looker->mux = witw->mux;
 			looker->muy = witw->muy;
@@ -2675,9 +2675,9 @@ mon_can_see_mon(looker, lookie)
 		//may still be able to feel target adjacent
 	}
 	
-	if(looker->data == &mons[PM_WIDE_CLUBBED_TENTACLE]){
+	if(looker->mtyp == PM_WIDE_CLUBBED_TENTACLE){
 		struct monst *keto;
-		for(keto = fmon; keto; keto = keto->nmon) if(keto->data == &mons[PM_KETO]) break;
+		for(keto = fmon; keto; keto = keto->nmon) if(keto->mtyp == PM_KETO) break;
 		if(keto){
 			looker->mux = keto->mux;
 			looker->muy = keto->muy;
@@ -2686,7 +2686,7 @@ mon_can_see_mon(looker, lookie)
 		//may still be able to feel target adjacent
 	}
 	
-	if(looker->data == &mons[PM_DANCING_BLADE]){
+	if(looker->mtyp == PM_DANCING_BLADE){
 		struct monst *surya;
 		for(surya = fmon; surya; surya = surya->nmon) if(surya->m_id == looker->mvar_suryaID) break;
 		if(surya){
@@ -2807,26 +2807,26 @@ struct monst *looker;
 	boolean catsightdark = !(levl[looker->mx][looker->my].lit || (viz_array[looker->my][looker->mx]&TEMP_LIT1 && !(viz_array[looker->my][looker->mx]&TEMP_DRK1)));
 	
 	
-	if(looker->data == &mons[PM_DREADBLOSSOM_SWARM]){
-		if(youracedata == &mons[PM_DREADBLOSSOM_SWARM]) return FALSE;
+	if(looker->mtyp == PM_DREADBLOSSOM_SWARM){
+		if(youracedata->mtyp == PM_DREADBLOSSOM_SWARM) return FALSE;
 		else return canseemon(looker);
 	}
 	
-	if(looker->data == &mons[PM_SWARM_OF_SNAKING_TENTACLES] || looker->data == &mons[PM_LONG_SINUOUS_TENTACLE]){
+	if(looker->mtyp == PM_SWARM_OF_SNAKING_TENTACLES || looker->mtyp == PM_LONG_SINUOUS_TENTACLE){
 		struct monst *witw;
-		for(witw = fmon; witw; witw = witw->nmon) if(witw->data == &mons[PM_WATCHER_IN_THE_WATER]) break;
+		for(witw = fmon; witw; witw = witw->nmon) if(witw->mtyp == PM_WATCHER_IN_THE_WATER) break;
 		if(witw && mon_can_see_you(witw)) return TRUE;
 		//may still be able to feel target adjacent
 	}
 	
-	if(looker->data == &mons[PM_WIDE_CLUBBED_TENTACLE]){
+	if(looker->mtyp == PM_WIDE_CLUBBED_TENTACLE){
 		struct monst *keto;
-		for(keto = fmon; keto; keto = keto->nmon) if(keto->data == &mons[PM_KETO]) break;
+		for(keto = fmon; keto; keto = keto->nmon) if(keto->mtyp == PM_KETO) break;
 		if(keto && mon_can_see_you(keto)) return TRUE;
 		//may still be able to feel target adjacent
 	}
 	
-	if(looker->data == &mons[PM_DANCING_BLADE]){
+	if(looker->mtyp == PM_DANCING_BLADE){
 		struct monst *surya;
 		for(surya = fmon; surya; surya = surya->nmon) if(surya->m_id == looker->mvar_suryaID) break;
 		if(surya && mon_can_see_you(surya)) return TRUE;
@@ -2977,7 +2977,7 @@ struct obj *otmp;
 	if (mtmp == u.usteed) return (FALSE);
 #endif
 	if (mtmp->isshk) return(TRUE); /* no limit */
-	if ((mtmp->mpeaceful && mtmp->data != &mons[PM_MAID]) && !mtmp->mtame) return(FALSE);
+	if ((mtmp->mpeaceful && mtmp->mtyp != PM_MAID) && !mtmp->mtame) return(FALSE);
 	/* otherwise players might find themselves obligated to violate
 	 * their alignment if the monster takes something they need
 	 * 
@@ -3018,17 +3018,17 @@ mfndpos(mon, poss, info, flag)
 	boolean rockok = FALSE, treeok = FALSE, thrudoor;
 	int maxx, maxy;
 	
-	if(mdat == &mons[PM_SWARM_OF_SNAKING_TENTACLES] || mdat == &mons[PM_LONG_SINUOUS_TENTACLE]){
-		for(witw = fmon; witw; witw = witw->nmon) if(witw->data == &mons[PM_WATCHER_IN_THE_WATER]) break;
+	if(mdat->mtyp == PM_SWARM_OF_SNAKING_TENTACLES || mdat->mtyp == PM_LONG_SINUOUS_TENTACLE){
+		for(witw = fmon; witw; witw = witw->nmon) if(witw->mtyp == PM_WATCHER_IN_THE_WATER) break;
 	}
 	
-	if(mdat == &mons[PM_WIDE_CLUBBED_TENTACLE]){
-		for(witw = fmon; witw; witw = witw->nmon) if(witw->data == &mons[PM_KETO]) break;
+	if(mdat->mtyp == PM_WIDE_CLUBBED_TENTACLE){
+		for(witw = fmon; witw; witw = witw->nmon) if(witw->mtyp == PM_KETO) break;
 	}
 	
-	if(mdat == &mons[PM_DANCING_BLADE]){
+	if(mdat->mtyp == PM_DANCING_BLADE){
 		for(madjacent = fmon; madjacent; madjacent = madjacent->nmon)
-			if(madjacent->data == &mons[PM_SURYA_DEVA] && madjacent->m_id == mon->mvar_suryaID)
+			if(madjacent->mtyp == PM_SURYA_DEVA && madjacent->m_id == mon->mvar_suryaID)
 				break;
 	}
 	
@@ -3036,7 +3036,7 @@ mfndpos(mon, poss, info, flag)
 	y = mon->my;
 	nowtyp = levl[x][y].typ;
 
-	nodiag = (mdat == &mons[PM_GRID_BUG]) || (mdat == &mons[PM_BEBELITH]);
+	nodiag = (mdat->mtyp == PM_GRID_BUG) || (mdat->mtyp == PM_BEBELITH);
 	wantpool = mdat->mlet == S_EEL;
 	wantpuddle = wantpool && mdat->msize == MZ_TINY;
 	cubewaterok = (mon_resistance(mon,SWIMMING) || breathless_mon(mon) || amphibious_mon(mon));
@@ -3089,7 +3089,7 @@ nexttry:	/* eels prefer the water, but if there is no water nearby,
 			   ((levl[nx][ny].doormask & D_CLOSED && !(flag & OPENDOOR)) ||
 			(levl[nx][ny].doormask & D_LOCKED && !(flag & UNLOCKDOOR))) &&
 			   !thrudoor) continue;
-	    if(nx != x && ny != y && (nodiag || mdat == &mons[PM_LONG_WORM] ||
+	    if(nx != x && ny != y && (nodiag || mdat->mtyp == PM_LONG_WORM ||
 #ifdef REINCARNATION
 	       ((IS_DOOR(nowtyp) &&
 		 ((levl[x][y].doormask & ~D_BROKEN) || Is_rogue_level(&u.uz))) ||
@@ -3101,26 +3101,26 @@ nexttry:	/* eels prefer the water, but if there is no water nearby,
 #endif
 	       ))
 			continue;
-		if(mdat == &mons[PM_CLOCKWORK_SOLDIER] || mdat == &mons[PM_CLOCKWORK_DWARF] || 
-		   mdat == &mons[PM_FABERGE_SPHERE] || mdat == &mons[PM_FIREWORK_CART] || 
-		   mdat == &mons[PM_JUGGERNAUT] || mdat == &mons[PM_ID_JUGGERNAUT]
+		if(mdat->mtyp == PM_CLOCKWORK_SOLDIER || mdat->mtyp == PM_CLOCKWORK_DWARF || 
+		   mdat->mtyp == PM_FABERGE_SPHERE || mdat->mtyp == PM_FIREWORK_CART || 
+		   mdat->mtyp == PM_JUGGERNAUT || mdat->mtyp == PM_ID_JUGGERNAUT
 		) if(x + xdir[(int)mon->mvar_vector] != nx || 
 			   y + ydir[(int)mon->mvar_vector] != ny 
 			) continue;
-		if((mdat == &mons[PM_GRUE]) && isdark(mon->mx, mon->my) && !isdark(nx, ny))
+		if((mdat->mtyp == PM_GRUE) && isdark(mon->mx, mon->my) && !isdark(nx, ny))
 				continue;
-		if((mdat == &mons[PM_WATCHER_IN_THE_WATER] || mdat == &mons[PM_KETO]) && 
+		if((mdat->mtyp == PM_WATCHER_IN_THE_WATER || mdat->mtyp == PM_KETO) && 
 			!no_upos(mon) && 
 			distmin(nx, ny, mon->mux, mon->muy) <= 3 && 
 			dist2(nx, ny, mon->mux, mon->muy) <= dist2(mon->mx, mon->my, mon->mux, mon->muy)) continue;
-		if((mdat == &mons[PM_WATCHER_IN_THE_WATER]) && 
+		if((mdat->mtyp == PM_WATCHER_IN_THE_WATER) && 
 			onlineu(nx, ny) && (lined_up(mon) || !rn2(4))) continue;
 		if(witw && dist2(nx, ny, witw->mx, witw->my) > 32 && 
 			dist2(nx, ny, witw->mx, witw->my) >= dist2(mon->mx, mon->my, witw->mx, witw->my)) continue;
 		if(madjacent && distmin(nx, ny, madjacent->mx, madjacent->my) > 1 && 
 			dist2(nx, ny, madjacent->mx, madjacent->my) >= dist2(mon->mx, mon->my, madjacent->mx, madjacent->my) &&
 			!(m_at(nx, ny) && distmin(nx, ny, madjacent->mx, madjacent->my) <= 2)) continue;
-		if(mdat == &mons[PM_HOOLOOVOO] && 
+		if(mdat->mtyp == PM_HOOLOOVOO && 
 			IS_WALL(levl[mon->mx][mon->my].typ) &&
 			!IS_WALL(levl[nx][ny].typ)
 		) continue;
@@ -3220,8 +3220,8 @@ impossible("A monster looked at a very strange trap of type %d.", ttmp->ttyp);
 			struct obj *mwep;
 			mwep = MON_WEP(mon);
 			if ((ttmp->ttyp != RUST_TRAP
-					|| mdat == &mons[PM_IRON_GOLEM]
-					|| mdat == &mons[PM_CHAIN_GOLEM])
+					|| mdat->mtyp == PM_IRON_GOLEM
+					|| mdat->mtyp == PM_CHAIN_GOLEM)
 				&& ((ttmp->ttyp != PIT
 				    && ttmp->ttyp != SPIKED_PIT
 				    && ttmp->ttyp != TRAPDOOR
@@ -3302,7 +3302,7 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	if(magr->mstrategy & STRAT_WAITMASK)
 		return 0L;
 	
-	if(magr->mtame && mdef->mpeaceful && !u.uevent.uaxus_foe && md == &mons[PM_AXUS])
+	if(magr->mtame && mdef->mpeaceful && !u.uevent.uaxus_foe && md->mtyp == PM_AXUS)
 		return 0L;
 	
 	if(magr->mhp < 100 && attacktype_fordmg(md, AT_BOOM, AD_MAND))
@@ -3311,14 +3311,14 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	if((Upolyd ? u.mh < 100 : u.uhp < 100) && magr->mtame && attacktype_fordmg(md, AT_BOOM, AD_MAND))
 		return 0L;
 	
-	if(ma == &mons[PM_DREADBLOSSOM_SWARM]){
+	if(ma->mtyp == PM_DREADBLOSSOM_SWARM){
 		if(!(is_fey(md) || is_plant(md))) return ALLOW_M|ALLOW_TM;
 	}
-	if(ma == &mons[PM_GRUE]){
+	if(ma->mtyp == PM_GRUE){
 		if(isdark(mdef->mx, mdef->my)) return ALLOW_M|ALLOW_TM;
 	}
 	
-	if((ma == &mons[PM_OONA] || ma == &mons[PM_OONA])
+	if((ma->mtyp == PM_OONA || ma->mtyp == PM_OONA)
 		&& sgn(ma->maligntyp) == -1*sgn(md->maligntyp) //"Oona grudges on chaotics, but not on neutrals"
 		&& !(magr->mtame || mdef->mtame) //Normal pet-vs-monster logic should take precedence over this
 	){
@@ -3341,7 +3341,7 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	)
 		return 0L;
 	
-	if(md == &mons[PM_MANDRAKE]) return 0L;
+	if(md->mtyp == PM_MANDRAKE) return 0L;
 	
 	if(is_drow(ma) && is_drow(md) && (magr->mfaction == mdef->mfaction)) return 0L;
 	
@@ -3349,8 +3349,8 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	    return ALLOW_M|ALLOW_TM;
 	/* supposedly purple worms are attracted to shrieking because they
 	   like to eat shriekers, so attack the latter when feasible */
-	if (ma == &mons[PM_PURPLE_WORM] &&
-		md == &mons[PM_SHRIEKER])
+	if (ma->mtyp == PM_PURPLE_WORM &&
+		md->mtyp == PM_SHRIEKER)
 			return ALLOW_M|ALLOW_TM;
 
 #ifdef ATTACK_PETS
@@ -3366,15 +3366,15 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	/* Gugs and ghouls fight each other. 
 		Gugs are afraid of
 		Ghouls, so they won't attack first. */
-	if (ma == &mons[PM_GHOUL] &&
-		md == &mons[PM_GUG])
+	if (ma->mtyp == PM_GHOUL &&
+		md->mtyp == PM_GUG)
 			return ALLOW_M|ALLOW_TM;
 
 	/* Since the quest guardians are under siege, it makes sense to have 
        them fight hostiles.  (But we don't want the quest leader to be in danger.) */
 	if( (ma->msound==MS_GUARDIAN 
-		  || (Role_if(PM_NOBLEMAN) && (ma == &mons[PM_KNIGHT] || ma == &mons[PM_MAID] || ma == &mons[PM_PEASANT]) && magr->mpeaceful && In_quest(&u.uz))
-		  || (Role_if(PM_KNIGHT) && ma == &mons[PM_KNIGHT] && magr->mpeaceful && In_quest(&u.uz))
+		  || (Role_if(PM_NOBLEMAN) && (ma->mtyp == PM_KNIGHT || ma->mtyp == PM_MAID || ma->mtyp == PM_PEASANT) && magr->mpeaceful && In_quest(&u.uz))
+		  || (Role_if(PM_KNIGHT) && ma->mtyp == PM_KNIGHT && magr->mpeaceful && In_quest(&u.uz))
 		  || (Race_if(PM_DROW) && is_drow(ma) && magr->mfaction == u.uhouse)
 		  || (Race_if(PM_GNOME) && (is_gnome(ma) && !is_undead_mon(magr)) && magr->mpeaceful)
 		)
@@ -3386,8 +3386,8 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	}
 	/* and vice versa */
 	if( (md->msound == MS_GUARDIAN 
-		  || (Role_if(PM_NOBLEMAN) && (md == &mons[PM_KNIGHT] || md == &mons[PM_MAID] || md == &mons[PM_PEASANT]) && mdef->mpeaceful && In_quest(&u.uz))
-		  || (Role_if(PM_KNIGHT) && md == &mons[PM_KNIGHT] && mdef->mpeaceful && In_quest(&u.uz))
+		  || (Role_if(PM_NOBLEMAN) && (md->mtyp == PM_KNIGHT || md->mtyp == PM_MAID || md->mtyp == PM_PEASANT) && mdef->mpeaceful && In_quest(&u.uz))
+		  || (Role_if(PM_KNIGHT) && md->mtyp == PM_KNIGHT && mdef->mpeaceful && In_quest(&u.uz))
 		  || (Race_if(PM_DROW) && is_drow(md) && mdef->mfaction == u.uhouse)
 		  || (Race_if(PM_GNOME) && (is_gnome(md) && !is_undead_mon(mdef)) && mdef->mpeaceful)
 		)
@@ -3399,14 +3399,14 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	}
 
 	/* elves (and Eladrin) vs. (orcs and undead and wargs) */
-	if((is_elf(ma) || is_eladrin(ma) || ma == &mons[PM_GROVE_GUARDIAN] || ma == &mons[PM_FORD_GUARDIAN] || ma == &mons[PM_FORD_ELEMENTAL])
-		&& (is_orc(md) || md == &mons[PM_WARG] || is_ogre(md) || is_undead_mon(mdef))
+	if((is_elf(ma) || is_eladrin(ma) || ma->mtyp == PM_GROVE_GUARDIAN || ma->mtyp == PM_FORD_GUARDIAN || ma->mtyp == PM_FORD_ELEMENTAL)
+		&& (is_orc(md) || md->mtyp == PM_WARG || is_ogre(md) || is_undead_mon(mdef))
 		&& !(is_orc(ma) || is_ogre(ma) || is_undead_mon(magr))
 	)
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
-	if((is_elf(md) || is_eladrin(md) || md == &mons[PM_GROVE_GUARDIAN] || md == &mons[PM_FORD_GUARDIAN] || md == &mons[PM_FORD_ELEMENTAL]) 
-		&& (is_orc(ma) || ma == &mons[PM_WARG] || is_ogre(ma) || is_undead_mon(magr))
+	if((is_elf(md) || is_eladrin(md) || md->mtyp == PM_GROVE_GUARDIAN || md->mtyp == PM_FORD_GUARDIAN || md->mtyp == PM_FORD_ELEMENTAL) 
+		&& (is_orc(ma) || ma->mtyp == PM_WARG || is_ogre(ma) || is_undead_mon(magr))
 		&& !(is_orc(md) || is_ogre(md) || is_undead_mon(mdef))
 	)
 		return ALLOW_M|ALLOW_TM;
@@ -3439,12 +3439,12 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	}
 	
 	/* Alabaster elves vs. oozes */
-	if((ma == &mons[PM_ALABASTER_ELF] || ma == &mons[PM_ALABASTER_ELF_ELDER] || ma == &mons[PM_SENTINEL_OF_MITHARDIR]) 
+	if((ma->mtyp == PM_ALABASTER_ELF || ma->mtyp == PM_ALABASTER_ELF_ELDER || ma->mtyp == PM_SENTINEL_OF_MITHARDIR) 
 		&& (md->mlet == S_PUDDING || md->mlet == S_BLOB || md->mlet == S_UMBER)
 				&&	!(is_undead_mon(magr)))
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
-	if((md == &mons[PM_ALABASTER_ELF] || md == &mons[PM_ALABASTER_ELF_ELDER] || md == &mons[PM_SENTINEL_OF_MITHARDIR])
+	if((md->mtyp == PM_ALABASTER_ELF || md->mtyp == PM_ALABASTER_ELF_ELDER || md->mtyp == PM_SENTINEL_OF_MITHARDIR)
 		&& (ma->mlet == S_PUDDING || ma->mlet == S_BLOB || ma->mlet == S_UMBER)
 				&&	!(is_undead_mon(mdef)))
 		return ALLOW_M|ALLOW_TM;
@@ -3476,19 +3476,19 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	}
 
 	/* drow vs. edderkops */
-	if(is_drow(ma) && magr->mfaction != XAXOX && magr->mfaction != EDDER_SYMBOL && md == &mons[PM_EDDERKOP]){
+	if(is_drow(ma) && magr->mfaction != XAXOX && magr->mfaction != EDDER_SYMBOL && md->mtyp == PM_EDDERKOP){
 		return ALLOW_M|ALLOW_TM;
 	}
 	/* and vice versa */
-	if(is_drow(md) && mdef->mfaction != XAXOX && mdef->mfaction != EDDER_SYMBOL && ma == &mons[PM_EDDERKOP]){
+	if(is_drow(md) && mdef->mfaction != XAXOX && mdef->mfaction != EDDER_SYMBOL && ma->mtyp == PM_EDDERKOP){
 		return ALLOW_M|ALLOW_TM;
 	}
 	
 	/* Nazgul vs. hobbits */
-	if(ma == &mons[PM_NAZGUL] && md == &mons[PM_HOBBIT])
+	if(ma->mtyp == PM_NAZGUL && md->mtyp == PM_HOBBIT)
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
-	if(md == &mons[PM_NAZGUL] && ma == &mons[PM_HOBBIT])
+	if(md->mtyp == PM_NAZGUL && ma->mtyp == PM_HOBBIT)
 		return ALLOW_M|ALLOW_TM;
 
 	/* gnolls vs. minotaurs */
@@ -3499,25 +3499,25 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 		return ALLOW_M|ALLOW_TM;
 
 	/* angels vs. demons */
-	if(is_angel(ma) && (is_demon(md) /*|| md == &mons[PM_FALLEN_ANGEL]*/))
+	if(is_angel(ma) && (is_demon(md) /*|| md->mtyp == PM_FALLEN_ANGEL*/))
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
-	if(is_angel(md) && (is_demon(ma) /*|| ma == &mons[PM_FALLEN_ANGEL] || ma == &mons[PM_LUCIFER]*/))
+	if(is_angel(md) && (is_demon(ma) /*|| ma->mtyp == PM_FALLEN_ANGEL || ma->mtyp == PM_LUCIFER*/))
 		return ALLOW_M|ALLOW_TM;
 
 	/* monadics vs. undead */
-	if(ma == &mons[PM_MONADIC_DEVA] && (is_undead_mon(mdef)))
+	if(ma->mtyp == PM_MONADIC_DEVA && (is_undead_mon(mdef)))
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
-	if(md == &mons[PM_MONADIC_DEVA] && (is_undead_mon(magr)))
+	if(md->mtyp == PM_MONADIC_DEVA && (is_undead_mon(magr)))
 		return ALLOW_M|ALLOW_TM;
 
 	/* woodchucks vs. The Oracle */
-	if(ma == &mons[PM_WOODCHUCK] && md == &mons[PM_ORACLE])
+	if(ma->mtyp == PM_WOODCHUCK && md->mtyp == PM_ORACLE)
 		return ALLOW_M|ALLOW_TM;
 
 	/* ravens like eyes */
-	if(ma == &mons[PM_RAVEN] && md == &mons[PM_FLOATING_EYE])
+	if(ma->mtyp == PM_RAVEN && md->mtyp == PM_FLOATING_EYE)
 		return ALLOW_M|ALLOW_TM;
 
 	/* dungeon fern spores hate everything */
@@ -3527,48 +3527,48 @@ struct monst *magr,	/* monster that is currently deciding where to move */
 	if(is_fern_spore(md) && !is_vegetation(ma))
 		return ALLOW_M|ALLOW_TM;
 	/* everything attacks razorvine */
-	// if(md == &mons[PM_RAZORVINE] && !is_vegetation(ma))
+	// if(md->mtyp == PM_RAZORVINE && !is_vegetation(ma))
 		// return ALLOW_M|ALLOW_TM;
 
-	else if (magr->data == &mons[PM_SKELETAL_PIRATE] &&
-		mdef->data == &mons[PM_SOLDIER])
+	else if (magr->mtyp == PM_SKELETAL_PIRATE &&
+		mdef->mtyp == PM_SOLDIER)
 	    return ALLOW_M|ALLOW_TM;
-	else if (mdef->data == &mons[PM_SKELETAL_PIRATE] &&
-		magr->data == &mons[PM_SOLDIER])
+	else if (mdef->mtyp == PM_SKELETAL_PIRATE &&
+		magr->mtyp == PM_SOLDIER)
 	    return ALLOW_M|ALLOW_TM;
-	else if (magr->data == &mons[PM_SKELETAL_PIRATE] &&
-		mdef->data == &mons[PM_SERGEANT])
+	else if (magr->mtyp == PM_SKELETAL_PIRATE &&
+		mdef->mtyp == PM_SERGEANT)
 	    return ALLOW_M|ALLOW_TM;
-	else if (mdef->data == &mons[PM_SKELETAL_PIRATE] &&
-		magr->data == &mons[PM_SERGEANT])
-	    return ALLOW_M|ALLOW_TM;
-
-	else if (magr->data == &mons[PM_DAMNED_PIRATE] &&
-		mdef->data == &mons[PM_SOLDIER])
-	    return ALLOW_M|ALLOW_TM;
-	else if (mdef->data == &mons[PM_DAMNED_PIRATE] &&
-		magr->data == &mons[PM_SOLDIER])
-	    return ALLOW_M|ALLOW_TM;
-	else if (magr->data == &mons[PM_DAMNED_PIRATE] &&
-		mdef->data == &mons[PM_SERGEANT])
-	    return ALLOW_M|ALLOW_TM;
-	else if (mdef->data == &mons[PM_DAMNED_PIRATE] &&
-		magr->data == &mons[PM_SERGEANT])
+	else if (mdef->mtyp == PM_SKELETAL_PIRATE &&
+		magr->mtyp == PM_SERGEANT)
 	    return ALLOW_M|ALLOW_TM;
 
-	else if (magr->data == &mons[PM_SKELETAL_PIRATE] &&
+	else if (magr->mtyp == PM_DAMNED_PIRATE &&
+		mdef->mtyp == PM_SOLDIER)
+	    return ALLOW_M|ALLOW_TM;
+	else if (mdef->mtyp == PM_DAMNED_PIRATE &&
+		magr->mtyp == PM_SOLDIER)
+	    return ALLOW_M|ALLOW_TM;
+	else if (magr->mtyp == PM_DAMNED_PIRATE &&
+		mdef->mtyp == PM_SERGEANT)
+	    return ALLOW_M|ALLOW_TM;
+	else if (mdef->mtyp == PM_DAMNED_PIRATE &&
+		magr->mtyp == PM_SERGEANT)
+	    return ALLOW_M|ALLOW_TM;
+
+	else if (magr->mtyp == PM_SKELETAL_PIRATE &&
 		u.ukinghill)
 	    return ALLOW_M|ALLOW_TM;
-	else if (magr->data == &mons[PM_DAMNED_PIRATE] &&
+	else if (magr->mtyp == PM_DAMNED_PIRATE &&
 		u.ukinghill)
 	    return ALLOW_M|ALLOW_TM;
-	else if (magr->data == &mons[PM_GITHYANKI_PIRATE] &&
+	else if (magr->mtyp == PM_GITHYANKI_PIRATE &&
 		u.ukinghill)
 	    return ALLOW_M|ALLOW_TM;
-	else if (mdef->data != &mons[PM_TINKER_GNOME] && mdef->data != &mons[PM_HOOLOOVOO] && 
-			(magr->data == &mons[PM_CLOCKWORK_SOLDIER] || magr->data == &mons[PM_CLOCKWORK_DWARF] || 
-			 magr->data == &mons[PM_FABERGE_SPHERE] || magr->data == &mons[PM_FIREWORK_CART] || 
-			 magr->data == &mons[PM_JUGGERNAUT] || magr->data == &mons[PM_ID_JUGGERNAUT]))
+	else if (mdef->mtyp != PM_TINKER_GNOME && mdef->mtyp != PM_HOOLOOVOO && 
+			(magr->mtyp == PM_CLOCKWORK_SOLDIER || magr->mtyp == PM_CLOCKWORK_DWARF || 
+			 magr->mtyp == PM_FABERGE_SPHERE || magr->mtyp == PM_FIREWORK_CART || 
+			 magr->mtyp == PM_JUGGERNAUT || magr->mtyp == PM_ID_JUGGERNAUT))
 	    return ALLOW_M|ALLOW_TM;
 	/* Various other combinations such as dog vs cat, cat vs rat, and
 	   elf vs orc have been suggested.  For the time being we don't
@@ -3583,15 +3583,15 @@ register int x,y;
 /* Is the square close enough for the monster to move or attack into? */
 {
 	register int distance = dist2(mon->mx, mon->my, x, y);
-	if (distance==2 && (mon->data==&mons[PM_GRID_BUG] || mon->data==&mons[PM_BEBELITH])) return 0;
-	if(mon->data == &mons[PM_CLOCKWORK_SOLDIER] || mon->data == &mons[PM_CLOCKWORK_DWARF] || 
-	   mon->data == &mons[PM_FABERGE_SPHERE]
+	if (distance==2 && (mon->mtyp==PM_GRID_BUG || mon->mtyp==PM_BEBELITH)) return 0;
+	if(mon->mtyp == PM_CLOCKWORK_SOLDIER || mon->mtyp == PM_CLOCKWORK_DWARF || 
+	   mon->mtyp == PM_FABERGE_SPHERE
 	) if(mon->mx + xdir[(int)mon->mvar_vector] != x || 
 		   mon->my + ydir[(int)mon->mvar_vector] != y 
 		) return 0;
-	if(mon->data == &mons[PM_FIREWORK_CART] || 
-	   mon->data == &mons[PM_JUGGERNAUT] || 
-	   mon->data == &mons[PM_ID_JUGGERNAUT]
+	if(mon->mtyp == PM_FIREWORK_CART || 
+	   mon->mtyp == PM_JUGGERNAUT || 
+	   mon->mtyp == PM_ID_JUGGERNAUT
 	){
 		if(mon->mx + xdir[(int)mon->mvar_vector] == x && 
 		   mon->my + ydir[(int)mon->mvar_vector] == y 
@@ -3764,17 +3764,17 @@ struct monst *mtmp;
 	/* get all lifesavers */
 	if (Role_if(PM_ANACHRONONAUT) && In_quest(&u.uz) && !(mtmp->mpeaceful) && !rn2(20))
 		lifesavers |= LSVD_ANA;
-	if(mtmp->data == &mons[PM_NITOCRIS]
+	if(mtmp->mtyp == PM_NITOCRIS
 		&& which_armor(mtmp, W_ARMC)
 		&& which_armor(mtmp, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF
 	)
 		lifesavers |= LSVD_NBW;
-	if (mtmp->mspec_used == 0 && (is_uvuudaum(mtmp->data) || mtmp->data == &mons[PM_PRAYERFUL_THING]))
+	if (mtmp->mspec_used == 0 && (is_uvuudaum(mtmp->data) || mtmp->mtyp == PM_PRAYERFUL_THING))
 		lifesavers |= LSVD_UVU;
 	if (lifesave)
 		lifesavers |= LSVD_OBJ;
-	if ((!rn2(20) && (mtmp->data == &mons[PM_ALABASTER_ELF]
-		|| mtmp->data == &mons[PM_ALABASTER_ELF_ELDER]
+	if ((!rn2(20) && (mtmp->mtyp == PM_ALABASTER_ELF
+		|| mtmp->mtyp == PM_ALABASTER_ELF_ELDER
 		|| is_alabaster_mummy(mtmp->data)
 		)))
 		lifesavers |= LSVD_ALA;
@@ -3786,9 +3786,9 @@ struct monst *mtmp;
 		lifesavers |= LSVD_ILU;
 	if (mtmp->zombify && is_kamerel(mtmp->data))
 		lifesavers |= LSVD_KAM;
-	if(mtmp->data == &mons[PM_NITOCRIS])
+	if(mtmp->mtyp == PM_NITOCRIS)
 		lifesavers |= LSVD_NIT;
-	if (mtmp->data == &mons[PM_BLESSED] && rn2(3))
+	if (mtmp->mtyp == PM_BLESSED && rn2(3))
 		lifesavers |= LSVD_HLO;
 
 	/* some lifesavers do NOT work on stone/gold/glass-ing */
@@ -4064,7 +4064,7 @@ register struct monst *mtmp;
 	lifesaved_monster(mtmp);
 	if (mtmp->mhp > 0) return;
 	//Special messages (Nyarlathotep)
-	if(canseemon(mtmp) && (mtmp->data == &mons[PM_THE_GOOD_NEIGHBOR] || mtmp->data == &mons[PM_HMNYW_PHARAOH])){
+	if(canseemon(mtmp) && (mtmp->mtyp == PM_THE_GOOD_NEIGHBOR || mtmp->mtyp == PM_HMNYW_PHARAOH)){
 		int nyar_form = rn2(SIZE(nyar_description));
 		pline("%s twists and morphs into %s.", Monnam(mtmp), nyar_description[nyar_form]);
 		pline("%s rises through the ceiling!", nyar_name[nyar_form]);
@@ -4082,16 +4082,16 @@ register struct monst *mtmp;
 	/* restore chameleon, lycanthropes to true form at death */
 	if (mtmp->cham)
 		set_mon_data(mtmp, cham_to_pm[mtmp->cham], -1);
-	else if (mtmp->data == &mons[PM_WEREJACKAL])
+	else if (mtmp->mtyp == PM_WEREJACKAL)
 		set_mon_data(mtmp, PM_HUMAN_WEREJACKAL, -1);
-	else if (mtmp->data == &mons[PM_WEREWOLF])
+	else if (mtmp->mtyp == PM_WEREWOLF)
 		set_mon_data(mtmp, PM_HUMAN_WEREWOLF, -1);
-	else if (mtmp->data == &mons[PM_WERERAT])
+	else if (mtmp->mtyp == PM_WERERAT)
 		set_mon_data(mtmp, PM_HUMAN_WERERAT, -1);
-	else if (mtmp->data == &mons[PM_ANUBAN_JACKAL])
+	else if (mtmp->mtyp == PM_ANUBAN_JACKAL)
 		set_mon_data(mtmp, PM_ANUBITE, -1);
 
-	if(mtmp->data == &mons[PM_WITCH_S_FAMILIAR]){
+	if(mtmp->mtyp == PM_WITCH_S_FAMILIAR){
 		dead_familiar(mtmp->mvar_witchID);
 	}
 
@@ -4159,14 +4159,14 @@ register struct monst *mtmp;
 		(void) mksobj_at(BELL_OF_OPENING, mtmp->mx, mtmp->my, TRUE, FALSE);
 		flags.made_bell = TRUE;
 	}
-	if(mtmp->data == &mons[PM_OONA]){
+	if(mtmp->mtyp == PM_OONA){
 		struct obj *obj;
 		obj = mksobj_at(SKELETON_KEY, mtmp->mx, mtmp->my, FALSE, FALSE);
 		obj = oname(obj, artiname(ART_THIRD_KEY_OF_LAW));
 		obj->spe = 0;
 		obj->cursed = obj->blessed = FALSE;
 	}
-	if(mtmp->data == &mons[PM_ASPECT_OF_THE_SILENCE]){
+	if(mtmp->mtyp == PM_ASPECT_OF_THE_SILENCE){
 		int remaining = 0;
 		if(!flags.made_first)
 			remaining++;
@@ -4184,16 +4184,16 @@ register struct monst *mtmp;
 				mksobj_at(NURTURING_WORD, mtmp->mx, mtmp->my, TRUE, FALSE);
 		}
 	}
-	if(mtmp->data == &mons[PM_GARLAND]){
+	if(mtmp->mtyp == PM_GARLAND){
 		int x = mtmp->mx, y = mtmp->my;
 		struct obj *otmp;
 		makemon(&mons[PM_CHAOS], mtmp->mx, mtmp->my, MM_ADJACENTOK);
 	}
-	if(mtmp->data == &mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES] && !(u.uevent.ukilled_illurien)){
+	if(mtmp->mtyp == PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES && !(u.uevent.ukilled_illurien)){
 		u.uevent.ukilled_illurien = 1;
 		u.ill_cnt = rn1(1000, 250);
 	}
-	if(mtmp->data == &mons[PM_ORCUS]){
+	if(mtmp->mtyp == PM_ORCUS){
 		struct engr *oep = engr_at(mtmp->mx,mtmp->my);
 		if(!oep){
 			make_engr_at(mtmp->mx, mtmp->my,
@@ -4205,11 +4205,11 @@ register struct monst *mtmp;
 		oep->ward_type = BURN;
 		oep->complete_wards = 1;
 	}
-	if(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH]){
+	if(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH){
 		u.chokhmah++;
 		u.keter++;
 	}
-	if (mtmp->data == &mons[PM_CHAOS] && mvitals[PM_CHAOS].died == 1) {
+	if (mtmp->mtyp == PM_CHAOS && mvitals[PM_CHAOS].died == 1) {
 	} else if(mtmp->data->geno & G_UNIQ && mvitals[monsndx(mtmp->data)].died == 1){
 		char buf[BUFSZ];
 		buf[0]='\0';
@@ -4217,11 +4217,11 @@ register struct monst *mtmp;
 		else Sprintf(buf,"killed %s",noit_nohalu_mon_nam(mtmp));
 	}
 	//Remove linked hungry dead
-	if(mtmp->data == &mons[PM_BLOB_OF_PRESERVED_ORGANS]){
+	if(mtmp->mtyp == PM_BLOB_OF_PRESERVED_ORGANS){
 		struct monst *mon, *mtmp2;
 		for (mon = fmon; mon; mon = mtmp2){
 			mtmp2 = mon->nmon;
-			if(mon->data == &mons[PM_HUNGRY_DEAD]){
+			if(mon->mtyp == PM_HUNGRY_DEAD){
 				if(mtmp->mvar_huskID == (long)mon->m_id){
 					if(mon->mhp > 0){
 						mon->mhp = 0;
@@ -4236,7 +4236,7 @@ register struct monst *mtmp;
 			mmtmp = &migrating_mons;
 			for (mon = migrating_mons; mon; mon = mtmp2){
 				mtmp2 = mon->nmon;
-				if(mon->data == &mons[PM_HUNGRY_DEAD]){
+				if(mon->mtyp == PM_HUNGRY_DEAD){
 					if(mtmp->mvar_huskID == (long)mon->m_id){
 						*mmtmp = mon->nmon;
 						mon_arrive(mon, TRUE);
@@ -4252,11 +4252,11 @@ register struct monst *mtmp;
 		}
 	}
 	//Remove linked sword
-	if(mtmp->data == &mons[PM_SURYA_DEVA]){
+	if(mtmp->mtyp == PM_SURYA_DEVA){
 		struct monst *mon, *mtmp2;
 		for (mon = fmon; mon; mon = mtmp2){
 			mtmp2 = mon->nmon;
-			if(mon->data == &mons[PM_DANCING_BLADE] && mon->mvar_suryaID == mtmp->m_id){
+			if(mon->mtyp == PM_DANCING_BLADE && mon->mvar_suryaID == mtmp->m_id){
 				if (DEADMONSTER(mon)) continue;
 				mon->mhp = -10;
 				monkilled(mon,"",AD_DRLI);
@@ -4264,11 +4264,11 @@ register struct monst *mtmp;
 		}
 	}
 	//Remove linked tentacles
-	if(mtmp->data == &mons[PM_WATCHER_IN_THE_WATER] || mtmp->data == &mons[PM_KETO]){
+	if(mtmp->mtyp == PM_WATCHER_IN_THE_WATER || mtmp->mtyp == PM_KETO){
 		struct monst *mon, *mtmp2;
 		for (mon = fmon; mon; mon = mtmp2){
 			mtmp2 = mon->nmon;
-			if(mon->data == &mons[PM_SWARM_OF_SNAKING_TENTACLES] || mon->data == &mons[PM_LONG_SINUOUS_TENTACLE] || mon->data == &mons[PM_WIDE_CLUBBED_TENTACLE]){
+			if(mon->mtyp == PM_SWARM_OF_SNAKING_TENTACLES || mon->mtyp == PM_LONG_SINUOUS_TENTACLE || mon->mtyp == PM_WIDE_CLUBBED_TENTACLE){
 				if (DEADMONSTER(mon)) continue;
 				mon->mhp = -10;
 				monkilled(mon,"",AD_DRLI);
@@ -4278,11 +4278,11 @@ register struct monst *mtmp;
 	
 	//Quest flavor
 	if(Role_if(PM_ANACHRONONAUT) && mtmp->mpeaceful && In_quest(&u.uz) && Is_qstart(&u.uz) && !(quest_status.leader_is_dead)){
-		if(mtmp->data == &mons[PM_TROOPER]){
+		if(mtmp->mtyp == PM_TROOPER){
 			verbalize("**ALERT: trooper %d vital signs terminated**", (int)(mtmp->m_id));
-		} else if(mtmp->data == &mons[PM_MYRKALFAR_WARRIOR]){
+		} else if(mtmp->mtyp == PM_MYRKALFAR_WARRIOR){
 			verbalize("**ALERT: warrior %d vital signs terminated**", (int)(mtmp->m_id));
-		} else if(mtmp->data != &mons[PM_PHANTASM]){
+		} else if(mtmp->mtyp != PM_PHANTASM){
 			verbalize("**ALERT: citizen %d vital signs terminated**", (int)(mtmp->m_id));
 		}
 	}
@@ -4291,20 +4291,20 @@ register struct monst *mtmp;
 		nomul(-1*rnd(6), "panicking");
 	}
 #ifdef RECORD_ACHIEVE
-	if(mtmp->data == &mons[PM_LUCIFER]){
+	if(mtmp->mtyp == PM_LUCIFER){
 		achieve.killed_lucifer = 1;
 	}
-	else if(mtmp->data == &mons[PM_ASMODEUS]){
+	else if(mtmp->mtyp == PM_ASMODEUS){
 		achieve.killed_asmodeus = 1;
 		u.umadness |= MAD_OVERLORD;
 	}
-	else if(mtmp->data == &mons[PM_DEMOGORGON]){
+	else if(mtmp->mtyp == PM_DEMOGORGON){
 		achieve.killed_demogorgon = 1;
 	}
-	else if (mtmp->data == &mons[PM_MEDUSA]
-	|| mtmp->data == &mons[PM_GRUE]
-	|| mtmp->data == &mons[PM_ECHO]
-	|| mtmp->data == &mons[PM_SYNAISTHESIA]
+	else if (mtmp->mtyp == PM_MEDUSA
+	|| mtmp->mtyp == PM_GRUE
+	|| mtmp->mtyp == PM_ECHO
+	|| mtmp->mtyp == PM_SYNAISTHESIA
 	) {
 		achieve.killed_challenge = 1;
 	}
@@ -4323,7 +4323,7 @@ boolean was_swallowed;			/* digestion */
 {
 	struct permonst *mdat = mon->data;
 	int i, tmp;
-	if (mdat == &mons[PM_VLAD_THE_IMPALER]) {
+	if (mdat->mtyp == PM_VLAD_THE_IMPALER) {
 		if(mvitals[PM_VLAD_THE_IMPALER].died == 1) livelog_write_string("destroyed Vlad the Impaler");
 	    if (cansee(mon->mx, mon->my) && !was_swallowed)
 		pline("%s body crumbles into dust.", s_suffix(Monnam(mon)));
@@ -4334,17 +4334,17 @@ boolean was_swallowed;			/* digestion */
 		pline("%s body crumbles into dust.", s_suffix(Monnam(mon)));
 	    return FALSE;
 	}
-	else if (mdat->mlet == S_LICH && mdat != &mons[PM_LICH__THE_FIEND_OF_EARTH]) {
+	else if (mdat->mlet == S_LICH && mdat->mtyp != PM_LICH__THE_FIEND_OF_EARTH) {
 	    if (cansee(mon->mx, mon->my) && !was_swallowed)
 			pline("%s body crumbles into dust.", s_suffix(Monnam(mon)));
-	    if(mdat != &mons[PM_VECNA] && mdat != &mons[PM_LICH__THE_FIEND_OF_EARTH]) return FALSE; /*Vecna leaves his hand or eye*/
+	    if(mdat->mtyp != PM_VECNA && mdat->mtyp != PM_LICH__THE_FIEND_OF_EARTH) return FALSE; /*Vecna leaves his hand or eye*/
 	}
-	else if(mdat == &mons[PM_ECLAVDRA]) return FALSE;
-	else if(mdat == &mons[PM_CHOKHMAH_SEPHIRAH]){
+	else if(mdat->mtyp == PM_ECLAVDRA) return FALSE;
+	else if(mdat->mtyp == PM_CHOKHMAH_SEPHIRAH){
 		if(mvitals[PM_CHOKHMAH_SEPHIRAH].died == 1) livelog_write_string("destroyed a chokhmah sephirah");
 		return FALSE;
 	}
-	else if (mdat == &mons[PM_CHAOS] && mvitals[PM_CHAOS].died == 1) {
+	else if (mdat->mtyp == PM_CHAOS && mvitals[PM_CHAOS].died == 1) {
 		if(Hallucination) livelog_write_string("perpetuated an asinine paradigm");
 		else livelog_write_string("destroyed Chaos");
 	} else if(mdat->geno & G_UNIQ && mvitals[monsndx(mdat)].died == 1){
@@ -4356,11 +4356,11 @@ boolean was_swallowed;			/* digestion */
 	}
 	//Must be done here for reasons that are obscure
 	if(Role_if(PM_ANACHRONONAUT) && mon->mpeaceful && In_quest(&u.uz) && Is_qstart(&u.uz)){
-		if(mdat == &mons[PM_TROOPER]){
+		if(mdat->mtyp == PM_TROOPER){
 			if(!cansee(mon->mx,mon->my)) map_invisible(mon->mx, mon->my);
-		} else if(mdat == &mons[PM_MYRKALFAR_WARRIOR]){
+		} else if(mdat->mtyp == PM_MYRKALFAR_WARRIOR){
 			if(!cansee(mon->mx,mon->my)) map_invisible(mon->mx, mon->my);
-		} else if(mdat != &mons[PM_PHANTASM]){
+		} else if(mdat->mtyp != PM_PHANTASM){
 			if(!cansee(mon->mx,mon->my)) map_invisible(mon->mx, mon->my);
 		}
 	}
@@ -4413,20 +4413,20 @@ boolean was_swallowed;			/* digestion */
 	    	Sprintf(killer_buf, "%s explosion", s_suffix(mdat->mname));
 	    	killer = killer_buf;
 	    	killer_format = KILLED_BY_AN;
-			if(mdat==&mons[PM_GAS_SPORE] || mdat==&mons[PM_DUNGEON_FERN_SPORE]){
+			if(mdat->mtyp==PM_GAS_SPORE || mdat->mtyp==PM_DUNGEON_FERN_SPORE){
 	    	  explode(mon->mx, mon->my, AD_ACID, MON_EXPLODE, tmp, EXPL_NOXIOUS, 1);
 			}
-			else if(mdat==&mons[PM_SWAMP_FERN_SPORE]){
+			else if(mdat->mtyp==PM_SWAMP_FERN_SPORE){
 	    	  explode(mon->mx, mon->my, AD_DISE, MON_EXPLODE, tmp, EXPL_MAGICAL, 1);
 			}
-			else if(mdat==&mons[PM_BURNING_FERN_SPORE]){
+			else if(mdat->mtyp==PM_BURNING_FERN_SPORE){
 	    	  explode(mon->mx, mon->my, AD_PHYS, MON_EXPLODE, tmp, EXPL_FIERY, 1);
 			}
 			else if(mdat->mattk[i].adtyp == AD_PHYS){
-				if(mdat == &mons[PM_FABERGE_SPHERE]) explode(mon->mx, mon->my, AD_PHYS, MON_EXPLODE, tmp, rn2(7), 1);
+				if(mdat->mtyp == PM_FABERGE_SPHERE) explode(mon->mx, mon->my, AD_PHYS, MON_EXPLODE, tmp, rn2(7), 1);
 				else explode(mon->mx, mon->my, AD_PHYS, MON_EXPLODE, tmp, EXPL_MUDDY, 1);
 			} else if(mdat->mattk[i].adtyp == AD_FIRE){
-				//mdat == &mons[PM_BALROG] || mdat == &mons[PM_MEPHISTOPHELES] || mdat == &mons[PM_FLAMING_SPHERE]){
+				//mdat->mtyp == PM_BALROG || mdat->mtyp == PM_MEPHISTOPHELES || mdat->mtyp == PM_FLAMING_SPHERE){
 				explode(mon->mx, mon->my, AD_FIRE, MON_EXPLODE, tmp, EXPL_FIERY, 1);
 			}
 			else if(mdat->mattk[i].adtyp == AD_JAILER){
@@ -4461,10 +4461,10 @@ boolean was_swallowed;			/* digestion */
 				}
 			}
 			else if(mdat->mattk[i].adtyp == AD_COLD){
-			//mdat == &mons[PM_BAALPHEGOR] || mdat == &mons[PM_ANCIENT_OF_ICE] || mdat == &mons[PM_FREEZING_SPHERE]){
+			//mdat->mtyp == PM_BAALPHEGOR || mdat->mtyp == PM_ANCIENT_OF_ICE || mdat->mtyp == PM_FREEZING_SPHERE){
 			  explode(mon->mx, mon->my, AD_COLD, MON_EXPLODE, tmp, EXPL_FROSTY, 1);
 			}
-			else if(mdat->mattk[i].adtyp == AD_ELEC){//mdat == &mons[PM_SHOCKING_SPHERE]){
+			else if(mdat->mattk[i].adtyp == AD_ELEC){//mdat->mtyp == PM_SHOCKING_SPHERE){
 				explode(mon->mx, mon->my, AD_ELEC, MON_EXPLODE, tmp, EXPL_MAGICAL, 1);
 			}
 			else if(mdat->mattk[i].adtyp == AD_FRWK){
@@ -4478,7 +4478,7 @@ boolean was_swallowed;			/* digestion */
 			} else if(mdat->mattk[i].adtyp == AD_SPNL){
 				explode(mon->mx, mon->my, AD_COLD, MON_EXPLODE, tmp, EXPL_WET, 1);
 				makemon(rn2(2) ? &mons[PM_LEVIATHAN] : &mons[PM_LEVISTUS], mon->mx, mon->my, MM_ADJACENTOK);
-			} else if(mdat == &mons[PM_ANCIENT_OF_DEATH]){
+			} else if(mdat->mtyp == PM_ANCIENT_OF_DEATH){
 				if(!(u.sealsActive&SEAL_OSE)) explode(mon->mx, mon->my, AD_MAGM, MON_EXPLODE, tmp, EXPL_DARK, 1);
 			} else if(mdat->mattk[i].adtyp == AD_MAND){
 				struct monst *mtmp, *mtmp2;
@@ -4513,10 +4513,10 @@ boolean was_swallowed;			/* digestion */
 			else{
 			  explode(mon->mx, mon->my, AD_MAGM, MON_EXPLODE, tmp, EXPL_MAGICAL, 1);
 			}
-	    	if(mdat == &mons[PM_GARO_MASTER] || mdat == &mons[PM_GARO]) return (TRUE);
+	    	if(mdat->mtyp == PM_GARO_MASTER || mdat->mtyp == PM_GARO) return (TRUE);
 			else return (FALSE);
 	    } //End AT_BOOM != AD_HLBD && != AD_POSN
-		else if(mdat->mattk[i].adtyp == AD_HLBD && mdat == &mons[PM_ASMODEUS]){
+		else if(mdat->mattk[i].adtyp == AD_HLBD && mdat->mtyp == PM_ASMODEUS){
 			int i;
 			for(i=0; i<2; i++) makemon(&mons[PM_NESSIAN_PIT_FIEND], mon->mx, mon->my, MM_ADJACENTOK);
 			for(i=0; i<7; i++) makemon(&mons[PM_PIT_FIEND], mon->mx, mon->my, MM_ADJACENTOK);
@@ -4525,7 +4525,7 @@ boolean was_swallowed;			/* digestion */
 			for(i = 0; i<30; i++) makemon(&mons[PM_LEMURE], mon->mx, mon->my, MM_ADJACENTOK);
 	    	return (FALSE);
 		}
-		else if(mdat->mattk[i].adtyp == AD_HLBD && mdat == &mons[PM_VERIER]){
+		else if(mdat->mattk[i].adtyp == AD_HLBD && mdat->mtyp == PM_VERIER){
 			int i;
 			for(i=0; i<9; i++) makemon(&mons[PM_PIT_FIEND], mon->mx, mon->my, MM_ADJACENTOK);
 			for(i = 0; i<12; i++) makemon(&mons[PM_BARBED_DEVIL], mon->mx, mon->my, MM_ADJACENTOK);
@@ -4533,20 +4533,20 @@ boolean was_swallowed;			/* digestion */
 			for(i = 0; i<30; i++) makemon(&mons[PM_LEMURE], mon->mx, mon->my, MM_ADJACENTOK);
 	    	return (FALSE);
 		}
-  		else if(	( (mdat->mattk[i].aatyp == AT_NONE && mdat==&mons[PM_GREAT_CTHULHU])
+  		else if(	( (mdat->mattk[i].aatyp == AT_NONE && mdat->mtyp==PM_GREAT_CTHULHU)
 					 || mdat->mattk[i].aatyp == AT_BOOM) 
 				&& mdat->mattk[i].adtyp == AD_POSN){
 	    	Sprintf(killer_buf, "%s explosion", s_suffix(mdat->mname));
 	    	killer = killer_buf;
 	    	killer_format = KILLED_BY_AN;
 			explode(mon->mx, mon->my, AD_PHYS, MON_EXPLODE, d(8,8), EXPL_NOXIOUS, 1);
-			if(mdat==&mons[PM_GREAT_CTHULHU]){
+			if(mdat->mtyp==PM_GREAT_CTHULHU){
 				flags.cth_attk=TRUE;//state machine stuff.
 				create_gas_cloud(mon->mx, mon->my, 2, 30);
 				flags.cth_attk=FALSE;
 			}
 		}
-		else if(mdat->mattk[i].adtyp == AD_GROW && (mdat==&mons[PM_AXUS])){
+		else if(mdat->mattk[i].adtyp == AD_GROW && (mdat->mtyp==PM_AXUS)){
 			struct monst *mtmp;
 			struct permonst *mdat1;
 			int quin = 1, qua = 2, tre = 3, duo = 4;
@@ -4556,8 +4556,8 @@ boolean was_swallowed;			/* digestion */
 				if(DEADMONSTER(mtmp))
 					continue;
 				mdat1 = mtmp->data;
-//				if(mdat1==&mons[PM_QUINON]) quincount++;
-				if(mdat1==&mons[PM_QUATON] && quin){
+//				if(mdat1->mtyp==PM_QUINON) quincount++;
+				if(mdat1->mtyp==PM_QUATON && quin){
 					set_mon_data(mtmp, PM_QUINON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
@@ -4566,7 +4566,7 @@ boolean was_swallowed;			/* digestion */
 					quin--;
 //					quincount++;
 				}
-				else if(mdat1==&mons[PM_TRITON] && qua){
+				else if(mdat1->mtyp==PM_TRITON && qua){
 					set_mon_data(mtmp, PM_QUATON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
@@ -4574,7 +4574,7 @@ boolean was_swallowed;			/* digestion */
 					newsym(mtmp->mx, mtmp->my);
 					qua--;
 				}
-				else if(mdat1==&mons[PM_DUTON] && tre){
+				else if(mdat1->mtyp==PM_DUTON && tre){
 					set_mon_data(mtmp, PM_TRITON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
@@ -4582,7 +4582,7 @@ boolean was_swallowed;			/* digestion */
 					newsym(mtmp->mx, mtmp->my);
 					tre--;
 				}
-				else if(mdat1==&mons[PM_MONOTON] && duo){
+				else if(mdat1->mtyp==PM_MONOTON && duo){
 					set_mon_data(mtmp, PM_DUTON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
@@ -4603,7 +4603,7 @@ boolean was_swallowed;			/* digestion */
 //			The dungeon of ill regard, where Axus is found, now spawns only Modrons.  So this is uneeded
 //			for(quincount;quincount<7;quincount++) makemon(&mons[PM_QUINON], mon->mx, mon->my,MM_ADJACENTOK|MM_ANGRY);
 		}
-		else if(mdat->mattk[i].adtyp == AD_GROW || (mdat==&mons[PM_QUINON] 
+		else if(mdat->mattk[i].adtyp == AD_GROW || (mdat->mtyp==PM_QUINON 
 		        && mdat->mattk[i].adtyp == AD_STUN)){//horrid quinon kludge
 			struct monst *mtmp;
 			struct monst * axus = (struct monst *)0;
@@ -4646,25 +4646,25 @@ boolean was_swallowed;			/* digestion */
 			int hpgain = 0;
 			int lvlgain = 0;
 			int lvls = 0;
-			if(mdat==&mons[PM_DEEP_ONE]){
+			if(mdat->mtyp==PM_DEEP_ONE){
 				hpgain = 2;
-			} else if(mdat==&mons[PM_DEEPER_ONE]){
+			} else if(mdat->mtyp==PM_DEEPER_ONE){
 				hpgain = 4;
-			} else if(mdat==&mons[PM_DEEPEST_ONE] || mdat==&mons[PM_FATHER_DAGON] || mdat==&mons[PM_MOTHER_HYDRA]){
+			} else if(mdat->mtyp==PM_DEEPEST_ONE || mdat->mtyp==PM_FATHER_DAGON || mdat->mtyp==PM_MOTHER_HYDRA){
 				hpgain = 8;
 			} else { //arcadian avenger
 				lvlgain = 1;
 			}
-			if(mdat==&mons[PM_DEEP_ONE] || mdat==&mons[PM_DEEPER_ONE] || mdat==&mons[PM_DEEPEST_ONE]
-			 || mdat==&mons[PM_FATHER_DAGON] || mdat==&mons[PM_MOTHER_HYDRA]
+			if(mdat->mtyp==PM_DEEP_ONE || mdat->mtyp==PM_DEEPER_ONE || mdat->mtyp==PM_DEEPEST_ONE
+			 || mdat->mtyp==PM_FATHER_DAGON || mdat->mtyp==PM_MOTHER_HYDRA
 			){
 				for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 					if(DEADMONSTER(mtmp))
 						continue;
 					mdat1 = mtmp->data;
-					if( mdat1==&mons[PM_DEEP_ONE] || 
-						mdat1==&mons[PM_DEEPER_ONE] || 
-						mdat1==&mons[PM_DEEPEST_ONE]
+					if( mdat1->mtyp==PM_DEEP_ONE || 
+						mdat1->mtyp==PM_DEEPER_ONE || 
+						mdat1->mtyp==PM_DEEPEST_ONE
 					){
 						if(lvlgain) for(lvls = lvlgain; lvls > 0; lvls--) grow_up(mtmp, 0);
 						if(hpgain){
@@ -4717,46 +4717,46 @@ boolean was_swallowed;			/* digestion */
 		   || mon->data->msound == MS_NEMESIS
 		   || is_alabaster_mummy(mon->data)
 		   || (uwep && uwep->oartifact == ART_SINGING_SWORD && uwep->osinging == OSING_LIFE && mon->mtame)
-		   || mdat == &mons[PM_UNDEAD_KNIGHT]
-		   || mdat == &mons[PM_WARRIOR_OF_SUNLIGHT]
-		   || mdat == &mons[PM_CROW_WINGED_HALF_DRAGON]
-		   || mdat == &mons[PM_SEYLL_AUZKOVYN]
-		   || mdat == &mons[PM_DARUTH_XAXOX]
-		   || mdat == &mons[PM_ORION]
-		   || mdat == &mons[PM_VECNA]
-//		   || mdat == &mons[PM_UNICORN_OF_AMBER]
-		   || mdat == &mons[PM_NIGHTMARE]
-		   || mdat == &mons[PM_CHROMATIC_DRAGON]
-		   || mdat == &mons[PM_PLATINUM_DRAGON]
-		   || mdat == &mons[PM_CHANGED]
-		   || mdat == &mons[PM_WARRIOR_CHANGED]
-		   || mdat == &mons[PM_TWITCHING_FOUR_ARMED_CHANGED]
-		   || mdat == &mons[PM_CLAIRVOYANT_CHANGED]
-		   || mdat == &mons[PM_NITOCRIS]
-		   || mdat == &mons[PM_GHOUL_QUEEN_NITOCRIS]
-		   || mdat == &mons[PM_ANDROID]
-		   || mdat == &mons[PM_GYNOID]
-		   || mdat == &mons[PM_OPERATOR]
-		   || mdat == &mons[PM_COMMANDER]
-		   || mdat == &mons[PM_MUMMIFIED_ANDROID]
-		   || mdat == &mons[PM_MUMMIFIED_GYNOID]
-		   || mdat == &mons[PM_FLAYED_ANDROID]
-		   || mdat == &mons[PM_FLAYED_GYNOID]
-		   || mdat == &mons[PM_PARASITIZED_EMBRACED_ALIDER]
-		   || mdat == &mons[PM_PARASITIZED_ANDROID]
-		   || mdat == &mons[PM_PARASITIZED_GYNOID]
-		   || mdat == &mons[PM_PARASITIZED_OPERATOR]
-		   || mdat == &mons[PM_PARASITIZED_COMMANDER]
-		   || mdat == &mons[PM_CRUCIFIED_ANDROID]
-		   || mdat == &mons[PM_CRUCIFIED_GYNOID]
-//		   || mdat == &mons[PM_PINK_UNICORN]
+		   || mdat->mtyp == PM_UNDEAD_KNIGHT
+		   || mdat->mtyp == PM_WARRIOR_OF_SUNLIGHT
+		   || mdat->mtyp == PM_CROW_WINGED_HALF_DRAGON
+		   || mdat->mtyp == PM_SEYLL_AUZKOVYN
+		   || mdat->mtyp == PM_DARUTH_XAXOX
+		   || mdat->mtyp == PM_ORION
+		   || mdat->mtyp == PM_VECNA
+//		   || mdat->mtyp == PM_UNICORN_OF_AMBER
+		   || mdat->mtyp == PM_NIGHTMARE
+		   || mdat->mtyp == PM_CHROMATIC_DRAGON
+		   || mdat->mtyp == PM_PLATINUM_DRAGON
+		   || mdat->mtyp == PM_CHANGED
+		   || mdat->mtyp == PM_WARRIOR_CHANGED
+		   || mdat->mtyp == PM_TWITCHING_FOUR_ARMED_CHANGED
+		   || mdat->mtyp == PM_CLAIRVOYANT_CHANGED
+		   || mdat->mtyp == PM_NITOCRIS
+		   || mdat->mtyp == PM_GHOUL_QUEEN_NITOCRIS
+		   || mdat->mtyp == PM_ANDROID
+		   || mdat->mtyp == PM_GYNOID
+		   || mdat->mtyp == PM_OPERATOR
+		   || mdat->mtyp == PM_COMMANDER
+		   || mdat->mtyp == PM_MUMMIFIED_ANDROID
+		   || mdat->mtyp == PM_MUMMIFIED_GYNOID
+		   || mdat->mtyp == PM_FLAYED_ANDROID
+		   || mdat->mtyp == PM_FLAYED_GYNOID
+		   || mdat->mtyp == PM_PARASITIZED_EMBRACED_ALIDER
+		   || mdat->mtyp == PM_PARASITIZED_ANDROID
+		   || mdat->mtyp == PM_PARASITIZED_GYNOID
+		   || mdat->mtyp == PM_PARASITIZED_OPERATOR
+		   || mdat->mtyp == PM_PARASITIZED_COMMANDER
+		   || mdat->mtyp == PM_CRUCIFIED_ANDROID
+		   || mdat->mtyp == PM_CRUCIFIED_GYNOID
+//		   || mdat->mtyp == PM_PINK_UNICORN
 		   )
 		return TRUE;
 		
 	if (LEVEL_SPECIFIC_NOCORPSE(mdat))
 		return FALSE;
 
-	if(bigmonst(mdat) || mdat == &mons[PM_LIZARD]) return TRUE;
+	if(bigmonst(mdat) || mdat->mtyp == PM_LIZARD) return TRUE;
 	
 	tmp = (int)(2 + ((int)(mdat->geno & G_FREQ)<2) + verysmall(mdat));
 	return (u.sealsActive&SEAL_EVE) ? (!rn2(tmp)||!rn2(tmp)) : 
@@ -4777,18 +4777,18 @@ struct monst *mon;
 	    create_gas_cloud(mm.x, mm.y, rn1(2,1), rnd(8));
 	    /* all fern spores have a 2/3 chance of creating nothing, except for
 	       the generic fern spore, which guarantees a terrain-appropriate fern */
-	    if (mon->data == &mons[PM_DUNGEON_FERN_SPORE]) {
+	    if (mon->mtyp == PM_DUNGEON_FERN_SPORE) {
 		/* dungeon ferns cannot reproduce on ice, lava, or water; swamp is okay */
 			if (!is_ice(mm.x, mm.y) && !is_lava(mm.x, mm.y) && !is_pool(mm.x, mm.y, FALSE))
 				sporetype = 0;
 			else return;
 			if (rn2(3)) return;
-	    } else if (mon->data == &mons[PM_SWAMP_FERN_SPORE]) {
+	    } else if (mon->mtyp == PM_SWAMP_FERN_SPORE) {
 			if (!is_ice(mm.x, mm.y) && !is_lava(mm.x, mm.y))
 				sporetype = 2;
 			else return;
 			if (rn2(3)) return;
-	    } else if (mon->data == &mons[PM_BURNING_FERN_SPORE]) {
+	    } else if (mon->mtyp == PM_BURNING_FERN_SPORE) {
 			if (!is_ice(mm.x, mm.y) && !is_pool(mm.x, mm.y, TRUE))
 				sporetype = 3;
 			else return;
@@ -5320,7 +5320,7 @@ xkilled(mtmp, dest)
 
 	/* KMH, conduct */
 	u.uconduct.killer++;
-	if(mtmp->data == &mons[PM_CROW] && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
+	if(mtmp->mtyp == PM_CROW && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
 
 	if(uwep && uwep->oproperties&OPROP_WRTHW){
 		struct obj *otmp = uwep;
@@ -5439,7 +5439,7 @@ xkilled(mtmp, dest)
 		goto cleanup;
 
 #ifdef MAIL
-	if(mdat == &mons[PM_MAIL_DAEMON]) {
+	if(mdat->mtyp == PM_MAIL_DAEMON) {
 		stackobj(mksobj_at(SCR_MAIL, x, y, FALSE, FALSE));
 		redisp = TRUE;
 	}
@@ -5560,7 +5560,7 @@ cleanup:
 	} else if (mdat->msound == MS_NEMESIS){	/* Real good! */
 	    adjalign((int)(ALIGNLIM/4));
 		u.hod = max(u.hod-10,0);
-	} else if (mdat->msound == MS_GUARDIAN && mdat != &mons[PM_THUG] && !is_derived_undead_mon(mtmp)) {	/* Bad *//*nobody cares if you kill thugs*/
+	} else if (mdat->msound == MS_GUARDIAN && mdat->mtyp != PM_THUG && !is_derived_undead_mon(mtmp)) {	/* Bad *//*nobody cares if you kill thugs*/
 	    adjalign(-(int)(ALIGNLIM/8));											/*what's a little murder amongst rogues?*/
 		u.hod += 10;
 	    if (!Hallucination) pline("That was probably a bad idea...");
@@ -5848,7 +5848,7 @@ register struct monst *mtmp;
 		mtmp->data->msound == MS_JUBJUB || mtmp->data->msound == MS_DREAD || 
 		mtmp->data->msound == MS_SONG || mtmp->data->msound == MS_OONA ||
 		mtmp->data->msound == MS_INTONE || mtmp->data->msound == MS_FLOWER ||
-		mtmp->data->msound == MS_TRUMPET || mtmp->data == &mons[PM_RHYMER]
+		mtmp->data->msound == MS_TRUMPET || mtmp->mtyp == PM_RHYMER
 		)
 	) {
 		domonnoise(mtmp, FALSE);
@@ -5885,21 +5885,21 @@ register struct monst *mtmp;
 	} else
 		adjalign(-1);		/* attacking peaceful monsters is bad */
 	
-	if(mtmp->data == &mons[PM_DANCING_BLADE]){
+	if(mtmp->mtyp == PM_DANCING_BLADE){
 		struct monst *surya;
 		for(surya = fmon; surya; surya = surya->nmon) if(surya->m_id == mtmp->mvar_suryaID) break;
 		if(surya) setmangry(surya);
 	}
-	if(mtmp->data == &mons[PM_SURYA_DEVA]){
+	if(mtmp->mtyp == PM_SURYA_DEVA){
 		struct monst *blade;
-		for(blade = fmon; blade; blade = blade->nmon) if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+		for(blade = fmon; blade; blade = blade->nmon) if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 		if(blade) setmangry(blade);
 	}
 	if (couldsee(mtmp->mx, mtmp->my)) {
 		if (humanoid(mtmp->data) || mtmp->isshk || mtmp->isgd)
 		    pline("%s gets angry!", Monnam(mtmp));
 		else if (flags.verbose && flags.soundok) growl(mtmp);
-		if(flags.stag && (mtmp->data == &mons[PM_DROW_MATRON_MOTHER] || mtmp->data == &mons[PM_ECLAVDRA])){
+		if(flags.stag && (mtmp->mtyp == PM_DROW_MATRON_MOTHER || mtmp->mtyp == PM_ECLAVDRA)){
 			struct monst *tm;
 			for(tm = fmon; tm; tm = tm->nmon){
 				if(tm->mfaction != EILISTRAEE_SYMBOL && 
@@ -6020,7 +6020,7 @@ register int x, y, distance;
 				mtmp->mcanhear = 0;
 				mtmp->mdeafened = distance - dist2(mtmp->mx, mtmp->my, x, y);
 			}
-			if(mtmp->data == &mons[PM_ECHO]){
+			if(mtmp->mtyp == PM_ECHO){
 				struct monst *tmpm;
 				int targets = 0, damage = 0;
 				for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -6437,13 +6437,13 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
 	set_mon_data(mtmp, mtyp, 0);
 
 	if (emits_light(olddata) != emits_light_mon(mtmp)
-		|| olddata == &mons[PM_MASKED_QUEEN]
+		|| olddata->mtyp == PM_MASKED_QUEEN
 	) {
 	    /* used to give light, now doesn't, or vice versa,
 	       or light's range has changed */
 	    if (emits_light(olddata) || mtmp->mfaction == ILLUMINATED)
 			del_light_source(LS_MONSTER, (genericptr_t)mtmp, FALSE);
-		if(olddata == &mons[PM_MASKED_QUEEN])
+		if(olddata->mtyp == PM_MASKED_QUEEN)
 			mtmp->mfaction = ILLUMINATED;
 	    if (emits_light_mon(mtmp))
 		new_light_source(mtmp->mx, mtmp->my, emits_light_mon(mtmp),
@@ -6461,7 +6461,7 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
 				/* Does mdat care? */
 				if (!noncorporeal(mdat) && !amorphous(mdat) &&
 				    !is_whirly(mdat) &&
-				    (mdat != &mons[PM_YELLOW_LIGHT])) {
+				    (mdat->mtyp != PM_YELLOW_LIGHT)) {
 					You("break out of %s%s!", mon_nam(mtmp),
 					    (is_animal(mdat)?
 					    "'s stomach" : ""));
@@ -6683,10 +6683,10 @@ int damtype, dam;
 {
     int heal = 0, slow = 0;
 
-    if (mon->data == &mons[PM_FLESH_GOLEM]) {
+    if (mon->mtyp == PM_FLESH_GOLEM) {
 	if (damtype == AD_ELEC) heal = dam / 6;
 	else if (damtype == AD_FIRE || damtype == AD_COLD) slow = 1;
-    } else if (mon->data == &mons[PM_IRON_GOLEM] || mon->data == &mons[PM_CHAIN_GOLEM] || mon->data == &mons[PM_ARGENTUM_GOLEM] || mon->data == &mons[PM_CENTER_OF_ALL]) {
+    } else if (mon->mtyp == PM_IRON_GOLEM || mon->mtyp == PM_CHAIN_GOLEM || mon->mtyp == PM_ARGENTUM_GOLEM || mon->mtyp == PM_CENTER_OF_ALL) {
 	if (damtype == AD_ELEC) slow = 1;
 	else if (damtype == AD_FIRE) heal = dam;
     } else {
@@ -6715,8 +6715,8 @@ register boolean silent;
 
 	for(mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 		if (DEADMONSTER(mtmp)) continue;
-		if((mtmp->data == &mons[PM_WATCHMAN] ||
-			       mtmp->data == &mons[PM_WATCH_CAPTAIN])
+		if((mtmp->mtyp == PM_WATCHMAN ||
+			       mtmp->mtyp == PM_WATCH_CAPTAIN)
 					&& mtmp->mpeaceful && !mtmp->mtame) {
 			ct++;
 			if(cansee(mtmp->mx, mtmp->my) && mtmp->mcanmove) {
@@ -6755,8 +6755,8 @@ pacify_guards()
 
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 	    if (DEADMONSTER(mtmp)) continue;
-	    if (mtmp->data == &mons[PM_WATCHMAN] ||
-		mtmp->data == &mons[PM_WATCH_CAPTAIN])
+	    if (mtmp->mtyp == PM_WATCHMAN ||
+		mtmp->mtyp == PM_WATCH_CAPTAIN)
 	    mtmp->mpeaceful = 1;
 	}
 }
@@ -6863,14 +6863,14 @@ long id;
 	struct monst *mtmp;
 	for(mtmp = fmon; mtmp; mtmp = mtmp->nmon)
 		if(id == (long)mtmp->m_id){
-			if(mtmp->data == &mons[PM_COVEN_LEADER]){
+			if(mtmp->mtyp == PM_COVEN_LEADER){
 				pline("%s screams in rage!", Monnam(mtmp));
 				mtmp->mspec_used = 4;
 				mtmp->encouraged += 8;
 			} else {
 				pline("%s screams in dismay!", Monnam(mtmp));
 				monflee(mtmp, 0, FALSE, TRUE);
-				if(mtmp->data == &mons[PM_WITCH])
+				if(mtmp->mtyp == PM_WITCH)
 					mtmp->mspec_used = 10;
 			}
 		}
@@ -6952,7 +6952,7 @@ struct monst *mtmp;
 {
 	if(DEADMONSTER(mtmp))
 		return;
-	if(mtmp->data == &mons[PM_LIVING_DOLL]){
+	if(mtmp->mtyp == PM_LIVING_DOLL){
 		mondied(mtmp);
 	} else {
 		migrate_to_level(mtmp, ledger_no(&u.uz), MIGR_EXACT_XY, (coord *)0);

--- a/src/mon.c
+++ b/src/mon.c
@@ -722,7 +722,7 @@ register struct monst *mtmp;
 				initedog(mon);
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				obj = mkcorpstat(BROKEN_ANDROID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -736,7 +736,7 @@ register struct monst *mtmp;
 				initedog(mon);
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				obj = mkcorpstat(BROKEN_ANDROID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -750,7 +750,7 @@ register struct monst *mtmp;
 				initedog(mon);
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				obj = mkcorpstat(BROKEN_ANDROID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -797,7 +797,7 @@ register struct monst *mtmp;
 				initedog(mon);
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				obj = mkcorpstat(BROKEN_GYNOID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -811,7 +811,7 @@ register struct monst *mtmp;
 				initedog(mon);
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				obj = mkcorpstat(BROKEN_GYNOID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -825,7 +825,7 @@ register struct monst *mtmp;
 				initedog(mon);
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				obj = mkcorpstat(BROKEN_GYNOID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -897,7 +897,7 @@ register struct monst *mtmp;
 				mon->mpeaceful = 1;
 				mon->mcrazed = 1;
 				EDOG(mon)->loyal = TRUE;
-				mon->mfaction = M_GREAT_WEB;
+				set_faction(mon, M_GREAT_WEB);
 				obj = mkcorpstat(BROKEN_GYNOID, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
 			} else {
@@ -1132,7 +1132,7 @@ register struct monst *mtmp;
 				mon->female = TRUE;
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 			}
 			obj = mkcorpstat(CORPSE, mon, (struct permonst *)0, x, y, FALSE);
 			mongone(mon);
@@ -1151,7 +1151,7 @@ register struct monst *mtmp;
 				mon->female = TRUE;
 				mon->mtame = 10;
 				mon->mpeaceful = 1;
-				mon->mfaction = ZOMBIFIED;
+				set_faction(mon, ZOMBIFIED);
 				EDOG(mon)->loyal = TRUE;
 				mkcorpstat(CORPSE, mon, (struct permonst *)0, x, y, FALSE);
 				mongone(mon);
@@ -1405,15 +1405,6 @@ mcalcmove(mon)
 struct monst *mon;
 {
     int mmove = mon->data->mmove;
-	
-	if(mon->mfaction == ZOMBIFIED && mmove > 6){
-		mmove = mmove/2;
-		if(mmove < 6) mmove = 6;
-	}
-	if(mon->mfaction == SKELIFIED && mmove > 6){
-		mmove = mmove*3/4;
-		if(mmove < 6) mmove = 6;
-	}
 	
 	if(u.ustuck == mon && mmove < 12 && mon->data->mlet == S_VORTEX){
 		mmove *= 2;
@@ -1838,7 +1829,7 @@ mcalcdistress()
 				tmpm->mpeaceful = mtmp->mpeaceful;
 				if(tmpm->mtame && tmpm->mtame != mtmp->mtame)
 					tmpm->mtame = 0;
-				tmpm->mfaction = CRYSTALFIED;
+				set_faction(tmpm, CRYSTALFIED);
 				newsym(tmpm->mx, tmpm->my);
 				mtmp->mhp += tmpm->mhp;
 			}
@@ -3961,7 +3952,7 @@ struct monst *mtmp;
 			}
 			/* If marked to do so, remve illuminated status */
 			if (!(lifesavers&LSVD_ILU)){
-				mtmp->mfaction = 0;
+				set_faction(mtmp, 0);
 				del_light_source(LS_MONSTER, (genericptr_t)mtmp, FALSE);
 				if (emits_light_mon(mtmp))
 					new_light_source(mtmp->mx, mtmp->my, emits_light_mon(mtmp),
@@ -3989,7 +3980,7 @@ struct monst *mtmp;
 				else
 					You_hear("something crack%s!", !is_silent(mtmp->data) ? " with an unearthly scream" : "");
 			}
-			mtmp->mfaction = FRACTURED;
+			set_faction(mtmp, FRACTURED);
 			/* make hostile */
 			mtmp->mtame = 0;
 			mtmp->mpeaceful = 0;
@@ -4155,7 +4146,7 @@ register struct monst *mtmp;
 	if(mtmp->iswiz) wizdead();
 	if(mtmp->data->msound == MS_NEMESIS) nemdead();        
 	//Asc items and crucial bookkeeping
-	if(Race_if(PM_DROW) && !Role_if(PM_NOBLEMAN) && mtmp->data == &mons[urole.neminum] && !flags.made_bell){
+	if(Race_if(PM_DROW) && !Role_if(PM_NOBLEMAN) && mtmp->mtyp == urole.neminum && !flags.made_bell){
 		(void) mksobj_at(BELL_OF_OPENING, mtmp->mx, mtmp->my, TRUE, FALSE);
 		flags.made_bell = TRUE;
 	}
@@ -5918,7 +5909,7 @@ register struct monst *mtmp;
 	/* attacking your own quest leader will anger his or her guardians */
 	if (!flags.mon_moving &&	/* should always be the case here */
 		mtmp->m_id == quest_status.leader_m_id) {
-		// mtmp->data == &mons[quest_info(MS_LEADER)]) {
+		// mtmp->mtyp == quest_info(MS_LEADER) {
 	    struct monst *mon;
 	    struct permonst *q_guardian = &mons[quest_info(MS_GUARDIAN)];
 	    int got_mad = 0;
@@ -6444,7 +6435,7 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
 	    if (emits_light(olddata) || mtmp->mfaction == ILLUMINATED)
 			del_light_source(LS_MONSTER, (genericptr_t)mtmp, FALSE);
 		if(olddata->mtyp == PM_MASKED_QUEEN)
-			mtmp->mfaction = ILLUMINATED;
+			set_faction(mtmp, ILLUMINATED);
 	    if (emits_light_mon(mtmp))
 		new_light_source(mtmp->mx, mtmp->my, emits_light_mon(mtmp),
 				 LS_MONSTER, (genericptr_t)mtmp);

--- a/src/mon.c
+++ b/src/mon.c
@@ -4002,7 +4002,7 @@ struct monst *mtmp;
 				pline("%s tears off the right half of %s face before rising through the ceiling!", nyar_name[nyar_form], s_suffix(Monnam(mtmp)));
 				change_usanity(u_sanity_loss_nyar());
 			}
-			set_mon_data(mtmp, PM_GHOUL_QUEEN_NITOCRIS, 0);
+			set_mon_data(mtmp, PM_GHOUL_QUEEN_NITOCRIS);
 			//Surprisingly, this is an effective means of life saving!
 			break;
 		}
@@ -4072,15 +4072,15 @@ register struct monst *mtmp;
 	mptr = mtmp->data;		/* save this for m_detach() */
 	/* restore chameleon, lycanthropes to true form at death */
 	if (mtmp->cham)
-		set_mon_data(mtmp, cham_to_pm[mtmp->cham], -1);
+		set_mon_data(mtmp, cham_to_pm[mtmp->cham]);
 	else if (mtmp->mtyp == PM_WEREJACKAL)
-		set_mon_data(mtmp, PM_HUMAN_WEREJACKAL, -1);
+		set_mon_data(mtmp, PM_HUMAN_WEREJACKAL);
 	else if (mtmp->mtyp == PM_WEREWOLF)
-		set_mon_data(mtmp, PM_HUMAN_WEREWOLF, -1);
+		set_mon_data(mtmp, PM_HUMAN_WEREWOLF);
 	else if (mtmp->mtyp == PM_WERERAT)
-		set_mon_data(mtmp, PM_HUMAN_WERERAT, -1);
+		set_mon_data(mtmp, PM_HUMAN_WERERAT);
 	else if (mtmp->mtyp == PM_ANUBAN_JACKAL)
-		set_mon_data(mtmp, PM_ANUBITE, -1);
+		set_mon_data(mtmp, PM_ANUBITE);
 
 	if(mtmp->mtyp == PM_WITCH_S_FAMILIAR){
 		dead_familiar(mtmp->mvar_witchID);
@@ -4549,7 +4549,7 @@ boolean was_swallowed;			/* digestion */
 				mdat1 = mtmp->data;
 //				if(mdat1->mtyp==PM_QUINON) quincount++;
 				if(mdat1->mtyp==PM_QUATON && quin){
-					set_mon_data(mtmp, PM_QUINON, 0);
+					set_mon_data(mtmp, PM_QUINON);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4558,7 +4558,7 @@ boolean was_swallowed;			/* digestion */
 //					quincount++;
 				}
 				else if(mdat1->mtyp==PM_TRITON && qua){
-					set_mon_data(mtmp, PM_QUATON, 0);
+					set_mon_data(mtmp, PM_QUATON);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4566,7 +4566,7 @@ boolean was_swallowed;			/* digestion */
 					qua--;
 				}
 				else if(mdat1->mtyp==PM_DUTON && tre){
-					set_mon_data(mtmp, PM_TRITON, 0);
+					set_mon_data(mtmp, PM_TRITON);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4574,7 +4574,7 @@ boolean was_swallowed;			/* digestion */
 					tre--;
 				}
 				else if(mdat1->mtyp==PM_MONOTON && duo){
-					set_mon_data(mtmp, PM_DUTON, 0);
+					set_mon_data(mtmp, PM_DUTON);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4608,7 +4608,7 @@ boolean was_swallowed;			/* digestion */
 					if (DEADMONSTER(mtmp))
 						continue;
 					if (mtmp->mtyp == current_ton-1) {
-						set_mon_data(mtmp, current_ton, 0);
+						set_mon_data(mtmp, current_ton);
 						//Assumes Auton
 						mtmp->m_lev += 1;
 						mtmp->mhp += 4;
@@ -6425,7 +6425,7 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
 		if (!mtmp->mhpmax) mtmp->mhpmax = 1;
 	} //else just take on new form I think....
 	/* take on the new form... */
-	set_mon_data(mtmp, mtyp, 0);
+	set_mon_data(mtmp, mtyp);
 
 	if (emits_light(olddata) != emits_light_mon(mtmp)
 		|| olddata->mtyp == PM_MASKED_QUEEN

--- a/src/mon.c
+++ b/src/mon.c
@@ -4011,7 +4011,7 @@ struct monst *mtmp;
 				pline("%s tears off the right half of %s face before rising through the ceiling!", nyar_name[nyar_form], s_suffix(Monnam(mtmp)));
 				change_usanity(u_sanity_loss_nyar());
 			}
-			set_mon_data(mtmp, &mons[PM_GHOUL_QUEEN_NITOCRIS], 0);
+			set_mon_data(mtmp, PM_GHOUL_QUEEN_NITOCRIS, 0);
 			//Surprisingly, this is an effective means of life saving!
 			break;
 		}
@@ -4081,15 +4081,15 @@ register struct monst *mtmp;
 	mptr = mtmp->data;		/* save this for m_detach() */
 	/* restore chameleon, lycanthropes to true form at death */
 	if (mtmp->cham)
-		set_mon_data(mtmp, &mons[cham_to_pm[mtmp->cham]], -1);
+		set_mon_data(mtmp, cham_to_pm[mtmp->cham], -1);
 	else if (mtmp->data == &mons[PM_WEREJACKAL])
-		set_mon_data(mtmp, &mons[PM_HUMAN_WEREJACKAL], -1);
+		set_mon_data(mtmp, PM_HUMAN_WEREJACKAL, -1);
 	else if (mtmp->data == &mons[PM_WEREWOLF])
-		set_mon_data(mtmp, &mons[PM_HUMAN_WEREWOLF], -1);
+		set_mon_data(mtmp, PM_HUMAN_WEREWOLF, -1);
 	else if (mtmp->data == &mons[PM_WERERAT])
-		set_mon_data(mtmp, &mons[PM_HUMAN_WERERAT], -1);
+		set_mon_data(mtmp, PM_HUMAN_WERERAT, -1);
 	else if (mtmp->data == &mons[PM_ANUBAN_JACKAL])
-		set_mon_data(mtmp, &mons[PM_ANUBITE], -1);
+		set_mon_data(mtmp, PM_ANUBITE, -1);
 
 	if(mtmp->data == &mons[PM_WITCH_S_FAMILIAR]){
 		dead_familiar(mtmp->mvar_witchID);
@@ -4558,7 +4558,7 @@ boolean was_swallowed;			/* digestion */
 				mdat1 = mtmp->data;
 //				if(mdat1==&mons[PM_QUINON]) quincount++;
 				if(mdat1==&mons[PM_QUATON] && quin){
-					set_mon_data(mtmp, &mons[PM_QUINON], 0);
+					set_mon_data(mtmp, PM_QUINON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4567,7 +4567,7 @@ boolean was_swallowed;			/* digestion */
 //					quincount++;
 				}
 				else if(mdat1==&mons[PM_TRITON] && qua){
-					set_mon_data(mtmp, &mons[PM_QUATON], 0);
+					set_mon_data(mtmp, PM_QUATON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4575,7 +4575,7 @@ boolean was_swallowed;			/* digestion */
 					qua--;
 				}
 				else if(mdat1==&mons[PM_DUTON] && tre){
-					set_mon_data(mtmp, &mons[PM_TRITON], 0);
+					set_mon_data(mtmp, PM_TRITON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4583,7 +4583,7 @@ boolean was_swallowed;			/* digestion */
 					tre--;
 				}
 				else if(mdat1==&mons[PM_MONOTON] && duo){
-					set_mon_data(mtmp, &mons[PM_DUTON], 0);
+					set_mon_data(mtmp, PM_DUTON, 0);
 					mtmp->m_lev += 1;
 					mtmp->mhp += 4;
 					mtmp->mhpmax += 4;
@@ -4606,127 +4606,39 @@ boolean was_swallowed;			/* digestion */
 		else if(mdat->mattk[i].adtyp == AD_GROW || (mdat==&mons[PM_QUINON] 
 		        && mdat->mattk[i].adtyp == AD_STUN)){//horrid quinon kludge
 			struct monst *mtmp;
-			struct permonst *mdat1, **child, **growto;
-			int i = 0;
-			int chain = FALSE;
-			int found = FALSE;
-			int tontype = FALSE;
-			if(mdat==&mons[PM_QUINON]){
-				chain = TRUE;
-				tontype = TRUE;
-				child = (struct permonst **) malloc(sizeof(struct permonst)*5);
-				growto = (struct permonst **) malloc(sizeof(struct permonst)*5);
-				child[0]=&mons[PM_QUATON];
-				growto[0]=&mons[PM_QUINON];
-				child[1]=&mons[PM_TRITON];
-				growto[1]=&mons[PM_QUATON];
-				child[2]=&mons[PM_DUTON];
-				growto[2]=&mons[PM_TRITON];
-				child[3]=&mons[PM_MONOTON];
-				growto[3]=&mons[PM_DUTON];
-				child[4]=0;
-				growto[4]=0;
-			}
-			else if(mdat==&mons[PM_QUATON]){
-				chain = TRUE;
-				tontype = TRUE;
-				child = (struct permonst **) malloc(sizeof(struct permonst)*4);
-				growto = (struct permonst **) malloc(sizeof(struct permonst)*4);
-				child[0]=&mons[PM_TRITON];
-				growto[0]=&mons[PM_QUATON];
-				child[1]=&mons[PM_DUTON];
-				growto[1]=&mons[PM_TRITON];
-				child[2]=&mons[PM_MONOTON];
-				growto[2]=&mons[PM_DUTON];
-				child[3]=0;
-				growto[3]=0;
-			}
-			else if(mdat==&mons[PM_TRITON]){
-				chain = TRUE;
-				tontype = TRUE;
-				child = (struct permonst **) malloc(sizeof(struct permonst)*3);
-				growto = (struct permonst **) malloc(sizeof(struct permonst)*3);
-				child[0]=&mons[PM_DUTON];
-				growto[0]=&mons[PM_TRITON];
-				child[1]=&mons[PM_MONOTON];
-				growto[1]=&mons[PM_DUTON];
-				child[2]=0;
-				growto[2]=0;
-			}
-			else if(mdat==&mons[PM_DUTON]){
-				chain = TRUE;
-				tontype = TRUE;
-				child = (struct permonst **) malloc(sizeof(struct permonst)*2);
-				growto = (struct permonst **) malloc(sizeof(struct permonst)*2);
-				child[0]=&mons[PM_MONOTON];
-				growto[0]=&mons[PM_DUTON];
-				child[1]=0;
-				growto[1]=0;
-			}
-			else if(mdat==&mons[PM_MONOTON]){
-				child = (struct permonst **) malloc(sizeof(struct permonst)*1);
-				growto = (struct permonst **) malloc(sizeof(struct permonst)*1);
-				child[0]=0;
-				growto[0]=0;
+			struct monst * axus = (struct monst *)0;
+			boolean found;
+			int current_ton;
+			/* ASSUMES AUTONS ARE IN ORDER FROM MONOTON TO QUINON */
+			for (current_ton = mon->mtyp; current_ton >= PM_MONOTON; current_ton--) {
+				found = FALSE; //haven't found this child yet - 1 per level
+				/* search for child */
 				for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
-					if(DEADMONSTER(mtmp))
+					if (DEADMONSTER(mtmp))
 						continue;
-					mdat1 = mtmp->data;
-					if(mdat1==&mons[PM_AXUS]){
-						mtmp = makemon(&mons[PM_MONOTON], mtmp->mx, mtmp->my,MM_ADJACENTOK|MM_ANGRY|MM_NOCOUNTBIRTH);
-						if(mtmp) mtmp->mclone = 1;
-						break; //break special for loop
-					}
-				}
-			}
-			for (i=0; child[i] && growto[i]; i++){
-				for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
-					found = FALSE; //haven't found the child yet.
-//				    mtmp2 = mtmp->nmon;
-					mdat1 = mtmp->data;
-					if(!DEADMONSTER(mtmp) && mdat1==child[i]){
-						set_mon_data(mtmp, growto[i], 0);
+					if (mtmp->mtyp == current_ton-1) {
+						set_mon_data(mtmp, current_ton, 0);
 						//Assumes Auton
 						mtmp->m_lev += 1;
 						mtmp->mhp += 4;
 						mtmp->mhpmax += 4;
-						
 						newsym(mtmp->mx, mtmp->my);
-						found=TRUE;
-						if(child[i] == &mons[PM_MONOTON]){
-							for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
-								if(DEADMONSTER(mtmp))
-									continue;
-								mdat1 = mtmp->data;
-								if(mdat1==&mons[PM_AXUS]){
-									mtmp = makemon(child[i], mtmp->mx, mtmp->my,MM_ADJACENTOK|MM_ANGRY);
-									if(mtmp) mtmp->mclone = 1;
-									break; //break special for loop
-								}
-							}
-						}
-						break;//exit inner for loop
+						found = TRUE;
 					}
+					if (!axus && mtmp->mtyp == PM_AXUS)
+						axus = mtmp;
 				}
-				if(!found && tontype){
-					for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
-						if(DEADMONSTER(mtmp))
-							continue;
-						mdat1 = mtmp->data;
-						if(mdat1==&mons[PM_AXUS]){
-							chain = FALSE;
-							mtmp = makemon(growto[i], mtmp->mx, mtmp->my,MM_ADJACENTOK|MM_ANGRY);
-							if(mtmp) mtmp->mclone = 1;
-//							makemon(&mons[PM_MONOTON], mtmp->mx, mtmp->my,MM_ADJACENTOK|MM_ANGRY);
-							break; //break special for loop
-						}
-					}
+				/* if Axus is on the level, generate a 'ton beside him */
+				/* monoton if we found someone to grow */
+				/* the full 'ton if we didn't find one */
+				if (axus && (!found || current_ton == PM_MONOTON)) {
+					mtmp = makemon(&mons[current_ton], mtmp->mx, mtmp->my, MM_ADJACENTOK | MM_ANGRY);
+					if (mtmp) mtmp->mclone = 1;
 				}
-				if(!found && chain) break;//exit outer loop if child[i] not found
-											//AND the growth is chained.
+				/* growth is chained -- if we didn't find a child (and Axus didn't provide one), we don't touch the lower 'tons. */
+				if (!axus && !found)
+					break;
 			}
-			free(growto);
-			free(child);
 		}//end AD_GROW basic
 		else if(mdat->mattk[i].adtyp == AD_SOUL){
 			struct monst *mtmp;
@@ -6522,7 +6434,7 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
 		if (!mtmp->mhpmax) mtmp->mhpmax = 1;
 	} //else just take on new form I think....
 	/* take on the new form... */
-	set_mon_data(mtmp, mdat, 0);
+	set_mon_data(mtmp, mtyp, 0);
 
 	if (emits_light(olddata) != emits_light_mon(mtmp)
 		|| olddata == &mons[PM_MASKED_QUEEN]

--- a/src/mon.c
+++ b/src/mon.c
@@ -6630,41 +6630,41 @@ boolean msg;		/* "The oldmon turns into a newmon!" */
  * NON_PM if the given monster can't be hatched.
  */
 int
-can_be_hatched(mnum)
-int mnum;
+can_be_hatched(mtyp)
+int mtyp;
 {
     /* ranger quest nemesis has the oviparous bit set, making it
        be possible to wish for eggs of that unique monster; turn
        such into ordinary eggs rather than forbidding them outright */
-    if (mnum == PM_SCORPIUS) mnum = PM_SCORPION;
-	else if(mnum == PM_ANCIENT_NAGA) mnum = rn2(PM_GUARDIAN_NAGA_HATCHLING - PM_RED_NAGA_HATCHLING + 1) + PM_RED_NAGA_HATCHLING;
-	else if(mnum == PM_SERPENT_MAN_OF_YOTH) mnum = rn2(PM_COBRA - PM_GARTER_SNAKE + 1) + PM_GARTER_SNAKE;
-	else if(mnum == PM_HUNTING_HORROR) mnum = PM_BABY_LONG_WORM;
-	else if(mnum == PM_SMAUG) mnum = PM_BABY_RED_DRAGON;
+    if (mtyp == PM_SCORPIUS) mtyp = PM_SCORPION;
+	else if(mtyp == PM_ANCIENT_NAGA) mtyp = rn2(PM_GUARDIAN_NAGA_HATCHLING - PM_RED_NAGA_HATCHLING + 1) + PM_RED_NAGA_HATCHLING;
+	else if(mtyp == PM_SERPENT_MAN_OF_YOTH) mtyp = rn2(PM_COBRA - PM_GARTER_SNAKE + 1) + PM_GARTER_SNAKE;
+	else if(mtyp == PM_HUNTING_HORROR) mtyp = PM_BABY_LONG_WORM;
+	else if(mtyp == PM_SMAUG) mtyp = PM_BABY_RED_DRAGON;
 	
-    mnum = little_to_big(mnum, (boolean)rn2(2));
+    mtyp = little_to_big(mtyp, (boolean)rn2(2));
     /*
      * Queen bees lay killer bee eggs (usually), but killer bees don't
      * grow into queen bees.  Ditto for [winged-]gargoyles.
      */
-    if (mnum == PM_KILLER_BEE || mnum == PM_GARGOYLE ||
-	    (lays_eggs(&mons[mnum]) && (BREEDER_EGG ||
-		(mnum != PM_QUEEN_BEE && mnum != PM_WINGED_GARGOYLE))))
-	return mnum;
+    if (mtyp == PM_KILLER_BEE || mtyp == PM_GARGOYLE ||
+	    (lays_eggs(&mons[mtyp]) && (BREEDER_EGG ||
+		(mtyp != PM_QUEEN_BEE && mtyp != PM_WINGED_GARGOYLE))))
+	return mtyp;
     return NON_PM;
 }
 
 /* type of egg laid by #sit; usually matches parent */
 int
-egg_type_from_parent(mnum, force_ordinary)
-int mnum;	/* parent monster; caller must handle lays_eggs() check */
+egg_type_from_parent(mtyp, force_ordinary)
+int mtyp;	/* parent monster; caller must handle lays_eggs() check */
 boolean force_ordinary;
 {
     if (force_ordinary || !BREEDER_EGG) {
-	if (mnum == PM_QUEEN_BEE) mnum = PM_KILLER_BEE;
-	else if (mnum == PM_WINGED_GARGOYLE) mnum = PM_GARGOYLE;
+	if (mtyp == PM_QUEEN_BEE) mtyp = PM_KILLER_BEE;
+	else if (mtyp == PM_WINGED_GARGOYLE) mtyp = PM_GARGOYLE;
     }
-    return mnum;
+    return mtyp;
 }
 
 /* decide whether an egg of the indicated monster type is viable; */

--- a/src/mon.c
+++ b/src/mon.c
@@ -4011,7 +4011,7 @@ struct monst *mtmp;
 				pline("%s tears off the right half of %s face before rising through the ceiling!", nyar_name[nyar_form], s_suffix(Monnam(mtmp)));
 				change_usanity(u_sanity_loss_nyar());
 			}
-			mtmp->data = &mons[PM_GHOUL_QUEEN_NITOCRIS];
+			set_mon_data(mtmp, &mons[PM_GHOUL_QUEEN_NITOCRIS], 0);
 			//Surprisingly, this is an effective means of life saving!
 			break;
 		}

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -24,17 +24,11 @@ id_permonst()
 
 /*
  * safely sets mon->data
- * 
- * flag:
- *  -1 - do nothing except set mon->data -- will not update intrinsics at all
- *   0 - replace current data, intrinsics
- *   1 - replace mtyp, add new intrinsics, but don't remove old intrinsics
  */
 void
-set_mon_data(mon, mtyp, flag)
+set_mon_data(mon, mtyp)
 struct monst *mon;
 int mtyp;
-int flag;
 {
 	int i;
 	struct permonst * ptr;
@@ -48,67 +42,59 @@ int flag;
 	}
 
 	mon->mtyp = mtyp;
-    if (flag == -1) return;		/* "don't care" */
 
 	/* resistances */
-    if (flag == 1)
-		mon->mintrinsics[0] |= (ptr->mresists & MR_MASK);
-    else
-		mon->mintrinsics[0] = (ptr->mresists & MR_MASK);
-	if(is_half_dragon(ptr) && (mon->mvar_hdBreath == 0 || flag != 1)){
+	mon->mintrinsics[0] = (ptr->mresists & MR_MASK);
+	if(is_half_dragon(ptr)){
 		/*
 			Store half dragon breath type in mvar_hdBreath
 		*/
 		if(is_half_dragon(ptr)){
-			switch(rnd(6)){
-				case 1:
-					mon->mvar_hdBreath = AD_COLD;
+			static const int half_dragon_types[] = { AD_COLD, AD_FIRE, AD_SLEE, AD_ELEC, AD_DRST, AD_ACID };
+			if (!mon->mvar_hdBreath)
+				mon->mvar_hdBreath = half_dragon_types[rn2(6)];
+			switch (mon->mvar_hdBreath){
+				case AD_COLD:
 					mon->mintrinsics[(COLD_RES-1)/32] |= (1 << (COLD_RES-1)%32);
 				break;
-				case 2:
-					mon->mvar_hdBreath = AD_FIRE;
+				case AD_FIRE:
 					mon->mintrinsics[(FIRE_RES-1)/32] |= (1 << (FIRE_RES-1)%32);
 				break;
-				case 3:
-					mon->mvar_hdBreath = AD_SLEE;
+				case AD_SLEE:
 					mon->mintrinsics[(SLEEP_RES-1)/32] |= (1 << (SLEEP_RES-1)%32);
 				break;
-				case 4:
-					mon->mvar_hdBreath = AD_ELEC;
+				case AD_ELEC:
 					mon->mintrinsics[(SHOCK_RES-1)/32] |= (1 << (SHOCK_RES-1)%32);
 				break;
-				case 5:
-					mon->mvar_hdBreath = AD_DRST;
+				case AD_DRST:
 					mon->mintrinsics[(POISON_RES-1)/32] |= (1 << (POISON_RES-1)%32);
 				break;
-				case 6:
-					mon->mvar_hdBreath = AD_ACID;
+				case AD_ACID:
 					mon->mintrinsics[(ACID_RES-1)/32] |= (1 << (ACID_RES-1)%32);
 				break;
 			}
 		} else if(is_boreal_dragoon(ptr)){
-			switch(rnd(4)){
-				case 1:
-					mon->mvar_hdBreath = AD_COLD;
+			static const int boreal_dragon_types[] = { AD_COLD, AD_FIRE, AD_MAGM, AD_PHYS };
+			if (!mon->mvar_hdBreath)
+				mon->mvar_hdBreath = boreal_dragon_types[rn2(4)];
+			switch (mon->mvar_hdBreath){
+				case AD_COLD:
 					mon->mintrinsics[(COLD_RES-1)/32] |= (1 << (COLD_RES-1)%32);
 				break;
-				case 2:
-					mon->mvar_hdBreath = AD_FIRE;
+				case AD_FIRE:
 					mon->mintrinsics[(FIRE_RES-1)/32] |= (1 << (FIRE_RES-1)%32);
 				break;
-				case 3:
-					mon->mvar_hdBreath = AD_MAGM;
+				case AD_MAGM:
 					mon->mintrinsics[(ANTIMAGIC-1)/32] |= (1 << (ANTIMAGIC-1)%32);
 				break;
-				case 4:
-					mon->mvar_hdBreath = AD_PHYS;
+				case AD_PHYS:
 				break;
 			}
 		}
 	}
 #define set_mintrinsic(ptr_condition, intrinsic) \
-	if ((ptr_condition)) { mon->mintrinsics[((intrinsic)-1)/32] |=  (1L<<((intrinsic)-1)%32); } \
-	else if (flag != 1)  { mon->mintrinsics[((intrinsic)-1)/32] &= ~(1L<<((intrinsic)-1)%32); }
+	if ((ptr_condition))	{ mon->mintrinsics[((intrinsic)-1)/32] |=  (1L<<((intrinsic)-1)%32); } \
+	else					{ mon->mintrinsics[((intrinsic)-1)/32] &= ~(1L<<((intrinsic)-1)%32); }
 
 	/* other intrinsics */
 	set_mintrinsic(species_flies(mon->data), FLYING);
@@ -131,7 +117,7 @@ struct monst * mtmp;
 int faction;
 {
 	mtmp->mfaction = faction;
-	set_mon_data(mtmp, mtmp->mtyp, 0);
+	set_mon_data(mtmp, mtmp->mtyp);
 	return;
 }
 

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -10,6 +10,16 @@
 
 #ifdef OVLB
 
+/* saves the index number of each part of the permonst array to itself */
+void
+id_permonst()
+{
+	int i;
+	for (i = 0; i < NUMMONS; i++);
+		mons[i].mtyp = i;
+	return;
+}
+
 /*
  * safely sets mon->data
  * 
@@ -25,7 +35,7 @@ int mtyp;
 int flag;
 {
 	int i;
-	struct permonst * ptr = &mons[mtyp];
+	struct permonst * ptr = &mons[mtyp]; /* this will be changed to a new system, mwahahaa! */
 	mon->data = ptr;
 
 	/* players in their base form are a special case */
@@ -170,7 +180,7 @@ boolean
 poly_when_stoned(ptr)
     struct permonst *ptr;
 {
-    return((boolean)(is_golem(ptr) && ptr != &mons[PM_STONE_GOLEM] && ptr != &mons[PM_SENTINEL_OF_MITHARDIR] &&
+    return((boolean)(is_golem(ptr) && ptr->mtyp != PM_STONE_GOLEM && ptr->mtyp != PM_SENTINEL_OF_MITHARDIR &&
 	    !(mvitals[PM_STONE_GOLEM].mvflags & G_GENOD && !In_quest(&u.uz))));
 	    /* allow G_EXTINCT */
 }
@@ -179,7 +189,7 @@ boolean
 poly_when_golded(ptr)
     struct permonst *ptr;
 {
-    return((boolean)(is_golem(ptr) && ptr != &mons[PM_GOLD_GOLEM] &&
+    return((boolean)(is_golem(ptr) && ptr->mtyp != PM_GOLD_GOLEM &&
 	    !(mvitals[PM_GOLD_GOLEM].mvflags & G_GENOD && !In_quest(&u.uz))));
 	    /* allow G_EXTINCT */
 }
@@ -308,7 +318,7 @@ struct monst *mon;
 
 	return (boolean)(is_undead_mon(mon) || is_demon(ptr) || is_were(ptr) ||
 			 mon->mfaction == TOMB_HERD || species_resists_drain(mon) || 
-			 ptr == &mons[PM_DEATH] ||
+			 ptr->mtyp == PM_DEATH ||
 			 mon_resistance(mon, DRAIN_RES) ||
 			 (mon == u.usteed && u.sealsActive&SEAL_BERITH && Drain_resistance));
 }
@@ -497,7 +507,7 @@ struct monst *mon;
 
     return (boolean) (mon_resistance(mon,PASSES_WALLS) || amorphous(mptr) ||
 		      is_whirly(mptr) || verysmall(mptr) ||
-			  dmgtype(mptr, AD_CORR) || (dmgtype(mptr, AD_RUST) && mptr != &mons[PM_NAIAD] ) ||
+			  dmgtype(mptr, AD_CORR) || (dmgtype(mptr, AD_RUST) && mptr->mtyp != PM_NAIAD ) ||
 		      (slithy(mptr) && !bigmonst(mptr)));
 }
 
@@ -796,7 +806,7 @@ struct monst *mtmp;
 	/* stalking types follow, but won't when fleeing unless you hold
 	   the Amulet */
 	return (boolean)(((mtmp->data->mflagst & MT_STALK) || is_derived_undead_mon(mtmp)) &&
-				(!mtmp->mflee || mtmp->data == &mons[PM_BANDERSNATCH] || u.uhave.amulet));
+				(!mtmp->mflee || mtmp->mtyp == PM_BANDERSNATCH || u.uhave.amulet));
 }
 
 static const short grownups[][2] = {

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -303,6 +303,7 @@ int faction;
 		break;
 	}
 	/* adjust attacks in the permonst */
+	extern struct attack noattack;
 	boolean special = FALSE;
 	struct attack * attk;
 	boolean insert;
@@ -336,7 +337,6 @@ int faction;
 			)
 		{
 			/* shift all further attacks forwards one slot, and make last one all 0s */
-			extern struct attack noattack;
 			for (j = 0; j < (NATTK - i); j++)
 				attk[j] = attk[j+1];
 			attk[j] = noattack;
@@ -344,7 +344,7 @@ int faction;
 
 		/* some factions want to adjust existing attacks, or add additional attacks */
 #define insert_okay (!special && (is_null_attk(attk) || (attk->aatyp > AT_HUGS && !weapon_aatyp(attk->aatyp))) && (insert = TRUE))
-#define maybe_insert() if(insert) {for(j=NATTK-i-1;j>0;j--)attk[j]=attk[j-1];}
+#define maybe_insert() if(insert) {for(j=NATTK-i-1;j>0;j--)attk[j]=attk[j-1];*attk=noattack;}
 		/* skeletons get a paralyzing touch */
 		if (faction == SKELIFIED && (
 			insert_okay

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -344,7 +344,7 @@ int faction;
 
 		/* some factions want to adjust existing attacks, or add additional attacks */
 #define insert_okay (!special && (is_null_attk(attk) || (attk->aatyp > AT_HUGS && !weapon_aatyp(attk->aatyp))) && (insert = TRUE))
-#define maybe_insert() if(insert) {for(j=0;j<NATTK-i;j++)attk[j+1]=attk[j];}
+#define maybe_insert() if(insert) {for(j=NATTK-i-1;j>0;j--)attk[j]=attk[j-1];}
 		/* skeletons get a paralyzing touch */
 		if (faction == SKELIFIED && (
 			insert_okay

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -10,6 +10,14 @@
 
 #ifdef OVLB
 
+/*
+ * safely sets mon->data
+ * 
+ * flag:
+ *  -1 - do nothing except set mon->data -- will not update intrinsics at all
+ *   0 - replace current data, intrinsics
+ *   1 - replace mtyp, add new intrinsics, but don't remove old intrinsics
+ */
 void
 set_mon_data(mon, ptr, flag)
 struct monst *mon;
@@ -18,6 +26,7 @@ int flag;
 {
 	int i;
     mon->data = ptr;
+	mon->mtyp = ptr - mons;
     if (flag == -1) return;		/* "don't care" */
 
 	/* resistances */

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -19,14 +19,20 @@
  *   1 - replace mtyp, add new intrinsics, but don't remove old intrinsics
  */
 void
-set_mon_data(mon, ptr, flag)
+set_mon_data(mon, mtyp, flag)
 struct monst *mon;
-struct permonst *ptr;
+int mtyp;
 int flag;
 {
 	int i;
-    mon->data = ptr;
-	mon->mtyp = ptr - mons;
+	struct permonst * ptr = &mons[mtyp];
+	mon->data = ptr;
+
+	/* players in their base form are a special case */
+	if (mon == &youmonst && (mtyp == u.umonster))
+		mon->data = ptr = &upermonst;
+
+	mon->mtyp = mtyp;
     if (flag == -1) return;		/* "don't care" */
 
 	/* resistances */

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -154,9 +154,9 @@ struct monst *mtmp;
 				 || (alignedfearobj && !touch_artifact(alignedfearobj, mtmp, FALSE))
 				 ) && scaryItem(mtmp)
 				)
-			 || (u.umonnum == PM_GHOUL && x == mtmp->mux && y == mtmp->muy && mtmp->data == &mons[PM_GUG])
-			 || (mat && mat->data == &mons[PM_GHOUL] && mtmp->data == &mons[PM_GUG])
-			 || (mat && mat->data == &mons[PM_MOVANIC_DEVA] && (is_animal(mtmp->data) || is_plant(mtmp->data)))
+			 || (u.umonnum == PM_GHOUL && x == mtmp->mux && y == mtmp->muy && mtmp->mtyp == PM_GUG)
+			 || (mat && mat->mtyp == PM_GHOUL && mtmp->mtyp == PM_GUG)
+			 || (mat && mat->mtyp == PM_MOVANIC_DEVA && (is_animal(mtmp->data) || is_plant(mtmp->data)))
 			 || (wardAt == HEPTAGRAM && scaryHept(num_wards_at(x,y), mtmp))
 			 || (wardAt == GORGONEION && scaryGorg(num_wards_at(x,y), mtmp))
 			 || (wardAt == CIRCLE_OF_ACHERON && scaryCircle(num_wards_at(x,y), mtmp))
@@ -192,8 +192,8 @@ struct monst *mtmp;
 			mtmp->data->mlet == S_NAGA ||
 			mtmp->data->mlet == S_SNAKE ||
 			mtmp->data->mlet == S_LIZARD ||
-			mtmp->data == &mons[PM_TOVE] ||
-			mtmp->data == &mons[PM_KRAKEN];
+			mtmp->mtyp == PM_TOVE ||
+			mtmp->mtyp == PM_KRAKEN;
 }
 
 boolean
@@ -221,7 +221,7 @@ struct monst *mtmp;
 			mtmp->data->mlet == S_SPIDER ||
 			mtmp->data->mlet == S_EEL ||
 			mtmp->data->mlet == S_LIZARD ||
-			mtmp->data == &mons[PM_TOVE];
+			mtmp->mtyp == PM_TOVE;
 }
 
 boolean
@@ -285,19 +285,19 @@ struct monst *mtmp;
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->iswiz || 
 			is_rider(mtmp->data) ||
-			(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH]) ||
-			(mtmp->data == &mons[PM_ELDER_PRIEST]) ||
-			(mtmp->data == &mons[PM_GREAT_CTHULHU]) ||
-			(mtmp->data == &mons[PM_CHAOS] && rn2(2)) ||
-			(mtmp->data == &mons[PM_DEMOGORGON] && rn2(3)) ||
-			(mtmp->data == &mons[PM_LAMASHTU] && rn2(3)) ||
-			(mtmp->data == &mons[PM_ASMODEUS] && rn2(9))
+			(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH) ||
+			(mtmp->mtyp == PM_ELDER_PRIEST) ||
+			(mtmp->mtyp == PM_GREAT_CTHULHU) ||
+			(mtmp->mtyp == PM_CHAOS && rn2(2)) ||
+			(mtmp->mtyp == PM_DEMOGORGON && rn2(3)) ||
+			(mtmp->mtyp == PM_LAMASHTU && rn2(3)) ||
+			(mtmp->mtyp == PM_ASMODEUS && rn2(9))
 		) return FALSE;
-	return 	mtmp->data == &mons[PM_FREEZING_SPHERE] ||
-			mtmp->data == &mons[PM_FLAMING_SPHERE] ||
-			mtmp->data == &mons[PM_SHOCKING_SPHERE] ||
+	return 	mtmp->mtyp == PM_FREEZING_SPHERE ||
+			mtmp->mtyp == PM_FLAMING_SPHERE ||
+			mtmp->mtyp == PM_SHOCKING_SPHERE ||
 			mtmp->data->mlet == S_FUNGUS ||
-			mtmp->data == &mons[PM_ZUGGTMOY] ||
+			mtmp->mtyp == PM_ZUGGTMOY ||
 			mtmp->data->mlet == S_VORTEX ||
 			mtmp->data->mlet == S_ELEMENTAL ||
 			mtmp->data->mlet == S_XORN ||
@@ -306,8 +306,8 @@ struct monst *mtmp;
 			(mtmp->data->mlet == S_NAGA && complete >= 4) ||
 			(is_undead_mon(mtmp) && complete >= 4) ||
 			(mtmp->data->mlet == S_TRAPPER && complete >= 4  && /*This one means "is a metroid", which are being counted as energions for this*/
-				mtmp->data != &mons[PM_TRAPPER] &&
-				mtmp->data != &mons[PM_LURKER_ABOVE]) ||
+				mtmp->mtyp != PM_TRAPPER &&
+				mtmp->mtyp != PM_LURKER_ABOVE) ||
 			(is_angel(mtmp->data) && complete == 7) ||
 			(is_keter(mtmp->data) && complete == 7) ||
 			(is_demon(mtmp->data) && complete == 7) ||
@@ -338,50 +338,50 @@ struct monst *mtmp;
 			mtmp->mfaction == CRANIUM_RAT ||
 			mtmp->mfaction == MISTWEAVER ||
 			mtmp->mfaction == FRACTURED ||
-			mtmp->data == &mons[PM_GUG] ||
-			mtmp->data == &mons[PM_MIGO_WORKER] ||
-			mtmp->data == &mons[PM_MIGO_SOLDIER] ||
-			mtmp->data == &mons[PM_MIGO_PHILOSOPHER] ||
-			mtmp->data == &mons[PM_MIGO_QUEEN] ||
-			mtmp->data == &mons[PM_HOUND_OF_TINDALOS] ||
-			mtmp->data == &mons[PM_TRAPPER] ||
-			mtmp->data == &mons[PM_LURKER_ABOVE] ||
-			mtmp->data == &mons[PM_NIGHTGAUNT] ||
-			mtmp->data == &mons[PM_BYAKHEE] ||
-			(mtmp->data == &mons[PM_HUNTING_HORROR] && complete == 6) ||
-			mtmp->data == &mons[PM_MIND_FLAYER] ||
-			mtmp->data == &mons[PM_PARASITIC_MIND_FLAYER] ||
-			mtmp->data == &mons[PM_PARASITIZED_ANDROID] ||
-			mtmp->data == &mons[PM_PARASITIZED_GYNOID] ||
-			(mtmp->data == &mons[PM_PARASITIC_MASTER_MIND_FLAYER] && complete == 6) ||
-			(mtmp->data == &mons[PM_PARASITIZED_EMBRACED_ALIDER] && complete == 6) ||
-			(mtmp->data == &mons[PM_MASTER_MIND_FLAYER] && complete == 6) ||
-			mtmp->data == &mons[PM_DEEP_ONE] ||
-			mtmp->data == &mons[PM_DEEPER_ONE] ||
-			(mtmp->data == &mons[PM_DEEPEST_ONE] && complete == 6) ||
-			mtmp->data == &mons[PM_CHANGED] ||
-			(mtmp->data == &mons[PM_WARRIOR_CHANGED] && complete == 6) ||
-			mtmp->data == &mons[PM_EDDERKOP] ||
-			mtmp->data == &mons[PM_NEVERWAS] ||
-			mtmp->data == &mons[PM_INTONER] ||
-			(mtmp->data == &mons[PM_BLACK_FLOWER] && complete == 6) ||
-			mtmp->data == &mons[PM_DARK_YOUNG] ||
-			mtmp->data == &mons[PM_WEEPING_ANGEL] ||
-			mtmp->data == &mons[PM_ANCIENT_OF_ICE] ||
-			(mtmp->data == &mons[PM_ANCIENT_OF_DEATH] && complete == 6) ||
-			(mtmp->data == &mons[PM_JUIBLEX] && complete == 6) ||
-			(mtmp->data == &mons[PM_MASKED_QUEEN] && complete == 6) ||
-			(mtmp->data == &mons[PM_PALE_NIGHT] && complete == 6) ||
-			(mtmp->data == &mons[PM_LEVIATHAN] && complete == 6) ||
-			(mtmp->data == &mons[PM_BAALPHEGOR] && complete == 6) ||
-			(mtmp->data == &mons[PM_VERIER] && complete == 6) ||
-			(mtmp->data == &mons[PM_DAGON] && complete == 6) ||
-			(mtmp->data == &mons[PM_DEMOGORGON] && complete == 6 && !rn2(3)) ||
-			(mtmp->data == &mons[PM_GREAT_CTHULHU] && complete == 6) ||
-			(mtmp->data == &mons[PM_LUGRIBOSSK] && complete == 6) ||
-			(mtmp->data == &mons[PM_MAANZECORIAN] && complete == 6) ||
-			(mtmp->data == &mons[PM_ELDER_PRIEST] && complete == 6) ||
-			(mtmp->data == &mons[PM_PRIEST_OF_AN_UNKNOWN_GOD] && complete == 6);
+			mtmp->mtyp == PM_GUG ||
+			mtmp->mtyp == PM_MIGO_WORKER ||
+			mtmp->mtyp == PM_MIGO_SOLDIER ||
+			mtmp->mtyp == PM_MIGO_PHILOSOPHER ||
+			mtmp->mtyp == PM_MIGO_QUEEN ||
+			mtmp->mtyp == PM_HOUND_OF_TINDALOS ||
+			mtmp->mtyp == PM_TRAPPER ||
+			mtmp->mtyp == PM_LURKER_ABOVE ||
+			mtmp->mtyp == PM_NIGHTGAUNT ||
+			mtmp->mtyp == PM_BYAKHEE ||
+			(mtmp->mtyp == PM_HUNTING_HORROR && complete == 6) ||
+			mtmp->mtyp == PM_MIND_FLAYER ||
+			mtmp->mtyp == PM_PARASITIC_MIND_FLAYER ||
+			mtmp->mtyp == PM_PARASITIZED_ANDROID ||
+			mtmp->mtyp == PM_PARASITIZED_GYNOID ||
+			(mtmp->mtyp == PM_PARASITIC_MASTER_MIND_FLAYER && complete == 6) ||
+			(mtmp->mtyp == PM_PARASITIZED_EMBRACED_ALIDER && complete == 6) ||
+			(mtmp->mtyp == PM_MASTER_MIND_FLAYER && complete == 6) ||
+			mtmp->mtyp == PM_DEEP_ONE ||
+			mtmp->mtyp == PM_DEEPER_ONE ||
+			(mtmp->mtyp == PM_DEEPEST_ONE && complete == 6) ||
+			mtmp->mtyp == PM_CHANGED ||
+			(mtmp->mtyp == PM_WARRIOR_CHANGED && complete == 6) ||
+			mtmp->mtyp == PM_EDDERKOP ||
+			mtmp->mtyp == PM_NEVERWAS ||
+			mtmp->mtyp == PM_INTONER ||
+			(mtmp->mtyp == PM_BLACK_FLOWER && complete == 6) ||
+			mtmp->mtyp == PM_DARK_YOUNG ||
+			mtmp->mtyp == PM_WEEPING_ANGEL ||
+			mtmp->mtyp == PM_ANCIENT_OF_ICE ||
+			(mtmp->mtyp == PM_ANCIENT_OF_DEATH && complete == 6) ||
+			(mtmp->mtyp == PM_JUIBLEX && complete == 6) ||
+			(mtmp->mtyp == PM_MASKED_QUEEN && complete == 6) ||
+			(mtmp->mtyp == PM_PALE_NIGHT && complete == 6) ||
+			(mtmp->mtyp == PM_LEVIATHAN && complete == 6) ||
+			(mtmp->mtyp == PM_BAALPHEGOR && complete == 6) ||
+			(mtmp->mtyp == PM_VERIER && complete == 6) ||
+			(mtmp->mtyp == PM_DAGON && complete == 6) ||
+			(mtmp->mtyp == PM_DEMOGORGON && complete == 6 && !rn2(3)) ||
+			(mtmp->mtyp == PM_GREAT_CTHULHU && complete == 6) ||
+			(mtmp->mtyp == PM_LUGRIBOSSK && complete == 6) ||
+			(mtmp->mtyp == PM_MAANZECORIAN && complete == 6) ||
+			(mtmp->mtyp == PM_ELDER_PRIEST && complete == 6) ||
+			(mtmp->mtyp == PM_PRIEST_OF_AN_UNKNOWN_GOD && complete == 6);
 }
 boolean
 scaryHam(complete, mtmp)
@@ -392,8 +392,8 @@ struct monst *mtmp;
 	else if(mtmp->isshk || mtmp->iswiz || 
 			is_rider(mtmp->data)) return FALSE;
 	return 	is_auton(mtmp->data) ||
-			mtmp->data == &mons[PM_FLOATING_EYE] || 
-			mtmp->data == &mons[PM_BEHOLDER];
+			mtmp->mtyp == PM_FLOATING_EYE || 
+			mtmp->mtyp == PM_BEHOLDER;
 
 }
 boolean
@@ -404,19 +404,19 @@ struct monst *mtmp;
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->iswiz || mtmp->mpeaceful || 
 			is_rider(mtmp->data) ||
-			(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH]) ||
-			(mtmp->data == &mons[PM_ELDER_PRIEST]) ||
-			(mtmp->data == &mons[PM_GREAT_CTHULHU]) ||
-			(mtmp->data == &mons[PM_CHAOS] && rn2(2)) ||
-			(mtmp->data == &mons[PM_DEMOGORGON] && rn2(3)) ||
-			(mtmp->data == &mons[PM_LAMASHTU] && rn2(3)) ||
-			(mtmp->data == &mons[PM_ASMODEUS] && complete <= d(1,8))
+			(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH) ||
+			(mtmp->mtyp == PM_ELDER_PRIEST) ||
+			(mtmp->mtyp == PM_GREAT_CTHULHU) ||
+			(mtmp->mtyp == PM_CHAOS && rn2(2)) ||
+			(mtmp->mtyp == PM_DEMOGORGON && rn2(3)) ||
+			(mtmp->mtyp == PM_LAMASHTU && rn2(3)) ||
+			(mtmp->mtyp == PM_ASMODEUS && complete <= d(1,8))
 		) return FALSE;
 	return 	(is_minion(mtmp->data) ||
-			mtmp->data == &mons[PM_HELL_HOUND] || 
-			mtmp->data == &mons[PM_HELL_HOUND_PUP] ||
-			mtmp->data == &mons[PM_EYE_OF_DOOM] ||
-			mtmp->data == &mons[PM_SON_OF_TYPHON] ||
+			mtmp->mtyp == PM_HELL_HOUND || 
+			mtmp->mtyp == PM_HELL_HOUND_PUP ||
+			mtmp->mtyp == PM_EYE_OF_DOOM ||
+			mtmp->mtyp == PM_SON_OF_TYPHON ||
 			is_golem(mtmp->data) ||
 			is_angel(mtmp->data) ||
 			is_keter(mtmp->data) ||
@@ -433,22 +433,22 @@ struct monst *mtmp;
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->iswiz || 
 			is_rider(mtmp->data) ||
-			(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH]) ||
-			(mtmp->data == &mons[PM_ELDER_PRIEST]) ||
-			(mtmp->data == &mons[PM_GREAT_CTHULHU]) ||
-			(mtmp->data == &mons[PM_CHAOS] && rn2(2)) ||
-			(mtmp->data == &mons[PM_DEMOGORGON] && rn2(3)) ||
-			(mtmp->data == &mons[PM_LAMASHTU] && rn2(3)) ||
-			(mtmp->data == &mons[PM_ASMODEUS] && !rn2(9))
+			(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH) ||
+			(mtmp->mtyp == PM_ELDER_PRIEST) ||
+			(mtmp->mtyp == PM_GREAT_CTHULHU) ||
+			(mtmp->mtyp == PM_CHAOS && rn2(2)) ||
+			(mtmp->mtyp == PM_DEMOGORGON && rn2(3)) ||
+			(mtmp->mtyp == PM_LAMASHTU && rn2(3)) ||
+			(mtmp->mtyp == PM_ASMODEUS && !rn2(9))
 		) return FALSE;
 	return 	(is_demon(mtmp->data) || 
-			mtmp->data == &mons[PM_HELL_HOUND] ||
-			mtmp->data == &mons[PM_HELL_HOUND_PUP] ||
-			mtmp->data == &mons[PM_GARGOYLE] || 
-			mtmp->data == &mons[PM_WINGED_GARGOYLE] ||
-			mtmp->data == &mons[PM_DJINNI] ||
-			mtmp->data == &mons[PM_SANDESTIN] ||
-			mtmp->data == &mons[PM_SALAMANDER] ||
+			mtmp->mtyp == PM_HELL_HOUND ||
+			mtmp->mtyp == PM_HELL_HOUND_PUP ||
+			mtmp->mtyp == PM_GARGOYLE || 
+			mtmp->mtyp == PM_WINGED_GARGOYLE ||
+			mtmp->mtyp == PM_DJINNI ||
+			mtmp->mtyp == PM_SANDESTIN ||
+			mtmp->mtyp == PM_SALAMANDER ||
 			mtmp->data->mlet == S_ELEMENTAL ||
 			mtmp->data->mlet == S_IMP);
 }
@@ -460,10 +460,10 @@ struct monst *mtmp;
 {
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->iswiz || 
-			is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
-			mtmp->data == &mons[PM_MAANZECORIAN] ||
+			is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
+			mtmp->mtyp == PM_MAANZECORIAN ||
 			is_rider(mtmp->data)) return FALSE;
-	return mtmp->data == &mons[PM_CERBERUS] || is_undead_mon(mtmp);
+	return mtmp->mtyp == PM_CERBERUS || is_undead_mon(mtmp);
 }
 
 boolean
@@ -473,22 +473,22 @@ struct monst *mtmp;
 {
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->iswiz || 
-			is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
+			is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
 			is_rider(mtmp->data)) return FALSE;
 	else if(mtmp->data->mlet == S_SNAKE){
 				mtmp->mpeaceful = TRUE;
 			}
 	return d(1,100) <= 33*complete && 
 			(!is_golem(mtmp->data)) &&
-			(mtmp->data != &mons[PM_CHOKHMAH_SEPHIRAH]) &&
-			(mtmp->data != &mons[PM_ELDER_PRIEST]) &&
-			(mtmp->data != &mons[PM_GREAT_CTHULHU]) &&
-			(mtmp->data != &mons[PM_LUGRIBOSSK]) &&
-			(mtmp->data != &mons[PM_MAANZECORIAN]) &&
-			(mtmp->data != &mons[PM_CHAOS] || rn2(2)) &&
-			(mtmp->data != &mons[PM_DEMOGORGON] || !rn2(3)) &&
-			(mtmp->data != &mons[PM_LAMASHTU] || !rn2(3)) &&
-			(mtmp->data != &mons[PM_ASMODEUS] || !rn2(9));
+			(mtmp->mtyp != PM_CHOKHMAH_SEPHIRAH) &&
+			(mtmp->mtyp != PM_ELDER_PRIEST) &&
+			(mtmp->mtyp != PM_GREAT_CTHULHU) &&
+			(mtmp->mtyp != PM_LUGRIBOSSK) &&
+			(mtmp->mtyp != PM_MAANZECORIAN) &&
+			(mtmp->mtyp != PM_CHAOS || rn2(2)) &&
+			(mtmp->mtyp != PM_DEMOGORGON || !rn2(3)) &&
+			(mtmp->mtyp != PM_LAMASHTU || !rn2(3)) &&
+			(mtmp->mtyp != PM_ASMODEUS || !rn2(9));
 	
 }
 
@@ -500,15 +500,15 @@ struct monst *mtmp;
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->isgd || mtmp->iswiz || 
 			mtmp->data->mlet == S_HUMAN || mtmp->mpeaceful ||
-			is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
+			is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
 			is_rider(mtmp->data) ||
-			(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH]) ||
-			(mtmp->data == &mons[PM_ELDER_PRIEST] && complete <= d(2,4)+2) ||
-			(mtmp->data == &mons[PM_GREAT_CTHULHU] && complete <= d(2,4)+2) ||
-			(mtmp->data == &mons[PM_CHAOS] && rn2(2)) ||
-			(mtmp->data == &mons[PM_DEMOGORGON] && rn2(3)) ||
-			(mtmp->data == &mons[PM_LAMASHTU] && rn2(3)) ||
-			(mtmp->data == &mons[PM_ASMODEUS] && complete <= d(1,10))
+			(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH) ||
+			(mtmp->mtyp == PM_ELDER_PRIEST && complete <= d(2,4)+2) ||
+			(mtmp->mtyp == PM_GREAT_CTHULHU && complete <= d(2,4)+2) ||
+			(mtmp->mtyp == PM_CHAOS && rn2(2)) ||
+			(mtmp->mtyp == PM_DEMOGORGON && rn2(3)) ||
+			(mtmp->mtyp == PM_LAMASHTU && rn2(3)) ||
+			(mtmp->mtyp == PM_ASMODEUS && complete <= d(1,10))
 		) return FALSE;
 	return( !(is_human(mtmp->data) || is_elf(mtmp->data) || is_dwarf(mtmp->data) ||
 		  is_gnome(mtmp->data) || is_orc(mtmp->data)) || 
@@ -522,9 +522,9 @@ struct monst *mtmp;
 {
 	if(complete <= 0) return FALSE;
 	else if(mtmp->isshk || mtmp->isgd || mtmp->iswiz || 
-			is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
+			is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
 			is_rider(mtmp->data) ||
-			(mtmp->data == &mons[PM_ELDER_PRIEST])
+			(mtmp->mtyp == PM_ELDER_PRIEST)
 		) return FALSE;
 	if((is_human(mtmp->data) || is_elf(mtmp->data) || is_dwarf(mtmp->data) ||
 		  is_gnome(mtmp->data) || is_orc(mtmp->data)) && 
@@ -541,16 +541,16 @@ struct monst *mtmp;
 {
 	if (mtmp->isshk || mtmp->isgd || mtmp->iswiz || is_blind(mtmp) ||
 	    mtmp->mpeaceful || mtmp->data->mlet == S_HUMAN || 
-	    is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
-	    is_rider(mtmp->data) || mtmp->data == &mons[PM_MINOTAUR])
+	    is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
+	    is_rider(mtmp->data) || mtmp->mtyp == PM_MINOTAUR)
 		return(FALSE);
-	return (boolean) (mtmp->data != &mons[PM_ELDER_PRIEST]) &&
-					(mtmp->data != &mons[PM_GREAT_CTHULHU]) &&
-					(mtmp->data != &mons[PM_CHOKHMAH_SEPHIRAH]) &&
-					(mtmp->data != &mons[PM_CHAOS] || rn2(2)) &&
-					(mtmp->data != &mons[PM_DEMOGORGON] || rn2(3)) &&
-					(mtmp->data != &mons[PM_LAMASHTU] || rn2(3)) &&
-					(mtmp->data != &mons[PM_ASMODEUS]);
+	return (boolean) (mtmp->mtyp != PM_ELDER_PRIEST) &&
+					(mtmp->mtyp != PM_GREAT_CTHULHU) &&
+					(mtmp->mtyp != PM_CHOKHMAH_SEPHIRAH) &&
+					(mtmp->mtyp != PM_CHAOS || rn2(2)) &&
+					(mtmp->mtyp != PM_DEMOGORGON || rn2(3)) &&
+					(mtmp->mtyp != PM_LAMASHTU || rn2(3)) &&
+					(mtmp->mtyp != PM_ASMODEUS);
 }
 
 boolean
@@ -565,13 +565,13 @@ struct monst *mtmp;
 	    (is_rider(mtmp->data))
 	)
 		return(FALSE);
-	return (boolean) (mtmp->data != &mons[PM_ELDER_PRIEST]) &&
-					(mtmp->data != &mons[PM_GREAT_CTHULHU]) &&
-					(mtmp->data != &mons[PM_CHOKHMAH_SEPHIRAH]) &&
-					(mtmp->data != &mons[PM_CHAOS] || rn2(2)) &&
-					(mtmp->data != &mons[PM_DEMOGORGON] || !rn2(3)) &&
-					(mtmp->data != &mons[PM_LAMASHTU]) &&
-					(mtmp->data != &mons[PM_ASMODEUS] || !rn2(9));
+	return (boolean) (mtmp->mtyp != PM_ELDER_PRIEST) &&
+					(mtmp->mtyp != PM_GREAT_CTHULHU) &&
+					(mtmp->mtyp != PM_CHOKHMAH_SEPHIRAH) &&
+					(mtmp->mtyp != PM_CHAOS || rn2(2)) &&
+					(mtmp->mtyp != PM_DEMOGORGON || !rn2(3)) &&
+					(mtmp->mtyp != PM_LAMASHTU) &&
+					(mtmp->mtyp != PM_ASMODEUS || !rn2(9));
   } else return(FALSE);
 }
 
@@ -583,27 +583,27 @@ struct monst *mtmp;
   if(Race_if(PM_ELF)){
 	if (mtmp->isshk || mtmp->isgd || mtmp->iswiz || is_blind(mtmp) ||
 	    mtmp->mpeaceful || mtmp->data->mlet == S_HUMAN || 
-	    is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
-	    (is_rider(mtmp->data) && !(mtmp->data == &mons[PM_NAZGUL])) || 
-		mtmp->data == &mons[PM_MINOTAUR])
+	    is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
+	    (is_rider(mtmp->data) && !(mtmp->mtyp == PM_NAZGUL)) || 
+		mtmp->mtyp == PM_MINOTAUR)
 		return(FALSE);
-	return (boolean) (mtmp->data != &mons[PM_ELDER_PRIEST]) &&
-					(mtmp->data != &mons[PM_GREAT_CTHULHU]) &&
-					(mtmp->data != &mons[PM_CHOKHMAH_SEPHIRAH]) &&
-					(mtmp->data != &mons[PM_CHAOS] || rn2(2)) &&
-					(mtmp->data != &mons[PM_DEMOGORGON] || !rn2(3)) &&
-					(mtmp->data != &mons[PM_LAMASHTU]) &&
-					(mtmp->data != &mons[PM_ASMODEUS] || !rn2(9));
+	return (boolean) (mtmp->mtyp != PM_ELDER_PRIEST) &&
+					(mtmp->mtyp != PM_GREAT_CTHULHU) &&
+					(mtmp->mtyp != PM_CHOKHMAH_SEPHIRAH) &&
+					(mtmp->mtyp != PM_CHAOS || rn2(2)) &&
+					(mtmp->mtyp != PM_DEMOGORGON || !rn2(3)) &&
+					(mtmp->mtyp != PM_LAMASHTU) &&
+					(mtmp->mtyp != PM_ASMODEUS || !rn2(9));
   }
   else{
 	if (mtmp->isshk || mtmp->isgd || mtmp->iswiz || is_blind(mtmp) ||
 	    mtmp->mpeaceful || mtmp->data->mlet == S_HUMAN || 
-	    is_lminion(mtmp) || mtmp->data == &mons[PM_ANGEL] ||
-	    (is_rider(mtmp->data) && !(mtmp->data == &mons[PM_NAZGUL])) || 
-		mtmp->data == &mons[PM_MINOTAUR])
+	    is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
+	    (is_rider(mtmp->data) && !(mtmp->mtyp == PM_NAZGUL)) || 
+		mtmp->mtyp == PM_MINOTAUR)
 		return(FALSE);
 	return (boolean) mtmp->data->mlet == S_ORC || mtmp->data->mlet == S_OGRE 
-				|| mtmp->data->mlet == S_TROLL || mtmp->data == &mons[PM_NAZGUL];
+				|| mtmp->data->mlet == S_TROLL || mtmp->mtyp == PM_NAZGUL;
   }
 	
 
@@ -651,7 +651,7 @@ boolean digest_meal;
 		}
 	}
 	
-	if(!DEADMONSTER(mon) && mon->mhp < mon->mhpmax/2 && (mon->data == &mons[PM_CHANGED] || mon->data == &mons[PM_WARRIOR_CHANGED])){
+	if(!DEADMONSTER(mon) && mon->mhp < mon->mhpmax/2 && (mon->mtyp == PM_CHANGED || mon->mtyp == PM_WARRIOR_CHANGED)){
 		mon->mhp -= 1;
 		flags.cth_attk=TRUE;//state machine stuff.
 		create_gas_cloud(mon->mx+rn2(3)-1, mon->my+rn2(3)-1, rnd(3), rnd(3)+1);
@@ -666,7 +666,7 @@ boolean digest_meal;
 		}
 		return;
 	}
-	if(!DEADMONSTER(mon) && mon->data == &mons[PM_INVIDIAK] && !isdark(mon->mx, mon->my)){
+	if(!DEADMONSTER(mon) && mon->mtyp == PM_INVIDIAK && !isdark(mon->mx, mon->my)){
 		mon->mhp -= 1;
 		if(mon->mhp == 0){
 			mondied(mon);
@@ -748,9 +748,9 @@ disturb(mtmp)
 	 */
 	if(couldsee(mtmp->mx,mtmp->my) &&
 		distu(mtmp->mx,mtmp->my) <= 100 &&
-		(!Stealth || (mtmp->data == &mons[PM_ETTIN] && rn2(10))) &&
+		(!Stealth || (mtmp->mtyp == PM_ETTIN && rn2(10))) &&
 		(!(mtmp->data->mlet == S_NYMPH
-			|| mtmp->data == &mons[PM_JABBERWOCK]
+			|| mtmp->mtyp == PM_JABBERWOCK
 			|| mtmp->data->mlet == S_LEPRECHAUN) || !rn2(50)) &&
 		(Aggravate_monster
 			|| (mtmp->data->mlet == S_DOG ||
@@ -789,7 +789,7 @@ boolean fleemsg;
 		mtmp->mtrack[j].y = 0;
 	}
 
-	if(mtmp->data == &mons[PM_VROCK]){
+	if(mtmp->mtyp == PM_VROCK){
 		struct monst *tmpm;
 		if(!(mtmp->mspec_used || mtmp->mcan)){
 			pline("%s screeches.", Monnam(mtmp));
@@ -817,13 +817,13 @@ boolean fleemsg;
 			if (fleetime == 1) fleetime++;
 				mtmp->mfleetim = min(fleetime, 127);
 	    }
-		if( !mtmp->mflee && mtmp->data == &mons[PM_GIANT_TURTLE]){
+		if( !mtmp->mflee && mtmp->mtyp == PM_GIANT_TURTLE){
 		 mtmp->mcanmove=0;
 		 // mtmp->mfrozen = mtmp->mfleetim;
 		 if(canseemon(mtmp)) 
 		   pline("%s hides in %s shell!",Monnam(mtmp),mhis(mtmp));
 		} else if (!mtmp->mflee && fleemsg && canseemon(mtmp) && !mtmp->mfrozen) 
-			mtmp->data == &mons[PM_BANDERSNATCH] ? pline("%s becomes frumious!", (Monnam(mtmp)))
+			mtmp->mtyp == PM_BANDERSNATCH ? pline("%s becomes frumious!", (Monnam(mtmp)))
 												 : pline("%s turns to flee!", (Monnam(mtmp)));
 	    mtmp->mflee = 1;
 	}
@@ -860,7 +860,7 @@ int *inrange, *nearby, *scared;
 	
 	if(*scared && mtmp->mvanishes > 0) mtmp->mvanishes = mtmp->mvanishes/2 + 1;
 	
-	if(mtmp->data == &mons[PM_DAUGHTER_OF_BEDLAM] && !rn2(20)) *scared = TRUE;
+	if(mtmp->mtyp == PM_DAUGHTER_OF_BEDLAM && !rn2(20)) *scared = TRUE;
 	else if(*nearby && !mtmp->mflee && fleetflee(mtmp->data) && (mtmp->data->mmove > youracedata->mmove || noattacks(mtmp->data))) *scared = TRUE;
 	
 	if(*scared) {
@@ -907,12 +907,12 @@ register struct monst *mtmp;
 	
 	mtmp->mattackedu = 0; /*Clear out attacked bit*/
 	
-	if(mdat == &mons[PM_GNOLL_MATRIARCH]){
+	if(mdat->mtyp == PM_GNOLL_MATRIARCH){
 		if(!rn2(20)){
 			makemon(&mons[PM_GNOLL], mtmp->mx, mtmp->my, NO_MINVENT|MM_ADJACENTOK|MM_ADJACENTSTRICT);
 		}
 	}
-	if(mdat == &mons[PM_FORD_GUARDIAN]){
+	if(mdat->mtyp == PM_FORD_GUARDIAN){
 		if(!rn2(20) && mtmp->mux == u.ux && mtmp->muy == u.uy && !(mtmp->mstrategy&STRAT_WAITFORU)){
 			int i = rnd(4);
 			pline("The waters of the ford rise to the aid of the guardian!");
@@ -920,13 +920,13 @@ register struct monst *mtmp;
 				makemon(&mons[PM_FORD_ELEMENTAL], mtmp->mx, mtmp->my, NO_MINVENT|MM_ADJACENTOK|MM_ADJACENTSTRICT);
 		}
 	}
-	if(mdat == &mons[PM_LEGION]){
+	if(mdat->mtyp == PM_LEGION){
 		rn2(7) ? makemon(mkclass(S_ZOMBIE, G_NOHELL|G_HELL), mtmp->mx, mtmp->my, NO_MINVENT|MM_ADJACENTOK|MM_ADJACENTSTRICT): 
 				 makemon(&mons[PM_LEGIONNAIRE], mtmp->mx, mtmp->my, NO_MINVENT|MM_ADJACENTOK|MM_ADJACENTSTRICT);
 	}
 	if(needs_familiar(mtmp) && !mtmp->mspec_used){
-		if((mdat == &mons[PM_COVEN_LEADER] && !rn2(4))
-			|| (mdat == &mons[PM_WITCH] && !rn2(20))
+		if((mdat->mtyp == PM_COVEN_LEADER && !rn2(4))
+			|| (mdat->mtyp == PM_WITCH && !rn2(20))
 		){
 			struct monst *familliar;
 			if(canseemon(mtmp))
@@ -964,7 +964,7 @@ register struct monst *mtmp;
 	/* update quest status flags */
 	quest_stat_check(mtmp);
 	
-	if(mdat == &mons[PM_CENTER_OF_ALL] 
+	if(mdat->mtyp == PM_CENTER_OF_ALL 
 		&& !mtmp->mtame 
 		&& !Is_astralevel(&u.uz)
 		&& (near_capacity()>SLT_ENCUMBER || u.ulevel < 14 || mtmp->mpeaceful) 
@@ -997,7 +997,7 @@ register struct monst *mtmp;
 		}
 	}
 
-   if (mdat != &mons[PM_GIANT_TURTLE] || !mtmp->mflee)
+   if (mdat->mtyp != PM_GIANT_TURTLE || !mtmp->mflee)
 	if (!(mtmp->mcanmove && mtmp->mnotlaugh) || (mtmp->mstrategy & STRAT_WAITMASK)) {
 	    if (Hallucination) newsym(mtmp->mx,mtmp->my);
 	    if (mtmp->mcanmove && mtmp->mnotlaugh && (mtmp->mstrategy & STRAT_CLOSE) &&
@@ -1038,19 +1038,19 @@ register struct monst *mtmp;
 			return 0;
 	}
 	
-	if(mtmp->data == &mons[PM_MAD_SEER]){
+	if(mtmp->mtyp == PM_MAD_SEER){
 		if(!rn2(80)){
 			mtmp->mnotlaugh=0;
 			mtmp->mlaughing=rnd(5);
 		}
 	}
 	
-	if(mtmp->data == &mons[PM_QUIVERING_BLOB] && !mtmp->mflee){
+	if(mtmp->mtyp == PM_QUIVERING_BLOB && !mtmp->mflee){
 		if(!rn2(20)){
 			monflee(mtmp, 0, TRUE, TRUE);
 		}
 	}
-	if(mtmp->data == &mons[PM_GRUE]){
+	if(mtmp->mtyp == PM_GRUE){
 		if(!mtmp->mflee && !isdark(mtmp->mx, mtmp->my)){
 			monflee(mtmp, 0, TRUE, TRUE);
 		} else if(mtmp->mflee && isdark(mtmp->mx, mtmp->my)){
@@ -1070,7 +1070,7 @@ register struct monst *mtmp;
 		return(0);
 	}
 	
-	if(mtmp->data == &mons[PM_DRACAE_ELADRIN]){
+	if(mtmp->mtyp == PM_DRACAE_ELADRIN){
 		if(!mtmp->mvar_dracaePreg){
 			struct permonst *ptr = mkclass(S_CHA_ANGEL, G_PLANES);
 			if(ptr)
@@ -1115,7 +1115,7 @@ register struct monst *mtmp;
 			return 0;
 		}
 	}
-	if(mtmp->data == &mons[PM_MOTHERING_MASS]){
+	if(mtmp->mtyp == PM_MOTHERING_MASS){
 		if(!mtmp->mvar_dracaePreg){
 			struct permonst *ptr = mkclass(S_CHA_ANGEL, G_PLANES);
 			if(ptr)
@@ -1163,7 +1163,7 @@ register struct monst *mtmp;
 		}
 	}
 	
-	if(mdat == &mons[PM_OONA] && !mtmp->mspec_used){
+	if(mdat->mtyp == PM_OONA && !mtmp->mspec_used){
 		nearby = FALSE;
 		struct monst *tmpm;
 		for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -1188,10 +1188,10 @@ register struct monst *mtmp;
 		(mdat->msound == MS_DREAD && !rn2(4)) ||
 		(mdat->msound == MS_OONA && (nearby || !rn2(6))) ||
 		(mdat->msound == MS_SONG && !rn2(6)) ||
-		(mdat == &mons[PM_RHYMER] && !mtmp->mspec_used && !rn2(6)) ||
+		(mdat->mtyp == PM_RHYMER && !mtmp->mspec_used && !rn2(6)) ||
 		(mdat->msound == MS_INTONE && !rn2(6)) ||
 		(mdat->msound == MS_FLOWER && !rn2(6)) ||
-		(mdat == &mons[PM_LAMASHTU] && !rn2(7))
+		(mdat->mtyp == PM_LAMASHTU && !rn2(7))
 	) m_respond(mtmp);
 	
 	if(!mtmp->mblinded) for (gazemon = fmon; gazemon; gazemon = nxtmon){
@@ -1203,7 +1203,7 @@ register struct monst *mtmp;
 			&& clear_path(mtmp->mx, mtmp->my, gazemon->mx, gazemon->my)
 		){
 			int i;
-			if(gazemon->data == &mons[PM_MEDUSA] && resists_ston(mtmp)
+			if(gazemon->mtyp == PM_MEDUSA && resists_ston(mtmp)
 			) continue;
 			
 			if (hideablewidegaze(gazemon->data) &&
@@ -1238,12 +1238,12 @@ register struct monst *mtmp;
 	if (mtmp->mflee && !mtmp->mfleetim
 	   && mtmp->mhp == mtmp->mhpmax && !rn2(25)){
 		mtmp->mflee = 0;
-        if(canseemon(mtmp) && (mdat == &mons[PM_GIANT_TURTLE]) && !(mtmp->mfrozen)){
+        if(canseemon(mtmp) && (mdat->mtyp == PM_GIANT_TURTLE) && !(mtmp->mfrozen)){
          pline("%s comes out of %s shell.", Monnam(mtmp), mhis(mtmp));
          mtmp->mcanmove=1;
 		}
     }
-   else if (mdat == &mons[PM_GIANT_TURTLE] && !mtmp->mcanmove)
+   else if (mdat->mtyp == PM_GIANT_TURTLE && !mtmp->mcanmove)
      return (0);
 
 	set_apparxy(mtmp);
@@ -1254,14 +1254,14 @@ register struct monst *mtmp;
 
 	/* Monsters that want to acquire things */
 	/* may teleport, so do it before inrange is set */
-	if(is_covetous(mdat) && (mdat!=&mons[PM_DEMOGORGON] || !rn2(3)) 
-		&& mdat!=&mons[PM_ELDER_PRIEST] /*&& mdat!=&mons[PM_SHAMI_AMOURAE]*/
-		&& mdat!=&mons[PM_LEGION] /*&& mdat!=&mons[PM_SHAMI_AMOURAE]*/
+	if(is_covetous(mdat) && (mdat->mtyp!=PM_DEMOGORGON || !rn2(3)) 
+		&& mdat->mtyp!=PM_ELDER_PRIEST /*&& mdat->mtyp!=PM_SHAMI_AMOURAE*/
+		&& mdat->mtyp!=PM_LEGION /*&& mdat->mtyp!=PM_SHAMI_AMOURAE*/
 		&& !(noactions(mtmp))
 		&& !(mtmp->mpeaceful && !mtmp->mtame) /*Don't telespam the player if peaceful*/
 	) (void) tactics(mtmp);
 	
-	// if(mdat == &mons[PM_GREAT_CTHULHU] && !rn2(20)){
+	// if(mdat->mtyp == PM_GREAT_CTHULHU && !rn2(20)){
 		// (void) tactics(mtmp);
 		// return 0;
 	// }
@@ -1277,7 +1277,7 @@ register struct monst *mtmp;
 			return 1;
 	}
 	
-	if((is_drow(mtmp->data) || mtmp->data == &mons[PM_LUGRIBOSSK] || mtmp->data == &mons[PM_MAANZECORIAN])
+	if((is_drow(mtmp->data) || mtmp->mtyp == PM_LUGRIBOSSK || mtmp->mtyp == PM_MAANZECORIAN)
 		&& (!mtmp->mpeaceful || Darksight)
 		&& (levl[mtmp->mx][mtmp->my].lit == 1 || viz_array[mtmp->my][mtmp->mx]&TEMP_LIT1)
 		&& !mtmp->mcan && mtmp->mspec_used < 4
@@ -1287,11 +1287,11 @@ register struct monst *mtmp;
 		if(cansee(mtmp->mx,mtmp->my)) pline("%s invokes the darkness.",Monnam(mtmp));
 	    do_clear_area(mtmp->mx,mtmp->my, 5, set_lit, (genericptr_t)0);
 		vision_full_recalc = 1;
-	    if(mtmp->data == &mons[PM_HEDROW_WARRIOR]) mtmp->mspec_used += d(4,4);
+	    if(mtmp->mtyp == PM_HEDROW_WARRIOR) mtmp->mspec_used += d(4,4);
 		else mtmp->mspec_used += max(10 - mtmp->m_lev,2);
 	}
 
-	if (mtmp->data == &mons[PM_NURSE] || mtmp->data == &mons[PM_HEALER]){
+	if (mtmp->mtyp == PM_NURSE || mtmp->mtyp == PM_HEALER){
 	    // && !uarmu && !uarm && !uarmh && !uarms && !uarmg && !uarmc && !uarmf){
 		struct monst *patient = 0;
 		int i, j, x, y, rot = rn2(3);
@@ -1328,7 +1328,7 @@ register struct monst *mtmp;
 		}
 	}
 	
-	if(mtmp->data == &mons[PM_OPERATOR] || mtmp->data == &mons[PM_PARASITIZED_OPERATOR]){
+	if(mtmp->mtyp == PM_OPERATOR || mtmp->mtyp == PM_PARASITIZED_OPERATOR){
 		struct monst *repairee = 0;
 		int i, j, x, y, rot = rn2(3);
 		for(i = -1; i < 2; i++){
@@ -1360,8 +1360,8 @@ register struct monst *mtmp;
 		}
 	}
 	
-	if((mtmp->data == &mons[PM_ANDROID] || mtmp->data == &mons[PM_GYNOID] || mtmp->data == &mons[PM_OPERATOR] ||
-		mtmp->data == &mons[PM_PARASITIZED_ANDROID] || mtmp->data == &mons[PM_PARASITIZED_GYNOID] || mtmp->data == &mons[PM_PARASITIZED_OPERATOR])
+	if((mtmp->mtyp == PM_ANDROID || mtmp->mtyp == PM_GYNOID || mtmp->mtyp == PM_OPERATOR ||
+		mtmp->mtyp == PM_PARASITIZED_ANDROID || mtmp->mtyp == PM_PARASITIZED_GYNOID || mtmp->mtyp == PM_PARASITIZED_OPERATOR)
 		&& MON_WEP(mtmp)
 		&& (is_vibroweapon(MON_WEP(mtmp)) || is_blaster(MON_WEP(mtmp)))
 		&& MON_WEP(mtmp)->ovar1 <= 0
@@ -1386,8 +1386,8 @@ register struct monst *mtmp;
 		return 0;
 	}
 
-	if((mtmp->data == &mons[PM_ANDROID] || mtmp->data == &mons[PM_GYNOID] || mtmp->data == &mons[PM_OPERATOR] ||
-		mtmp->data == &mons[PM_PARASITIZED_ANDROID] || mtmp->data == &mons[PM_PARASITIZED_GYNOID] || mtmp->data == &mons[PM_PARASITIZED_OPERATOR])
+	if((mtmp->mtyp == PM_ANDROID || mtmp->mtyp == PM_GYNOID || mtmp->mtyp == PM_OPERATOR ||
+		mtmp->mtyp == PM_PARASITIZED_ANDROID || mtmp->mtyp == PM_PARASITIZED_GYNOID || mtmp->mtyp == PM_PARASITIZED_OPERATOR)
 		&& MON_WEP(mtmp)
 		&& (is_lightsaber(MON_WEP(mtmp)) && MON_WEP(mtmp)->oartifact != ART_INFINITY_S_MIRRORED_ARC && MON_WEP(mtmp)->otyp != KAMEREL_VAJRA)
 		&& MON_WEP(mtmp)->age <= 0
@@ -1404,7 +1404,7 @@ register struct monst *mtmp;
 		return 0;
 	}
 
-	if(mtmp->data == &mons[PM_PHALANX]
+	if(mtmp->mtyp == PM_PHALANX
 		&& !mtmp->mcan
 		&& !(noactions(mtmp))
 	){
@@ -1466,9 +1466,9 @@ register struct monst *mtmp;
 #endif /* CONVICT */
 
 	/* the watch will look around and see if you are up to no good :-) */
-	if (mdat == &mons[PM_WATCHMAN] || mdat == &mons[PM_WATCH_CAPTAIN])
+	if (mdat->mtyp == PM_WATCHMAN || mdat->mtyp == PM_WATCH_CAPTAIN)
 		watch_on_duty(mtmp);
-	if(mdat == &mons[PM_NURSE]){
+	if(mdat->mtyp == PM_NURSE){
 		int i, j;
 		struct trap *ttmp;
 		struct monst *tmon;
@@ -1494,7 +1494,7 @@ register struct monst *mtmp;
 					}
 				}
 	}
-	if(mdat == &mons[PM_TOVE] && !rn2(20)){
+	if(mdat->mtyp == PM_TOVE && !rn2(20)){
 		struct trap *ttmp = t_at(mtmp->mx, mtmp->my);
 		struct rm *lev = &levl[mtmp->mx][mtmp->my];
 		schar typ;
@@ -1541,7 +1541,7 @@ register struct monst *mtmp;
 				digactualhole(mtmp->mx, mtmp->my, mtmp, HOLE, FALSE, TRUE);
 		}
 	}
-	if (has_mind_blast(mdat) && !u.uinvulnerable && !rn2(mdat == &mons[PM_ELDER_BRAIN] ? 10 : 20)) {
+	if (has_mind_blast(mdat) && !u.uinvulnerable && !rn2(mdat->mtyp == PM_ELDER_BRAIN ? 10 : 20)) {
 		boolean reducedFlayerMessages = (((Role_if(PM_NOBLEMAN) && Race_if(PM_DROW) && flags.initgend) || Role_if(PM_ANACHRONONAUT)) && In_quest(&u.uz));
 		struct monst *m2, *nmon = (struct monst *)0;
 		
@@ -1558,23 +1558,23 @@ register struct monst *mtmp;
 		} else {
 			register boolean m_sen = tp_sensemon(mtmp);
 			
-			if(mdat == &mons[PM_ELDER_BRAIN]) quest_chat(mtmp);
+			if(mdat->mtyp == PM_ELDER_BRAIN) quest_chat(mtmp);
 			
 			if (m_sen || (Blind_telepat && rn2(2)) || !rn2(10)) {
 				int dmg;
 				pline("It locks on to your %s!",
 					m_sen ? "telepathy" :
 					Blind_telepat ? "latent telepathy" : "mind");
-				dmg = (mdat == &mons[PM_GREAT_CTHULHU] || mdat == &mons[PM_LUGRIBOSSK] || mdat == &mons[PM_MAANZECORIAN]) ? d(5,15) : (mdat == &mons[PM_ELDER_BRAIN]) ? d(3,15) : rnd(15);
+				dmg = (mdat->mtyp == PM_GREAT_CTHULHU || mdat->mtyp == PM_LUGRIBOSSK || mdat->mtyp == PM_MAANZECORIAN) ? d(5,15) : (mdat->mtyp == PM_ELDER_BRAIN) ? d(3,15) : rnd(15);
 				if (Half_spell_damage) dmg = (dmg+1) / 2;
 				if(u.uvaul_duration) dmg = (dmg + 1) / 2;
 				losehp(dmg, "psychic blast", KILLED_BY_AN);
-				if(mdat == &mons[PM_SEMBLANCE]) make_hallucinated(HHallucination + dmg, FALSE, 0L);
-				if(mdat == &mons[PM_GREAT_CTHULHU]){
+				if(mdat->mtyp == PM_SEMBLANCE) make_hallucinated(HHallucination + dmg, FALSE, 0L);
+				if(mdat->mtyp == PM_GREAT_CTHULHU){
 					make_stunned(HStun + dmg*10, TRUE);
 					u.umadness |= MAD_DREAMS;
 				}
-				if (mdat == &mons[PM_ELDER_BRAIN]) {
+				if (mdat->mtyp == PM_ELDER_BRAIN) {
 					for (m2 = fmon; m2; m2 = nmon) {
 						nmon = m2->nmon;
 						if (!DEADMONSTER(m2) && (m2->mpeaceful == mtmp->mpeaceful) && mon_resistance(m2,TELEPAT) && (m2!=mtmp))
@@ -1582,7 +1582,7 @@ register struct monst *mtmp;
 							m2->msleeping = 0;
 							if (!m2->mcanmove && !rn2(5)) {
 								m2->mfrozen = 0;
-								if (m2->data != &mons[PM_GIANT_TURTLE] || !(m2->mflee))
+								if (m2->mtyp != PM_GIANT_TURTLE || !(m2->mflee))
 									m2->mcanmove = 1;
 							}
 							m2->mux = u.ux;
@@ -1603,15 +1603,15 @@ register struct monst *mtmp;
 			    (rn2(2) || m2->mblinded)) || !rn2(10)) {
 				if (cansee(m2->mx, m2->my))
 				    pline("It locks on to %s.", mon_nam(m2));
-				if(mdat == &mons[PM_GREAT_CTHULHU]) m2->mconf=TRUE;
-				if(mdat == &mons[PM_GREAT_CTHULHU] || mdat == &mons[PM_LUGRIBOSSK] || mdat == &mons[PM_MAANZECORIAN]) m2->mhp -= d(5,15);
-				else if(mdat == &mons[PM_ELDER_BRAIN]){
+				if(mdat->mtyp == PM_GREAT_CTHULHU) m2->mconf=TRUE;
+				if(mdat->mtyp == PM_GREAT_CTHULHU || mdat->mtyp == PM_LUGRIBOSSK || mdat->mtyp == PM_MAANZECORIAN) m2->mhp -= d(5,15);
+				else if(mdat->mtyp == PM_ELDER_BRAIN){
 					int mfdmg = d(3,15);
 					m2->mhp -= mfdmg;
 					m2->mstdy = max(mfdmg, m2->mstdy);
 				} else {
 					m2->mhp -= rnd(15);
-					if(mdat == &mons[PM_SEMBLANCE]) m2->mconf=TRUE;
+					if(mdat->mtyp == PM_SEMBLANCE) m2->mconf=TRUE;
 				}
 				if (m2->mhp <= 0)
 				    monkilled(m2, "", AD_DRIN);
@@ -1704,7 +1704,7 @@ toofar:
 /*	Now the actual movement phase	*/
 
 #ifndef GOLDOBJ
-	if(!nearby || (mtmp->mflee && mtmp->data != &mons[PM_BANDERSNATCH]) || scared ||
+	if(!nearby || (mtmp->mflee && mtmp->mtyp != PM_BANDERSNATCH) || scared ||
 	   mtmp->mconf || mtmp->mstun || (mtmp->minvis && !rn2(3)) ||
 	   (mdat->mlet == S_LEPRECHAUN && !u.ugold && (mtmp->mgold || rn2(2))) ||
 #else
@@ -1712,7 +1712,7 @@ toofar:
 	    ygold = findgold(invent);
 	    lepgold = findgold(mtmp->minvent);
 	}
-	if(!nearby || (mtmp->mflee && mtmp->data != &mons[PM_BANDERSNATCH]) || scared ||
+	if(!nearby || (mtmp->mflee && mtmp->mtyp != PM_BANDERSNATCH) || scared ||
 	   mtmp->mconf || mtmp->mstun || (mtmp->minvis && !rn2(3)) ||
 	   (mdat->mlet == S_LEPRECHAUN && !ygold && (lepgold || rn2(2))) ||
 #endif
@@ -1735,12 +1735,12 @@ toofar:
 				){
 					if(castmu(mtmp, a, TRUE, TRUE)){
 						tmp = 3;
-						// if(mdat != &mons[PM_DEMOGORGON]) break;
+						// if(mdat->mtyp != PM_DEMOGORGON) break;
 					}
 			    } else {
 					if(castmu(mtmp, a, FALSE, FALSE)){
 						tmp = 3;
-						// if(mdat != &mons[PM_DEMOGORGON]) break;
+						// if(mdat->mtyp != PM_DEMOGORGON) break;
 					}
 				}
 			}
@@ -1770,7 +1770,7 @@ toofar:
 			if(mtmp->wormno && (!mtmp->mpeaceful || Conflict)) wormhitu(mtmp);
 			if(!nearby &&
 			  (ranged_attk(mdat) || find_offensive(mtmp))){
-				if(mdat == &mons[PM_GREAT_CTHULHU] || mdat == &mons[PM_WATCHER_IN_THE_WATER] || mdat == &mons[PM_KETO] || mdat == &mons[PM_ARCADIAN_AVENGER]){
+				if(mdat->mtyp == PM_GREAT_CTHULHU || mdat->mtyp == PM_WATCHER_IN_THE_WATER || mdat->mtyp == PM_KETO || mdat->mtyp == PM_ARCADIAN_AVENGER){
 					break;
 			    } else return(0);
 			    // return(0);
@@ -1801,9 +1801,9 @@ toofar:
 	/* extra emotional attack for vile monsters */
 	if (inrange && mtmp->data->msound == MS_CUSS && !mtmp->mpeaceful &&
 		couldsee(mtmp->mx, mtmp->my) && ((!mtmp->minvis && !rn2(5)) || 
-										mtmp->data == &mons[PM_SIR_GARLAND] || mtmp->data == &mons[PM_GARLAND] ||
-										(mtmp->data == &mons[PM_CHAOS] && (mtmp->mvar2 < 5 || !rn2(5)) )|| 
-										mtmp->data == &mons[PM_APOLLYON]
+										mtmp->mtyp == PM_SIR_GARLAND || mtmp->mtyp == PM_GARLAND ||
+										(mtmp->mtyp == PM_CHAOS && (mtmp->mvar2 < 5 || !rn2(5)) )|| 
+										mtmp->mtyp == PM_APOLLYON
 	) )
 	    cuss(mtmp);
 
@@ -1890,7 +1890,7 @@ register int after;
 	    can_tunnel = tunnels(ptr);
 	can_open = !(nohands(ptr) || verysmall(ptr));
 	can_unlock = ((can_open && (m_carrying(mtmp, SKELETON_KEY)||m_carrying(mtmp, UNIVERSAL_KEY))) ||
-		      mtmp->iswiz || is_rider(ptr) || ptr==&mons[PM_DREAD_SERAPH]);
+		      mtmp->iswiz || is_rider(ptr) || ptr->mtyp==PM_DREAD_SERAPH);
 	doorbuster = is_giant(ptr);
 	if(mtmp->wormno) goto not_special;
 	/* my dog gets special treatment */
@@ -1930,9 +1930,9 @@ register int after;
 			if(mattackm(mtmp, intruder) == 2) return(2);
 			mmoved = 1;
 			goto postmov;
-		} else if(mtmp->data != &mons[PM_DEMOGORGON] 
-			   && mtmp->data!=&mons[PM_ELDER_PRIEST]
-			   /*&& mtmp->data!=&mons[PM_SHAMI_AMOURAE]*/
+		} else if(mtmp->mtyp != PM_DEMOGORGON 
+			   && mtmp->mtyp!=PM_ELDER_PRIEST
+			   /*&& mtmp->mtyp!=PM_SHAMI_AMOURAE*/
 			   ){
 			mmoved = 0;
 		    goto postmov;
@@ -1949,7 +1949,7 @@ register int after;
 	}
 
 #ifdef MAIL
-	if(ptr == &mons[PM_MAIL_DAEMON]) {
+	if(ptr->mtyp == PM_MAIL_DAEMON) {
 	    if(flags.soundok && canseemon(mtmp))
 		verbalize("I'm late!");
 	    mongone(mtmp);
@@ -1974,7 +1974,7 @@ not_special:
 	omy = mtmp->my;
 	gx = mtmp->mux;
 	gy = mtmp->muy;
-	appr = (mtmp->mflee && mtmp->data != &mons[PM_BANDERSNATCH]) ? -1 : 1;
+	appr = (mtmp->mflee && mtmp->mtyp != PM_BANDERSNATCH) ? -1 : 1;
 	if (mtmp->mconf || (u.uswallow && mtmp == u.ustuck) || (gx == 0 && gy == 0))
 		appr = 0;
 	else {
@@ -2010,7 +2010,7 @@ not_special:
 		}
 	}
 
-	if (( !mtmp->mpeaceful || mtmp->data == &mons[PM_MAID] || !rn2(10) )
+	if (( !mtmp->mpeaceful || mtmp->mtyp == PM_MAID || !rn2(10) )
 #ifdef REINCARNATION
 				    && (!Is_rogue_level(&u.uz))
 #endif
@@ -2099,7 +2099,7 @@ not_special:
 		       (likegems && otmp->oclass == GEM_CLASS &&
 			otmp->obj_material != MINERAL) ||
 		       (conceals && !cansee(otmp->ox,otmp->oy)) ||
-		       (ptr == &mons[PM_GELATINOUS_CUBE] &&
+		       (ptr->mtyp == PM_GELATINOUS_CUBE &&
 			!index(indigestion, otmp->oclass) &&
 			!(otmp->otyp == CORPSE &&
 			  touch_petrifies(&mons[otmp->corpsenm])))
@@ -2118,7 +2118,7 @@ not_special:
 					lmy = max(0, omy-minr);
 					gx = otmp->ox;
 					gy = otmp->oy;
-					if(mtmp->data == &mons[PM_MAID] && appr == 0) appr = 1;
+					if(mtmp->mtyp == PM_MAID && appr == 0) appr = 1;
 					if (gx == omx && gy == omy) {
 						mmoved = 3; /* actually unnecessary */
 						goto postmov;
@@ -2161,7 +2161,7 @@ not_special:
 	if (mon_resistance(mtmp,PASSES_WALLS)) flag |= (ALLOW_WALL | ALLOW_ROCK);
 	if (passes_bars(mtmp) && !Is_illregrd(&u.uz) ) flag |= ALLOW_BARS;
 	if (can_tunnel) flag |= ALLOW_DIG;
-	if (is_human(ptr) || ptr == &mons[PM_MINOTAUR]) flag |= ALLOW_SSM;
+	if (is_human(ptr) || ptr->mtyp == PM_MINOTAUR) flag |= ALLOW_SSM;
 	if (is_undead_mon(mtmp) && ptr->mlet != S_GHOST && ptr->mlet != S_SHADE) flag |= NOGARLIC;
 	if (throws_rocks(ptr)) flag |= ALLOW_ROCK;
 	if (can_open) flag |= OPENDOOR;
@@ -2241,9 +2241,9 @@ not_special:
 		}
 		if(Role_if(PM_ANACHRONONAUT) && !mtmp->mpeaceful && In_quest(&u.uz) && Is_qstart(&u.uz)){
 			if(mtmp->mhp == mtmp->mhpmax && (
-				(mtmp->data == &mons[PM_DEEP_ONE] && !rn2(1000))
-				|| (mtmp->data == &mons[PM_DEEPER_ONE] && !rn2(500))
-				|| (mtmp->data == &mons[PM_DEEPEST_ONE] && !rn2(100))
+				(mtmp->mtyp == PM_DEEP_ONE && !rn2(1000))
+				|| (mtmp->mtyp == PM_DEEPER_ONE && !rn2(500))
+				|| (mtmp->mtyp == PM_DEEPEST_ONE && !rn2(100))
 			)){
 				int i, j, count=0;
 				for(i = -1; i < 2; i++) for(j = -1; j < 2; j++){
@@ -2271,9 +2271,9 @@ not_special:
 						}
 					}
 				}
-			} else if((mtmp->data == &mons[PM_DEEP_ONE] && !rn2(20))
-				|| (mtmp->data == &mons[PM_DEEPER_ONE] && !rn2(5))
-				|| (mtmp->data == &mons[PM_DEEPEST_ONE])
+			} else if((mtmp->mtyp == PM_DEEP_ONE && !rn2(20))
+				|| (mtmp->mtyp == PM_DEEPER_ONE && !rn2(5))
+				|| (mtmp->mtyp == PM_DEEPEST_ONE)
 			){
 				int i, j, count=0;
 				for(i = -1; i < 2; i++) for(j = -1; j < 2; j++){
@@ -2414,7 +2414,7 @@ not_special:
 		mtmp->mtrack[j] = mtmp->mtrack[j-1];
 	    mtmp->mtrack[0].x = omx;
 	    mtmp->mtrack[0].y = omy;
-		if(mtmp->data == &mons[PM_HEMORRHAGIC_THING]){
+		if(mtmp->mtyp == PM_HEMORRHAGIC_THING){
 			//The thing leaves bloody footprints, that appear *after* the monster has passed by
 			if(isok(mtmp->mtrack[1].x, mtmp->mtrack[1].y) && mtmp->mtrack[1].x != 0){
 				struct engr *oep = engr_at(mtmp->mtrack[1].x, mtmp->mtrack[1].y);
@@ -2434,9 +2434,9 @@ not_special:
 	    /* Place a segment at the old position. */
 	    if (mtmp->wormno) worm_move(mtmp);
 		
-		if(mtmp->data == &mons[PM_SURYA_DEVA]){
+		if(mtmp->mtyp == PM_SURYA_DEVA){
 			struct monst *blade;
-			for(blade = fmon; blade; blade = blade->nmon) if(blade->data == &mons[PM_DANCING_BLADE] && mtmp->m_id == blade->mvar_suryaID) break;
+			for(blade = fmon; blade; blade = blade->nmon) if(blade->mtyp == PM_DANCING_BLADE && mtmp->m_id == blade->mvar_suryaID) break;
 			if(blade){
 				int bx = blade->mx, by = blade->my;
 				remove_monster(bx, by);
@@ -2477,8 +2477,8 @@ postmov:
 		    if(here->doormask & (D_LOCKED|D_CLOSED) && amorphous(ptr)) {
 			if (flags.verbose && canseemon(mtmp))
 			    pline("%s %s under the door.", Monnam(mtmp),
-				  (ptr == &mons[PM_FOG_CLOUD] ||
-				   ptr == &mons[PM_YELLOW_LIGHT])
+				  (ptr->mtyp == PM_FOG_CLOUD ||
+				   ptr->mtyp == PM_YELLOW_LIGHT)
 				  ? "flows" : "oozes");
 		    } else if(here->doormask & D_LOCKED && can_unlock) {
 			if(btrapped) {
@@ -2539,13 +2539,13 @@ postmov:
 			    add_damage(mtmp->mx, mtmp->my, 0L);
 		    }
 		} else if (levl[mtmp->mx][mtmp->my].typ == IRONBARS && !Is_illregrd(&u.uz)) {
-		    if ( (dmgtype(ptr,AD_RUST) && ptr != &mons[PM_NAIAD]) || dmgtype(ptr,AD_CORR)) {
+		    if ( (dmgtype(ptr,AD_RUST) && ptr->mtyp != PM_NAIAD) || dmgtype(ptr,AD_CORR)) {
 				if (canseemon(mtmp)) {
 					pline("%s eats through the iron bars.", 
 					Monnam(mtmp)); 
 				}
 				dissolve_bars(mtmp->mx, mtmp->my);
-				if(mtmp->data == &mons[PM_RUST_MONSTER] && mtmp->mtame && mtmp->isminion){
+				if(mtmp->mtyp == PM_RUST_MONSTER && mtmp->mtame && mtmp->isminion){
 					EDOG(mtmp)->hungrytime += 5*objects[BAR].oc_nutrition;
 				}
 			}
@@ -2599,7 +2599,7 @@ postmov:
 		if(g_at(mtmp->mx,mtmp->my) && likegold) mpickgold(mtmp);
 
 		/* Maybe a cube ate just about anything */
-		if (ptr == &mons[PM_GELATINOUS_CUBE]) {
+		if (ptr->mtyp == PM_GELATINOUS_CUBE) {
 		    if (meatobj(mtmp) == 2) return 2;	/* it died */
 		}
 
@@ -2723,7 +2723,7 @@ register struct monst *mtmp;
 	/* Can also learn your position via hearing you */
 	if(couldsee(mtmp->mx,mtmp->my) &&
 		distu(mtmp->mx,mtmp->my) <= 100 &&
-		(!Stealth || (mtmp->data == &mons[PM_ETTIN] && rn2(10))) &&
+		(!Stealth || (mtmp->mtyp == PM_ETTIN && rn2(10))) &&
 		(Aggravate_monster || ((sensitive_ears(mtmp->data) || !rn2(7)) && !is_deaf(mtmp)))
 	) {
 		notseen = FALSE;

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1958,7 +1958,7 @@ register int after;
 #endif
 
 	/* teleport if that lies in our nature */
-	if((mteleport(ptr) || mtmp->mfaction == TOMB_HERD) && !rn2(5) && !mtmp->mcan &&
+	if((mteleport(ptr)) && !rn2(5) && !mtmp->mcan &&
 	   !tele_restrict(mtmp) && !(noactions(mtmp))
 	) {
 	    if(mtmp->mhp < 7 || mtmp->mpeaceful || rn2(2))

--- a/src/monst.c
+++ b/src/monst.c
@@ -39,7 +39,7 @@ void NDECL(monst_init);
  *	symbol color (C(x) macro)
  */
 #define MON(nam,sym,lvl,gen,atk,siz,mr1,mr2,flgm,flgt,flgb,flgg,flga,flgv,col) \
-	   {nam,sym,lvl,gen,atk,siz,mr1,mr2,flgm,flgt,flgb,flgg,flga,flgv,C(col)}
+	   {nam,sym,lvl,gen,atk,siz,mr1,mr2,flgm,flgt,flgb,flgg,flga,flgv,C(col),-1}
 /*Variable-specificity armor-class*/
 #define NAT_AC(ac)  10-ac,0,0
 #define DEX_AC(ac)  0,10-ac,0

--- a/src/monst.c
+++ b/src/monst.c
@@ -477,6 +477,7 @@ NEARDATA struct permonst mons[] = {
 	MM_FLY|MM_FLOAT|MM_AMPHIBIOUS /*MM*/, MT_HOSTILE|MT_NOTAKE /*MT*/,
 	MB_NOLIMBS|MB_NOHEAD|MB_NEUTER /*MB*/, MG_INFRAVISIBLE|MG_SANLOSS /*MG*/,
 	0 /*MA*/,  MV_INFRAVISION|MV_CATSIGHT|MV_SEE_INVIS|MV_TELEPATHIC /*MV*/, CLR_BLUE),
+	/* growth code in mon.c relies on sequential order of autons, Monoton to Quinon. */
     MON("monoton", S_EYE, //4 //autons need useful entries I think?
 	LVL_NDR(1, 1, 8, 1, 10, 2), (G_LGROUP|G_NOCORPSE|1),
 	A(ATTK(AT_NONE, AD_PLYS, 1,1), ATTK(AT_GAZE, AD_STDY, 1,11), 

--- a/src/mplayer.c
+++ b/src/mplayer.c
@@ -480,8 +480,8 @@ register struct monst *mtmp;
 	if(mtmp->mpeaceful) return; /* will drop to humanoid talk */
 
 	pline("Talk? -- %s",
-		(mtmp->data == &mons[urole.malenum] ||
-		mtmp->data == &mons[urole.femalenum]) ?
+		(mtmp->mtyp == urole.malenum ||
+		mtmp->mtyp == urole.femalenum) ?
 		same_class_msg[rn2(3)] : other_class_msg[rn2(3)]);
 }
 

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -132,7 +132,7 @@ int force_linedup;
 			   ))
 		)
 	){
-	    if(!(mtmp->data == &mons[PM_OONA] && resists_oona(mtmp2)) && mm_aggression(mtmp, mtmp2)) return mtmp2;
+	    if(!(mtmp->mtyp == PM_OONA && resists_oona(mtmp2)) && mm_aggression(mtmp, mtmp2)) return mtmp2;
 	}
 	
 #if 0
@@ -175,7 +175,7 @@ int force_linedup;
 				( is_pole(mrwep) && lined_up(mtmp) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2 && (mtmp->mux == mtmp->mx || mtmp->muy == mtmp->my))
 			   ))
 		)) {
-        	if(!(mtmp->data == &mons[PM_OONA] && Oona_resistance)) return &youmonst;  /* kludge - attack the player first
+        	if(!(mtmp->mtyp == PM_OONA && Oona_resistance)) return &youmonst;  /* kludge - attack the player first
 				      if possible */
 		}
 		if(gx != 0 || gy != 0){
@@ -246,7 +246,7 @@ int force_linedup;
 				( is_pole(mrwep) && lined_up(mtmp) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2 && (mtmp->mux == mtmp->mx || mtmp->muy == mtmp->my))
 			   ))
 		)) {
-        	if(!(mtmp->data == &mons[PM_OONA] && Oona_resistance)) return &youmonst;  /* kludge - attack the player first
+        	if(!(mtmp->mtyp == PM_OONA && Oona_resistance)) return &youmonst;  /* kludge - attack the player first
 				      if possible */
 		}
     }
@@ -284,7 +284,7 @@ int force_linedup;
 				if (((!oldmret) ||
 					(monstr[monsndx(mat->data)] >
 					monstr[monsndx(oldmret->data)])
-					) && !(mtmp->data == &mons[PM_OONA] && resists_oona(mat))
+					) && !(mtmp->mtyp == PM_OONA && resists_oona(mat))
 					 && mm_aggression(mtmp, mat)
 				) mret = mat;
 			}
@@ -304,7 +304,7 @@ int force_linedup;
 					if (((!oldmret) ||
 						(monstr[monsndx(mat->data)] >
 						monstr[monsndx(oldmret->data)])
-						) && !(mtmp->data == &mons[PM_OONA] && resists_oona(mat))
+						) && !(mtmp->mtyp == PM_OONA && resists_oona(mat))
 						 && mm_aggression(mtmp, mat)
 					)
 						mret = mat;
@@ -340,7 +340,7 @@ int force_linedup;
 			if (((!mret) ||
 				(monstr[monsndx(mtmp2->data)] >
 				monstr[monsndx(mret->data)])
-				) && !(mtmp->data == &mons[PM_OONA] && resists_oona(mtmp2))
+				) && !(mtmp->mtyp == PM_OONA && resists_oona(mtmp2))
 				 && mm_aggression(mtmp, mtmp2)
 			){
 				mret = mtmp2;

--- a/src/muse.c
+++ b/src/muse.c
@@ -2236,13 +2236,13 @@ museamnesia:
 	case MUSE_WAN_POLYMORPH:
 		mzapmsg(mtmp, otmp, TRUE);
 		otmp->spe--;
-		if(!resists_poly(mtmp->data)) newcham(mtmp, (struct permonst *) 0, TRUE, FALSE);
+		if(!resists_poly(mtmp->data)) newcham(mtmp, NON_PM, TRUE, FALSE);
 		if (oseen) makeknown(WAN_POLYMORPH);
 		return 2;
 	case MUSE_POT_POLYMORPH:
 		mquaffmsg(mtmp, otmp);
 		if (vismon) pline("%s suddenly mutates!", Monnam(mtmp));
-		if(!resists_poly(mtmp->data)) newcham(mtmp, (struct permonst *) 0, FALSE, FALSE);
+		if(!resists_poly(mtmp->data)) newcham(mtmp, NON_PM, FALSE, FALSE);
 		if (oseen) makeknown(POT_POLYMORPH);
 		m_useup(mtmp, otmp);
 		return 2;
@@ -2261,7 +2261,7 @@ museamnesia:
 		newsym(trapx, trapy);
 		
 		if(resists_magm(mtmp)) shieldeff(mtmp->mx, mtmp->my);
-		else if(!resists_poly(mtmp->data)) newcham(mtmp, (struct permonst *)0, FALSE, FALSE);
+		else if(!resists_poly(mtmp->data)) newcham(mtmp, NON_PM, FALSE, FALSE);
 		return 2;
 	case MUSE_BULLWHIP:
 		/* attempt to disarm hero */
@@ -2385,7 +2385,7 @@ museamnesia:
 			pline("%s puts on a mask!", Monnam(mtmp));
 		m_useup(mtmp, otmp);
 		mtmp->ispolyp = TRUE;
-		newcham(mtmp, &mons[pm], FALSE, FALSE);
+		newcham(mtmp, pm, FALSE, FALSE);
 		mtmp->m_insight_level = 0;
 		m_dowear(mtmp, TRUE);
 		init_mon_wield_item(mtmp);

--- a/src/muse.c
+++ b/src/muse.c
@@ -273,12 +273,12 @@ struct monst *mtmp;
 	 * silly trying to use the same cursed horn round after round
 	 */
 	if (mtmp->mconf || mtmp->mstun || !mtmp->mcansee) {
-	    if (!(is_unicorn(mtmp->data) || mtmp->data == &mons[PM_KI_RIN]) && !nohands(mtmp->data)) {
+	    if (!(is_unicorn(mtmp->data) || mtmp->mtyp == PM_KI_RIN) && !nohands(mtmp->data)) {
 			for(obj = mtmp->minvent; obj; obj = obj->nobj)
 				if (obj->otyp == UNICORN_HORN && !obj->cursed)
 				break;
 	    }
-	    if (obj || is_unicorn(mtmp->data) || mtmp->data == &mons[PM_KI_RIN]) {
+	    if (obj || is_unicorn(mtmp->data) || mtmp->mtyp == PM_KI_RIN) {
 			m.defensive = obj;
 			m.has_defense = MUSE_UNICORN_HORN;
 			return TRUE;
@@ -304,7 +304,7 @@ struct monst *mtmp;
 	 * Pestilence won't use healing even when blind.
 	 */
 	if (!mtmp->mcansee && !nohands(mtmp->data) &&
-		mtmp->data != &mons[PM_PESTILENCE]) {
+		mtmp->mtyp != PM_PESTILENCE) {
 	    if ((obj = m_carrying(mtmp, POT_FULL_HEALING)) != 0) {
 		m.defensive = obj;
 		m.has_defense = MUSE_POT_FULL_HEALING;
@@ -349,7 +349,7 @@ struct monst *mtmp;
 	}
 
 	if (levl[x][y].typ == STAIRS && !stuck && !immobile) {
-		if (x == xdnstair && y == ydnstair && !mon_resistance(mtmp,LEVITATION) && mtmp->data != &mons[PM_SMAUG])
+		if (x == xdnstair && y == ydnstair && !mon_resistance(mtmp,LEVITATION) && mtmp->mtyp != PM_SMAUG)
 			m.has_defense = MUSE_DOWNSTAIRS;
 		if (x == xupstair && y == yupstair && ledger_no(&u.uz) != 1)
 	/* Unfair to let the monsters leave the dungeon with the Amulet */
@@ -369,10 +369,10 @@ struct monst *mtmp;
 		for(xx = x-1; xx <= x+1; xx++) for(yy = y-1; yy <= y+1; yy++)
 		if (isok(xx,yy))
 		if (xx != u.ux && yy != u.uy)
-		if ((mtmp->data != &mons[PM_GRID_BUG] && mtmp->data != &mons[PM_BEBELITH]) || xx == x || yy == y)
-		if((mtmp->data != &mons[PM_CLOCKWORK_SOLDIER] && mtmp->data != &mons[PM_CLOCKWORK_DWARF] && 
-		   mtmp->data != &mons[PM_FABERGE_SPHERE] && mtmp->data != &mons[PM_FIREWORK_CART] && 
-		   mtmp->data != &mons[PM_JUGGERNAUT] && mtmp->data != &mons[PM_ID_JUGGERNAUT]) ||
+		if ((mtmp->mtyp != PM_GRID_BUG && mtmp->mtyp != PM_BEBELITH) || xx == x || yy == y)
+		if((mtmp->mtyp != PM_CLOCKWORK_SOLDIER && mtmp->mtyp != PM_CLOCKWORK_DWARF && 
+		   mtmp->mtyp != PM_FABERGE_SPHERE && mtmp->mtyp != PM_FIREWORK_CART && 
+		   mtmp->mtyp != PM_JUGGERNAUT && mtmp->mtyp != PM_ID_JUGGERNAUT) ||
 			(x + xdir[(int)mtmp->mvar_vector] == xx && 
 			   y + ydir[(int)mtmp->mvar_vector] == yy 
 			)
@@ -413,7 +413,7 @@ struct monst *mtmp;
 		for(xx = x-3; xx <= x+3; xx++) for(yy = y-3; yy <= y+3; yy++)
 		if (isok(xx,yy))
 		if ((mon = m_at(xx,yy)) && is_mercenary(mon->data) &&
-				mon->data != &mons[PM_GUARD] &&
+				mon->mtyp != PM_GUARD &&
 				(mon->msleeping || (!mon->mcanmove && mon->mnotlaugh))) {
 			m.defensive = obj;
 			m.has_defense = MUSE_BUGLE;
@@ -446,7 +446,7 @@ struct monst *mtmp;
 		    && !(levl[x][y].wall_info & W_NONDIGGABLE)
 		    && !(Is_botlevel(&u.uz) || In_endgame(&u.uz))
 		    && !(is_ice(x,y) || is_pool(x,y, TRUE) || is_lava(x,y))
-		    && !(mtmp->data == &mons[PM_VLAD_THE_IMPALER]
+		    && !(mtmp->mtyp == PM_VLAD_THE_IMPALER
 			 && In_V_tower(&u.uz))) {
 			m.defensive = obj;
 			m.has_defense = MUSE_WAN_DIGGING;
@@ -482,7 +482,7 @@ struct monst *mtmp;
 		    }
 		}
 
-	    if (mtmp->data != &mons[PM_PESTILENCE]) {
+	    if (mtmp->mtyp != PM_PESTILENCE) {
 		nomore(MUSE_POT_FULL_HEALING);
 		if(obj->otyp == POT_FULL_HEALING) {
 			m.defensive = obj;
@@ -953,7 +953,7 @@ struct monst *mtmp;
 		case 2: return POT_HEALING;
 		case 3: 
 		case 4: return POT_EXTRA_HEALING;
-		case 5: return (mtmp->data != &mons[PM_PESTILENCE]) ?
+		case 5: return (mtmp->mtyp != PM_PESTILENCE) ?
 				POT_FULL_HEALING : POT_SICKNESS;
 		case 7: if (mon_resistance(mtmp,LEVITATION) || mtmp->isshk || mtmp->isgd
 						|| mtmp->ispriest
@@ -1051,7 +1051,7 @@ struct monst *mtmp;
 	if (!ranged_stuff) return FALSE;
 #define nomore(x) if(m.has_offense==x) continue;
 	for(obj=mtmp->minvent; obj; obj=obj->nobj) {
-	    if(mtmp->data == &mons[PM_VALKYRIE] && obj->oartifact == ART_MJOLLNIR && !obj->cursed && mtmp->misc_worn_check & ARM_GLOVES) {
+	    if(mtmp->mtyp == PM_VALKYRIE && obj->oartifact == ART_MJOLLNIR && !obj->cursed && mtmp->misc_worn_check & ARM_GLOVES) {
 			struct obj *otmp;
 			for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
 				if (otmp->owornmask & ARM_GLOVES && otmp->otyp == GAUNTLETS_OF_POWER){
@@ -1857,7 +1857,7 @@ struct monst *mtmp;
 	int xx, yy;
 	boolean immobile = (mdat->mmove == 0);
 	boolean stuck = (mtmp == u.ustuck);
-	boolean nomouth = mdat==&mons[PM_NIGHTGAUNT] || ((mtmp->misc_worn_check & W_ARMH) && which_armor(mtmp, W_ARMH) &&
+	boolean nomouth = mdat->mtyp==PM_NIGHTGAUNT || ((mtmp->misc_worn_check & W_ARMH) && which_armor(mtmp, W_ARMH) &&
 			(((which_armor(mtmp, W_ARMH))->otyp) == PLASTEEL_HELM || ((which_armor(mtmp, W_ARMH))->otyp) == CRYSTAL_HELM || ((which_armor(mtmp, W_ARMH))->otyp) == PONTIFF_S_CROWN))
 			 || ((mtmp->misc_worn_check & W_ARMC) && which_armor(mtmp, W_ARMC)
 				&& (((which_armor(mtmp, W_ARMC))->otyp) == WHITE_FACELESS_ROBE
@@ -1888,10 +1888,10 @@ struct monst *mtmp;
 	  for(xx = x-1; xx <= x+1; xx++)
 	    for(yy = y-1; yy <= y+1; yy++)
 		if (isok(xx,yy) && (xx != u.ux || yy != u.uy))
-		    if ((mdat != &mons[PM_GRID_BUG] && mtmp->data != &mons[PM_BEBELITH]) || xx == x || yy == y)
-			if((mtmp->data != &mons[PM_CLOCKWORK_SOLDIER] && mtmp->data != &mons[PM_CLOCKWORK_DWARF] && 
-			   mtmp->data != &mons[PM_FABERGE_SPHERE] && mtmp->data != &mons[PM_FIREWORK_CART] && 
-			   mtmp->data != &mons[PM_JUGGERNAUT] && mtmp->data != &mons[PM_ID_JUGGERNAUT]) ||
+		    if ((mdat->mtyp != PM_GRID_BUG && mtmp->mtyp != PM_BEBELITH) || xx == x || yy == y)
+			if((mtmp->mtyp != PM_CLOCKWORK_SOLDIER && mtmp->mtyp != PM_CLOCKWORK_DWARF && 
+			   mtmp->mtyp != PM_FABERGE_SPHERE && mtmp->mtyp != PM_FIREWORK_CART && 
+			   mtmp->mtyp != PM_JUGGERNAUT && mtmp->mtyp != PM_ID_JUGGERNAUT) ||
 				(x + xdir[(int)mtmp->mvar_vector] == xx && 
 				   y + ydir[(int)mtmp->mvar_vector] == yy 
 				)
@@ -1921,7 +1921,7 @@ struct monst *mtmp;
 			m.has_misc = MUSE_POT_GAIN_LEVEL;
 		}
 		nomore(MUSE_MASK);
-		if(obj->otyp == MASK && !obj->oartifact && mtmp->data == &mons[PM_POLYPOID_BEING] && !(mons[obj->corpsenm].geno&G_UNIQ)){
+		if(obj->otyp == MASK && !obj->oartifact && mtmp->mtyp == PM_POLYPOID_BEING && !(mons[obj->corpsenm].geno&G_UNIQ)){
 			m.misc = obj;
 			m.has_misc = MUSE_MASK;
 		}
@@ -2412,7 +2412,7 @@ struct monst *mtmp;
 			tmpm->msleeping = 0;
 			if(!tmpm->mcanmove && !rn2(5)) {
 				tmpm->mfrozen = 0;
-				if(tmpm->data != &mons[PM_GIANT_TURTLE] || !(tmpm->mflee))
+				if(tmpm->mtyp != PM_GIANT_TURTLE || !(tmpm->mflee))
 					tmpm->mcanmove = 1;
 			}
 			tmpm->mux = mtmp->mx;
@@ -2485,9 +2485,9 @@ struct obj *obj;
 
 	if (is_animal(mon->data) ||
 		mindless_mon(mon) ||
-		mon->data == &mons[PM_SHADE] ||
-		mon->data == &mons[PM_BROKEN_SHADOW] ||
-		mon->data == &mons[PM_GHOST])	/* don't loot bones piles */
+		mon->mtyp == PM_SHADE ||
+		mon->mtyp == PM_BROKEN_SHADOW ||
+		mon->mtyp == PM_GHOST)	/* don't loot bones piles */
 	    return FALSE;
 
 	if (typ == WAN_MAKE_INVISIBLE || typ == POT_INVISIBILITY)
@@ -2809,7 +2809,7 @@ const char *fmt, *str;
 	    if (fmt && str)
 	    	pline(fmt, str, "boots");
 	    return TRUE;
-	} else if (youracedata == &mons[PM_SILVER_DRAGON]) {
+	} else if (youracedata->mtyp == PM_SILVER_DRAGON) {
 	    if (fmt && str)
 	    	pline(fmt, str, "scales");
 	    return TRUE;

--- a/src/music.c
+++ b/src/music.c
@@ -1258,7 +1258,7 @@ int distance;
 		    distu(mtmp->mx, mtmp->my) < distance) {
 		was_peaceful = mtmp->mpeaceful;
 		mtmp->mpeaceful = 1;
-		if(&mons[urole.neminum] == mtmp->data){
+		if(mtmp->mtyp == urole.neminum){
 			mtmp->mpeacetime = max(mtmp->mpeacetime, ACURR(A_DEX));
 			if(mtmp->mpeacetime < 1) mtmp->mpeacetime = 1;
 		}
@@ -1295,7 +1295,7 @@ int distance;
 		    distu(mtmp->mx, mtmp->my) < distance) {
 		mtmp->msleeping = 0;
 		mtmp->mpeaceful = 1;
-		if(&mons[urole.neminum] == mtmp->data){
+		if(mtmp->mtyp == urole.neminum){
 			mtmp->mpeacetime = max(mtmp->mpeacetime, ACURR(A_DEX));
 			if(mtmp->mpeacetime < 1) mtmp->mpeacetime = 1;
 		}

--- a/src/music.c
+++ b/src/music.c
@@ -201,14 +201,14 @@ boolean domsg;
 	    else if ((instr_otyp == HARP)
 		&& (mtmp->data->mlet == S_NYMPH || is_elf(mtmp->data)
 			|| mtmp->data->mlet == S_CHA_ANGEL
-			|| mtmp->data == &mons[PM_ANGEL]
+			|| mtmp->mtyp == PM_ANGEL
 			|| mtmp->data->mlet == S_NYMPH)
-		&& !(is_drow(mtmp->data) || mtmp->data == &mons[PM_WEEPING_ANGEL] || mtmp->data == &mons[PM_OONA])
+		&& !(is_drow(mtmp->data) || mtmp->mtyp == PM_WEEPING_ANGEL || mtmp->mtyp == PM_OONA)
 		&& (mtmp->mhp*2 > mtmp->mhpmax))
 		    r = max(10,(mtmp->data->mlet == S_NYMPH ? mtmp->m_lev*2 : mtmp->m_lev));
 	    /* parrots (and other birds?) sing along flutes */
 	    if ((instr_otyp == FLUTE)
-		&& (mtmp->data == &mons[PM_PARROT] || mtmp->data->mlet == S_CHA_ANGEL)
+		&& (mtmp->mtyp == PM_PARROT || mtmp->data->mlet == S_CHA_ANGEL)
 		&& (mtmp->mhp*2 > mtmp->mhpmax))
 		    r = max(10,(mtmp->data->mlet == S_NYMPH ? mtmp->m_lev*2 : mtmp->m_lev));
 	    /* undeads sing along horns */
@@ -216,22 +216,22 @@ boolean domsg;
 		     && (mtmp->data->mlet == S_LICH || mtmp->data->mlet == S_MUMMY
 			 || mtmp->data->mlet == S_VAMPIRE || mtmp->data->mlet == S_WRAITH
 			 || mtmp->data->mlet == S_DEMON || mtmp->data->mlet == S_GHOST
-			 || mtmp->data->mlet == S_SHADE || mtmp->data == &mons[PM_OONA] 
-			 || mtmp->data == &mons[PM_CROW] || mtmp->data == &mons[PM_RAVEN]))
+			 || mtmp->data->mlet == S_SHADE || mtmp->mtyp == PM_OONA 
+			 || mtmp->mtyp == PM_CROW || mtmp->mtyp == PM_RAVEN))
 		    r = max(10,(mtmp->data->mlet == S_LICH || mtmp->data->mlet == S_DEMON
 				? mtmp->m_lev*2 : mtmp->m_lev));
 	    /* orcs and ogres sing along (shout, actually) drums and bugles */
 	    else if ((instr_otyp == DRUM || instr_otyp == BUGLE)
 		     && (mtmp->data->mlet == S_ORC
 			 || mtmp->data->mlet == S_OGRE
-			 || (mtmp->data == &mons[PM_TRUMPET_ARCHON] && MON_WEP(mtmp) && !mtmp->mcan)
+			 || (mtmp->mtyp == PM_TRUMPET_ARCHON && MON_WEP(mtmp) && !mtmp->mcan)
 			 || mtmp->data->mlet == S_GIANT))
 		    r = max(10, mtmp->m_lev);
     }
 
     if (domsg && (r > 0)){
 		if (canseemon(mtmp)) {
-			if (mtmp->data == &mons[PM_LILLEND])
+			if (mtmp->mtyp == PM_LILLEND)
 				pline("%s's lovely voice sings your song!", Monnam(mtmp));
 			else if (is_bardmon(mtmp->data))
 				pline("%s skillfully sings along with your song!", Monnam(mtmp));
@@ -240,42 +240,42 @@ boolean domsg;
 				pline("%s's dreadful voice chants your song!", Monnam(mtmp));
 			else if (mtmp->data->mlet == S_MUMMY || mtmp->data->mlet == S_GHOST
 					 || mtmp->data->mlet == S_WRAITH || mtmp->data->mlet == S_SHADE
-					 || mtmp->data == &mons[PM_OONA] 
+					 || mtmp->mtyp == PM_OONA 
 			)
 				pline("%s mourns while you play!", Monnam(mtmp));
-			else if (mtmp->data == &mons[PM_CROW] || mtmp->data == &mons[PM_RAVEN])
+			else if (mtmp->mtyp == PM_CROW || mtmp->mtyp == PM_RAVEN)
 				pline("%s caws and croaks while you play!", Monnam(mtmp));
-			else if (mtmp->data == &mons[PM_PARROT])
+			else if (mtmp->mtyp == PM_PARROT)
 				pline("%s whistles while you play!", Monnam(mtmp));
 			else if (mtmp->data->mlet == S_NYMPH)
 				pline("%s's charming voice sings along!", Monnam(mtmp));
 			else if (mtmp->data->mlet == S_CENTAUR)
 				pline("%s's strong voice sings along!", Monnam(mtmp));
-			else if ((mtmp->data == &mons[PM_TRUMPET_ARCHON] && MON_WEP(mtmp) && !mtmp->mcan))
+			else if ((mtmp->mtyp == PM_TRUMPET_ARCHON && MON_WEP(mtmp) && !mtmp->mcan))
 				pline("%s plays along on %s trumpet!", Monnam(mtmp), hisherits(mtmp));
 			else if (mtmp->data->mlet == S_ORC || mtmp->data->mlet == S_OGRE || mtmp->data->mlet == S_GIANT)
 				pline("%s shouts!", Monnam(mtmp));
 			else
 				pline("%s sings while you play!", Monnam(mtmp));
 		} else {
-			if (mtmp->data == &mons[PM_LILLEND])
+			if (mtmp->mtyp == PM_LILLEND)
 				You_hear("a lovely voice singing your song!");
 			else if (mtmp->data->mlet == S_LICH || mtmp->data->mlet == S_DEMON 
 				|| mtmp->data->mlet == S_VAMPIRE)
 				You_hear("a horrible voice chanting your song!");
 			else if (mtmp->data->mlet == S_MUMMY || mtmp->data->mlet == S_GHOST
 					 || mtmp->data->mlet == S_WRAITH || mtmp->data->mlet == S_SHADE
-					 || mtmp->data == &mons[PM_OONA] )
+					 || mtmp->mtyp == PM_OONA )
 				You_hear("someone mourning while you play!");
-			else if (mtmp->data == &mons[PM_CROW] || mtmp->data == &mons[PM_RAVEN])
+			else if (mtmp->mtyp == PM_CROW || mtmp->mtyp == PM_RAVEN)
 				You_hear("something caw and croak while you play!");
-			else if (mtmp->data == &mons[PM_PARROT])
+			else if (mtmp->mtyp == PM_PARROT)
 				You_hear("something whistle while you play!");
 			else if (mtmp->data->mlet == S_NYMPH)
 				You_hear("a charming voice singing along!");
 			else if (mtmp->data->mlet == S_CENTAUR)
 				You_hear("a strong voice sing along!");
-			else if ((mtmp->data == &mons[PM_TRUMPET_ARCHON] && MON_WEP(mtmp) && !mtmp->mcan))
+			else if ((mtmp->mtyp == PM_TRUMPET_ARCHON && MON_WEP(mtmp) && !mtmp->mcan))
 				pline("a trumpet playing along!");
 			else if (mtmp->data->mlet == S_ORC || mtmp->data->mlet == S_OGRE || mtmp->data->mlet == S_GIANT)
 				You_hear("a shout!");
@@ -299,23 +299,23 @@ boolean domsg;
     if ((mtmp->mcanmove) && (!mtmp->msleeping)
 	&& (!mtmp->mconf) && (!mtmp->mflee) && (!mtmp->mcan)
 	&& (distu(mtmp->mx, mtmp->my) <= 25)) {
-		if(mtmp->data == &mons[PM_DREAD_SERAPH])
+		if(mtmp->mtyp == PM_DREAD_SERAPH)
 			r = -2*mtmp->m_lev;
-		else if(mtmp->data == &mons[PM_AGLAOPE] || mtmp->data == &mons[PM_ELVENKING] || mtmp->data == &mons[PM_BAELNORN])
+		else if(mtmp->mtyp == PM_AGLAOPE || mtmp->mtyp == PM_ELVENKING || mtmp->mtyp == PM_BAELNORN)
 			r = -1*(rnd(20) + mtmp->m_lev/3);
-		else if(mtmp->data == &mons[PM_LILLEND])
+		else if(mtmp->mtyp == PM_LILLEND)
 			r = -1*(rnd(20) + mtmp->m_lev);
 	    else if ((instr_otyp == HARP || instr_otyp == FLUTE)
-		     && (mtmp->data == &mons[PM_CROW] || mtmp->data == &mons[PM_RAVEN]))
+		     && (mtmp->mtyp == PM_CROW || mtmp->mtyp == PM_RAVEN))
 			r = -1*(mtmp->m_lev);
 		else if (mtmp->data->mlet == S_LICH || mtmp->data->mlet == S_DEMON 
 			 || mtmp->data->mlet == S_VAMPIRE)
 			r = -1*(mtmp->m_lev);
 		else if (mtmp->data->mlet == S_MUMMY || mtmp->data->mlet == S_GHOST
 				 || mtmp->data->mlet == S_WRAITH || mtmp->data->mlet == S_SHADE
-				 || mtmp->data == &mons[PM_OONA])
+				 || mtmp->mtyp == PM_OONA)
 			r = -2*(mtmp->m_lev);
-		else if (mtmp->data == &mons[PM_PARROT])
+		else if (mtmp->mtyp == PM_PARROT)
 			r = -1*(mtmp->m_lev);
 		else if (!(instr_otyp == HARP || instr_otyp == FLUTE)
 		     && mtmp->data->mlet == S_NYMPH)
@@ -329,22 +329,22 @@ boolean domsg;
 
     if (domsg && (r < 0)){
 		if (canseemon(mtmp)) {
-			if(mtmp->data == &mons[PM_DREAD_SERAPH])
+			if(mtmp->mtyp == PM_DREAD_SERAPH)
 				pline("%s's terrible voice sings in opposition to your song!", Monnam(mtmp));
-			else if (mtmp->data == &mons[PM_LILLEND])
+			else if (mtmp->mtyp == PM_LILLEND)
 				pline("%s's lovely voice sings in opposition to your song!", Monnam(mtmp));
-			else if (mtmp->data == &mons[PM_AGLAOPE])
+			else if (mtmp->mtyp == PM_AGLAOPE)
 				pline("%s's mocking voice sings in opposition to your song!", Monnam(mtmp));
 			else if (mtmp->data->mlet == S_LICH || mtmp->data->mlet == S_DEMON 
 				|| mtmp->data->mlet == S_VAMPIRE)
 				pline("%s's dreadful voice chants in opposition to your song!", Monnam(mtmp));
 			else if (mtmp->data->mlet == S_MUMMY || mtmp->data->mlet == S_GHOST
 					 || mtmp->data->mlet == S_WRAITH || mtmp->data->mlet == S_SHADE
-					 || mtmp->data == &mons[PM_OONA])
+					 || mtmp->mtyp == PM_OONA)
 				pline("%s wails in opposition to your song!", Monnam(mtmp));
-			else if (mtmp->data == &mons[PM_CROW] || mtmp->data == &mons[PM_RAVEN])
+			else if (mtmp->mtyp == PM_CROW || mtmp->mtyp == PM_RAVEN)
 				pline("%s caws and croaks in opposition to your song!", Monnam(mtmp));
-			else if (mtmp->data == &mons[PM_PARROT])
+			else if (mtmp->mtyp == PM_PARROT)
 				pline("%s squawks in opposition to your song!", Monnam(mtmp));
 			else if (mtmp->data->mlet == S_NYMPH)
 				pline("%s's charming voice sings in opposition to your song!", Monnam(mtmp));
@@ -355,22 +355,22 @@ boolean domsg;
 			else
 				pline("%s sings in opposition to your song!", Monnam(mtmp));
 		} else {
-			if(mtmp->data == &mons[PM_DREAD_SERAPH])
+			if(mtmp->mtyp == PM_DREAD_SERAPH)
 				You_hear("a terrible voice singing in opposition to your song!");
-			else if (mtmp->data == &mons[PM_LILLEND])
+			else if (mtmp->mtyp == PM_LILLEND)
 				You_hear("a lovely voice singing in opposition to your song!");
-			else if (mtmp->data == &mons[PM_AGLAOPE])
+			else if (mtmp->mtyp == PM_AGLAOPE)
 				You_hear("a mocking voice singing in opposition to your song!");
 			else if (mtmp->data->mlet == S_LICH || mtmp->data->mlet == S_DEMON 
 				|| mtmp->data->mlet == S_VAMPIRE)
 				You_hear("a horrible voice chanting in opposition to your song!");
 			else if (mtmp->data->mlet == S_MUMMY || mtmp->data->mlet == S_GHOST
 					 || mtmp->data->mlet == S_WRAITH || mtmp->data->mlet == S_SHADE
-					 || mtmp->data == &mons[PM_OONA])
+					 || mtmp->mtyp == PM_OONA)
 				You_hear("someone wailing in opposition to your song!");
-			else if (mtmp->data == &mons[PM_CROW] || mtmp->data == &mons[PM_RAVEN])
+			else if (mtmp->mtyp == PM_CROW || mtmp->mtyp == PM_RAVEN)
 				You_hear("something caws and croaks in opposition to your song!");
-			else if (mtmp->data == &mons[PM_PARROT])
+			else if (mtmp->mtyp == PM_PARROT)
 				You_hear("something squak in opposition to your song!");
 			else if (mtmp->data->mlet == S_NYMPH)
 				You_hear("a charming voice singing in opposition to your song!");
@@ -632,7 +632,7 @@ struct obj * instr;
 			if (showmsg) msg = "%s seems to briefly swing with your music.";
 		}
 		// angels like the sound of harps
-		if ((mtmp->data == &mons[PM_ANGEL]) && (mtmp->malign >= A_COALIGNED)
+		if ((mtmp->mtyp == PM_ANGEL) && (mtmp->malign >= A_COALIGNED)
 		    && (instr_otyp == HARP))
 			dlev -= dlev0/5;
 		// snakes (and nagas) also like music from flutes
@@ -1120,7 +1120,7 @@ int distance;
 		distm = distu(mtmp->mx, mtmp->my);
 		if (distm < distance) {
 		    mtmp->msleeping = 0;
-			if(mtmp->data != &mons[PM_GIANT_TURTLE] || !(mtmp->mflee)){
+			if(mtmp->mtyp != PM_GIANT_TURTLE || !(mtmp->mflee)){
 			    mtmp->mcanmove = 1;
 			    mtmp->mfrozen = 0;
 				if(mtmp->mux == 0 && mtmp->muy == 0){
@@ -1318,7 +1318,7 @@ awaken_soldiers()
 
 	while(mtmp) {
 	    if (!DEADMONSTER(mtmp) &&
-			is_mercenary(mtmp->data) && mtmp->data != &mons[PM_GUARD]) {
+			is_mercenary(mtmp->data) && mtmp->mtyp != PM_GUARD) {
 		mtmp->mpeaceful = mtmp->msleeping = mtmp->mfrozen = 0;
 		mtmp->mcanmove = 1;
 		if (canseemon(mtmp))

--- a/src/pager.c
+++ b/src/pager.c
@@ -189,7 +189,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 	    char *name, monnambuf[BUFSZ];
 	    boolean accurate = !do_halu;
 
-	    if (mtmp->data == &mons[PM_COYOTE] && accurate)
+	    if (mtmp->mtyp == PM_COYOTE && accurate)
 		name = coyotename(mtmp, monnambuf);
 	    else
 		name = distant_monnam(mtmp, ARTICLE_NONE, monnambuf);
@@ -205,9 +205,9 @@ lookat(x, y, buf, monbuf, shapebuff)
 #else
 		    "tame " :
 #endif
-		    (mtmp->mpeaceful && accurate) ? (mtmp->data==&mons[PM_UVUUDAUM]) ? "meditating " : "peaceful " : "",
+		    (mtmp->mpeaceful && accurate) ? (mtmp->mtyp==PM_UVUUDAUM) ? "meditating " : "peaceful " : "",
 		    name);
-	    if (mtmp->data==&mons[PM_DREAD_SERAPH] && mtmp->mvar2)
+	    if (mtmp->mtyp==PM_DREAD_SERAPH && mtmp->mvar2)
 		Strcat(buf, "praying ");
 		
 	    if (u.ustuck == mtmp)
@@ -337,7 +337,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 				if(u.specialSealsActive&SEAL_ACERERAK && is_undead_mon(mtmp)) ways_seen++;
 				if(uwep && ((uwep->oward & WARD_THJOFASTAFUR) && 
 					((mtmp)->data->mlet == S_LEPRECHAUN || (mtmp)->data->mlet == S_NYMPH || is_thief((mtmp)->data)))) ways_seen++;
-				if(youracedata == &mons[PM_SHARK] && has_blood_mon(mtmp) &&
+				if(youracedata->mtyp == PM_SHARK && has_blood_mon(mtmp) &&
 						(mtmp)->mhp < (mtmp)->mhpmax && is_pool(u.ux, u.uy, TRUE) && is_pool((mtmp)->mx, (mtmp)->my, TRUE)) ways_seen++;
 				if(MATCH_WARN_OF_MON_STRICT(mtmp)){
 					Sprintf(wbuf, "warned of %s",
@@ -369,7 +369,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 					Strcat(monbuf, wbuf);
 					if (ways_seen-- > 1) Strcat(monbuf, ", ");
 					}
-					if(youracedata == &mons[PM_SHARK] && has_blood_mon(mtmp) &&
+					if(youracedata->mtyp == PM_SHARK && has_blood_mon(mtmp) &&
 						(mtmp)->mhp < (mtmp)->mhpmax && is_pool(u.ux, u.uy, TRUE) && is_pool((mtmp)->mx, (mtmp)->my, TRUE)){
 					Sprintf(wbuf, "smell blood in the water");
 					Strcat(monbuf, wbuf);

--- a/src/pager.c
+++ b/src/pager.c
@@ -1429,28 +1429,6 @@ generate_list_of_resistances(struct monst * mtmp, char * temp_buf, int resists)
 	unsigned long mg_flags = mtmp->data->mflagsg;
 	if (resists == 1){
 		mr_flags = mtmp->data->mresists;
-		if(mtmp->mfaction == ZOMBIFIED){
-			mr_flags |= MR_COLD | MR_SLEEP | MR_POISON | MR_DRAIN;
-			mg_flags |= MG_RPIERCE | MG_RBLUNT;
-		}
-		if(mtmp->mfaction == SKELIFIED){
-			mr_flags |= MR_COLD | MR_SLEEP | MR_POISON | MR_DRAIN;
-			mg_flags |= MG_RPIERCE | MG_RSLASH;
-		}
-		if(mtmp->mfaction == CRYSTALFIED){
-			mr_flags |= MR_COLD | MR_SLEEP | MR_POISON | MR_DRAIN;
-			mg_flags |= MG_RPIERCE | MG_RSLASH;
-		}
-		if(mtmp->mfaction == VAMPIRIC){
-			mr_flags |= MR_SLEEP | MR_POISON | MR_DRAIN;
-			if(mtmp->m_lev > 10) mr_flags |= MR_COLD;
-		}
-		if(mtmp->mfaction == PSEUDONATURAL){
-			mr_flags |= MR_POISON;
-		}
-		if(mtmp->mfaction == TOMB_HERD){
-			mr_flags |= MR_FIRE|MR_COLD|MR_SLEEP|MR_STONE|MR_DRAIN|MR_POISON|MR_SICK|MR_MAGIC;
-		}
 	}
 	if (resists == 0)
 		mr_flags = mtmp->data->mconveys;
@@ -1545,7 +1523,7 @@ get_weakness_description_of_monster_type(struct monst * mtmp, char * description
 	if (many) {
 		strcat(description, "Weak to ");
 		strcat(description, temp_buf);
-		strcat(description, ".");
+		strcat(description, ". ");
 	}
 	return description;
 }
@@ -1557,7 +1535,7 @@ get_conveys_description_of_monster_type(struct monst * mtmp, char * description)
 	char temp_buf[BUFSZ] = "";
 	temp_buf[0] = '\0';
 	int count = generate_list_of_resistances(mtmp, temp_buf, 0);
-	if ((ptr->geno & G_NOCORPSE) != 0 || mtmp->mfaction == SKELIFIED || mtmp->mfaction == CRYSTALFIED) {
+	if ((ptr->geno & G_NOCORPSE) != 0) {
 		strcat(description, "Leaves no corpse. ");
 	}
 	else if (count == 0) {
@@ -1775,15 +1753,6 @@ char *
 get_speed_description_of_monster_type(struct monst * mtmp, char * description)
 {
 	int speed = mtmp->data->mmove;
-	switch (mtmp->mfaction)
-	{
-	case ZOMBIFIED:
-		speed = max(6, speed * 1/2);
-		break;
-	case SKELIFIED:
-		speed = max(6, speed * 3/4);
-		break;
-	}
 	if (speed > 35) {
 		sprintf(description, "Extremely fast (%d). ", speed);
 	}
@@ -2111,7 +2080,6 @@ get_description_of_monster_type(struct monst * mtmp, char * description)
 			strcat(description, "Base statistics of this monster type:");
 			strcat(description, "\n");
 			int ac = 10-(ptr->nac+ptr->dac+ptr->pac);
-			ac += (mtmp->mfaction == CRYSTALFIED ? -16 : mtmp->mfaction == SKELIFIED ? -6 : mtmp->mfaction == ZOMBIFIED ? -2 : 0);
 			sprintf(temp_buf, "Base level = %d. Difficulty = %d. AC = %d. MR = %d. Alignment %d. ", ptr->mlevel, monstr[monsndx(ptr)], ac, ptr->mr, ptr->maligntyp);
 			strcat(description, temp_buf);
 			temp_buf[0] = '\0';

--- a/src/pline.c
+++ b/src/pline.c
@@ -445,8 +445,8 @@ register struct monst *mtmp;
 	aligntyp alignment;
 	char info[BUFSZ], monnambuf[BUFSZ];
 
-	if (mtmp->ispriest || mtmp->data == &mons[PM_ALIGNED_PRIEST]
-				|| mtmp->data == &mons[PM_ANGEL])
+	if (mtmp->ispriest || mtmp->mtyp == PM_ALIGNED_PRIEST
+				|| mtmp->mtyp == PM_ANGEL)
 		alignment = EPRI(mtmp)->shralign;
 	else
 		alignment = mtmp->data->maligntyp;
@@ -467,10 +467,10 @@ register struct monst *mtmp;
 #endif
 	}
 	else if (mtmp->mpeaceful){
-		if(mtmp->data == &mons[PM_UVUUDAUM]) Strcat(info, ", in contemplative meditation");
+		if(mtmp->mtyp == PM_UVUUDAUM) Strcat(info, ", in contemplative meditation");
 		else Strcat(info, ", peaceful");
 	}
-	else if (mtmp->data==&mons[PM_DREAD_SERAPH] && mtmp->mvar2)  Strcat(info, ", in prayer");
+	else if (mtmp->mtyp==PM_DREAD_SERAPH && mtmp->mvar2)  Strcat(info, ", in prayer");
 	else if (mtmp->mtraitor)  Strcat(info, ", traitor");
 	else if (mtmp->mferal)  Strcat(info, ", feral");
 	if (mtmp->meating)	  Strcat(info, ", eating");
@@ -496,7 +496,7 @@ register struct monst *mtmp;
 				  /* [arbitrary reason why it isn't moving] */
 	else if (mtmp->mstrategy & STRAT_WAITMASK)
 				  Strcat(info, ", meditating");
-	else if (mtmp->mflee && mtmp->data != &mons[PM_BANDERSNATCH]) Strcat(info, ", scared");
+	else if (mtmp->mflee && mtmp->mtyp != PM_BANDERSNATCH) Strcat(info, ", scared");
 	if (mtmp->mtrapped)	  Strcat(info, ", trapped");
 	if (mtmp->mspeed)	  Strcat(info,
 					mtmp->mspeed == MFAST ? ", fast" :

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -631,7 +631,7 @@ int	mntmp;
 		pline(use_thec,monsterc,"spin a web");
 	    if (u.umonnum == PM_GREMLIN)
 		pline(use_thec,monsterc,"multiply in a fountain");
-	    if (is_unicorn(youmonst.data) || youmonst.data == &mons[PM_KI_RIN])
+	    if (is_unicorn(youmonst.data) || youmonst.data->mtyp == PM_KI_RIN)
 		pline(use_thec,monsterc,"use your horn");
 	    if (is_mind_flayer(youmonst.data))
 		pline(use_thec,monsterc,"emit a mental blast");
@@ -639,7 +639,7 @@ int	mntmp;
 		pline(use_thec,monsterc,"shriek");
 	    if (youmonst.data->msound == MS_JUBJUB)
 		pline(use_thec,monsterc,"scream");
-	    if (youmonst.data == &mons[PM_TOVE])
+	    if (youmonst.data->mtyp == PM_TOVE)
 		pline(use_thec,monsterc,"gimble a hole in the ground");
 		if (attacktype(youracedata, AT_LNCK) || attacktype(youracedata, AT_LRCH))
 		pline(use_thec,monsterc,"attack a distant target");
@@ -1312,7 +1312,7 @@ dogaze()
 			* affects you if the monster is still alive.
 			*/
 			if (!DEADMONSTER(mtmp) &&
-				(mtmp->data == &mons[PM_FLOATING_EYE]) && !mtmp->mcan) {
+				(mtmp->mtyp == PM_FLOATING_EYE) && !mtmp->mcan) {
 				if (!Free_action) {
 					You("are frozen by %s gaze!",
 						s_suffix(mon_nam(mtmp)));
@@ -1332,7 +1332,7 @@ dogaze()
 			* effect would be too weird.
 			*/
 			if (!DEADMONSTER(mtmp) &&
-				(mtmp->data == &mons[PM_MEDUSA]) && !mtmp->mcan) {
+				(mtmp->mtyp == PM_MEDUSA) && !mtmp->mcan) {
 				pline(
 					"Gazing at the awake %s is not a very good idea.",
 					l_monnam(mtmp));
@@ -1476,19 +1476,19 @@ dogaze()
 				int mndx;
 				struct monst *mtmp2;
 				struct monst *mtmp3;
-				if(youracedata ==  &mons[PM_MIGO_PHILOSOPHER]){
+				if(youracedata->mtyp ==  PM_MIGO_PHILOSOPHER){
 					n = rnd(4);
 					pline("Whirling snow swirls out from around you.");
 					mndx = PM_ICE_VORTEX;
-				} else if(youracedata == &mons[PM_MIGO_QUEEN]){
+				} else if(youracedata->mtyp == PM_MIGO_QUEEN){
 					n = rnd(2);
 					pline("Scalding steam swirls out from around you.");
 					mndx = PM_STEAM_VORTEX;
-				} else if(youracedata == &mons[PM_SWAMP_FERN]){
+				} else if(youracedata->mtyp == PM_SWAMP_FERN){
 					n = 1;
 					You("release a spore.");
 					mndx = PM_SWAMP_FERN_SPORE;
-				} else if(youracedata == &mons[PM_BURNING_FERN]){
+				} else if(youracedata->mtyp == PM_BURNING_FERN){
 					n = 1;
 					You("release a spore.");
 					mndx = PM_BURNING_FERN_SPORE;
@@ -1534,7 +1534,7 @@ dogaze()
 		     * affects you if the monster is still alive.
 		     */
 		    if (!DEADMONSTER(mtmp) &&
-			  (mtmp->data==&mons[PM_FLOATING_EYE]) && !mtmp->mcan) {
+			  (mtmp->mtyp==PM_FLOATING_EYE) && !mtmp->mcan) {
 			if (!Free_action) {
 			    You("are frozen by %s gaze!",
 					     s_suffix(mon_nam(mtmp)));
@@ -1553,7 +1553,7 @@ dogaze()
 		     * effect would be too weird.
 		     */
 		    if (!DEADMONSTER(mtmp) &&
-			    (mtmp->data == &mons[PM_MEDUSA]) && !mtmp->mcan) {
+			    (mtmp->mtyp == PM_MEDUSA) && !mtmp->mcan) {
 			pline(
 			 "Gazing at the awake %s is not a very good idea.",
 			    l_monnam(mtmp));
@@ -2046,31 +2046,31 @@ int part;
 	    if (mptr->mlet == S_DOG || mptr->mlet == S_FELINE ||
 		    mptr->mlet == S_YETI)
 		return part == HAND ? "paw" : "pawed";
-		if(mon == &youmonst && youracedata == &mons[PM_HALF_DRAGON])
+		if(mon == &youmonst && youracedata->mtyp == PM_HALF_DRAGON)
 			return part == HAND ? "claw" : "clawed";
-		if(mon->data == &mons[PM_HALF_DRAGON])
+		if(mon->mtyp == PM_HALF_DRAGON)
 			return part == HAND ? "claw" : "clawed";
 	    if (humanoid(mptr) && attacktype(mptr, AT_CLAW) &&
 		    !index(not_claws, mptr->mlet) &&
-		    mptr != &mons[PM_STONE_GOLEM] &&
-		    mptr != &mons[PM_SENTINEL_OF_MITHARDIR] &&
-		    mptr != &mons[PM_INCUBUS] && mptr != &mons[PM_SUCCUBUS])
+		    mptr->mtyp != PM_STONE_GOLEM &&
+		    mptr->mtyp != PM_SENTINEL_OF_MITHARDIR &&
+		    mptr->mtyp != PM_INCUBUS && mptr->mtyp != PM_SUCCUBUS)
 		return part == HAND ? "claw" : "clawed";
 	}
-	if ((mptr == &mons[PM_MUMAK] || mptr == &mons[PM_MASTODON]) &&
+	if ((mptr->mtyp == PM_MUMAK || mptr->mtyp == PM_MASTODON) &&
 		part == NOSE)
 	    return "trunk";
-	if (mptr == &mons[PM_SHARK] && part == HAIR)
+	if (mptr->mtyp == PM_SHARK && part == HAIR)
 	    return "skin";	/* sharks don't have scales */
-	if (mptr == &mons[PM_JELLYFISH] && (part == ARM || part == FINGER ||
+	if (mptr->mtyp == PM_JELLYFISH && (part == ARM || part == FINGER ||
 	    part == HAND || part == FOOT || part == TOE))
 	    return "tentacle";
-	if (mptr == &mons[PM_FLOATING_EYE] && part == EYE)
+	if (mptr->mtyp == PM_FLOATING_EYE && part == EYE)
 	    return "cornea";
-	if (mptr == &mons[PM_RAVEN] || mptr == &mons[PM_CROW])
+	if (mptr->mtyp == PM_RAVEN || mptr->mtyp == PM_CROW)
 	    return bird_parts[part];
 	if (mptr->mlet == S_CENTAUR || mptr->mlet == S_UNICORN ||
-		(mptr == &mons[PM_ROTHE] && part != HAIR))
+		(mptr->mtyp == PM_ROTHE && part != HAIR))
 	    return horse_parts[part];
 	if (mptr->mlet == S_LIGHT) {
 		if (part == HANDED) return "rayed";
@@ -2081,13 +2081,13 @@ int part;
 	if (mptr->mlet == S_EYE && !is_auton(mptr))
 	    return sphere_parts[part];
 	if (mptr->mlet == S_JELLY || mptr->mlet == S_PUDDING ||
-		mptr->mlet == S_BLOB || mptr == &mons[PM_JELLYFISH])
+		mptr->mlet == S_BLOB || mptr->mtyp == PM_JELLYFISH)
 	    return jelly_parts[part];
 	if (mptr->mlet == S_VORTEX || mptr->mlet == S_ELEMENTAL)
 	    return vortex_parts[part];
 	if (mptr->mlet == S_FUNGUS)
 	    return fungus_parts[part];
-	if (mptr->mlet == S_EEL && mptr != &mons[PM_JELLYFISH])
+	if (mptr->mlet == S_EEL && mptr->mtyp != PM_JELLYFISH)
 	    return fish_parts[part];
 	if (mptr->mlet == S_ANT)
 		return insect_parts[part];

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -68,8 +68,7 @@ init_uasmon()
 void
 set_uasmon()
 {
-	set_mon_data(&youmonst, ((u.umonnum == u.umonster) ? 
-					&upermonst : &mons[u.umonnum]), 0);
+	set_mon_data(&youmonst, u.umonnum, 0);
 }
 
 /** Returns true if the player monster is genocided. */

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -68,7 +68,7 @@ init_uasmon()
 void
 set_uasmon()
 {
-	set_mon_data(&youmonst, u.umonnum, 0);
+	set_mon_data(&youmonst, u.umonnum);
 }
 
 /** Returns true if the player monster is genocided. */

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1235,7 +1235,7 @@ dovampminion()
 	} else {
 		struct monst *mtmp = makemon(pm, u.ux, u.uy, MM_EDOG|MM_ADJACENTOK);
 		mtmp = tamedog(mtmp, (struct obj *) 0);
-		mtmp->mfaction = VAMPIRIC;
+		set_faction(mtmp, VAMPIRIC);
 
 		if (onfloor) useupf(corpse, 1);
 		else useup(corpse);

--- a/src/potion.c
+++ b/src/potion.c
@@ -1409,26 +1409,26 @@ boolean your_fault;
 		}
 	break;
 	case POT_BLOOD:{
-		int mnum = obj->corpsenm;
-		if(acidic(&mons[mnum]) && !Acid_resistance){
+		int mtyp = obj->corpsenm;
+		if(acidic(&mons[mtyp]) && !Acid_resistance){
 		    pline("This burns%s!", obj->blessed ? " a little" :
 				    obj->cursed ? " a lot" : "");
 		    losehp(d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8),
 				    "potion of acidic blood", KILLED_BY_AN);
 		}
-		if(freezing(&mons[mnum]) && !Cold_resistance){
+		if(freezing(&mons[mtyp]) && !Cold_resistance){
 		    pline("This burns%s!", obj->blessed ? " a little" :
 				    obj->cursed ? " a lot" : "");
 		    losehp(d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8),
 				    "potion of cryonic blood", KILLED_BY_AN);
 		}
-		if(burning(&mons[mnum]) && !Fire_resistance){
+		if(burning(&mons[mtyp]) && !Fire_resistance){
 		    pline("This burns%s!", obj->blessed ? " a little" :
 				    obj->cursed ? " a lot" : "");
 		    losehp(d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8),
 				    "potion of scalding blood", KILLED_BY_AN);
 		}
-		if(poisonous(&mons[mnum]) && !Poison_resistance){
+		if(poisonous(&mons[mtyp]) && !Poison_resistance){
 			if (Upolyd) {
 			    if (u.mh <= 5) u.mh = 1; else u.mh -= 5;
 			} else {
@@ -1438,12 +1438,12 @@ boolean your_fault;
 			losestr(1);
 			exercise(A_CON, FALSE);
 		}
-		if (touch_petrifies(&mons[mnum])) {
+		if (touch_petrifies(&mons[mtyp])) {
 		    if (!Stone_resistance &&
 			!(poly_when_stoned(youracedata) && polymon(PM_STONE_GOLEM))) {
 			if (!Stoned) Stoned = 5;
 			killer_format = KILLED_BY;
-			Sprintf(killer_buf, "%s blood", mons[mnum].mname);
+			Sprintf(killer_buf, "%s blood", mons[mtyp].mname);
 			delayed_killer = killer_buf;
 		    }
 		}
@@ -1705,8 +1705,8 @@ boolean your_fault;
 		}
 		break;
 	case POT_BLOOD:{
-		int mnum = obj->corpsenm;
-		if(acidic(&mons[mnum]) && !resists_acid(mon)){
+		int mtyp = obj->corpsenm;
+		if(acidic(&mons[mtyp]) && !resists_acid(mon)){
 		    pline("%s %s in pain!", Monnam(mon),
 			  is_silent_mon(mon) ? "writhes" : "shrieks");
 		    mon->mhp -= d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8);
@@ -1717,7 +1717,7 @@ boolean your_fault;
 			    monkilled(mon, "", AD_ACID);
 			}
 		}
-		if(freezing(&mons[mnum]) && !resists_cold(mon)){
+		if(freezing(&mons[mtyp]) && !resists_cold(mon)){
 		    pline("%s %s in pain!", Monnam(mon),
 			  is_silent_mon(mon) ? "writhes" : "shrieks");
 		    mon->mhp -= d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8);
@@ -1728,7 +1728,7 @@ boolean your_fault;
 			    monkilled(mon, "", AD_COLD);
 			}
 		}
-		if(burning(&mons[mnum]) && !resists_fire(mon)){
+		if(burning(&mons[mtyp]) && !resists_fire(mon)){
 		    pline("%s %s in pain!", Monnam(mon),
 			  is_silent_mon(mon) ? "writhes" : "shrieks");
 		    mon->mhp -= d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8);
@@ -1739,7 +1739,7 @@ boolean your_fault;
 			    monkilled(mon, "", AD_FIRE);
 			}
 		}
-		if(poisonous(&mons[mnum]) && !resists_poison(mon)){
+		if(poisonous(&mons[mtyp]) && !resists_poison(mon)){
 			if((mon->mhpmax > 3) && !resist(mon, POTION_CLASS, 0, NOTELL))
 				mon->mhpmax /= 2;
 			if((mon->mhp > 2) && !resist(mon, POTION_CLASS, 0, NOTELL))
@@ -1748,7 +1748,7 @@ boolean your_fault;
 			if (canseemon(mon))
 				pline("%s looks rather ill.", Monnam(mon));
 		}
-		if (touch_petrifies(&mons[mnum]) && !resists_ston(mon)) {
+		if (touch_petrifies(&mons[mtyp]) && !resists_ston(mon)) {
 			minstapetrify(mon, TRUE);
 		}
 	}break;

--- a/src/potion.c
+++ b/src/potion.c
@@ -513,7 +513,7 @@ peffects(otmp)
 		    if (u.ulycn >= LOW_PM && !Race_if(PM_HUMAN_WEREWOLF)) {
 			You("forget your affinity to %s!",
 					makeplural(mons[u.ulycn].mname));
-			if (youracedata == &mons[u.ulycn])
+			if (youracedata->mtyp == u.ulycn)
 			    you_unwere(FALSE);
 			u.ulycn = NON_PM;	/* cure lycanthropy */
 		    }
@@ -557,7 +557,7 @@ peffects(otmp)
 				if (u.ulycn >= LOW_PM) {
 					Your("affinity to %s disappears!",
 					 makeplural(mons[u.ulycn].mname));
-					if (youracedata == &mons[u.ulycn])
+					if (youracedata->mtyp == u.ulycn)
 					you_unwere(FALSE);
 					u.ulycn = NON_PM;	/* cure lycanthropy */
 				}
@@ -607,7 +607,7 @@ peffects(otmp)
 				if (u.ulycn >= LOW_PM) {
 					Your("affinity to %s disappears!",
 					 makeplural(mons[u.ulycn].mname));
-					if (youracedata == &mons[u.ulycn])
+					if (youracedata->mtyp == u.ulycn)
 					you_unwere(FALSE);
 					u.ulycn = NON_PM;	/* cure lycanthropy */
 				}
@@ -1901,7 +1901,7 @@ register struct obj *obj;
 		} else if (u.ulycn >= LOW_PM) {
 		    /* vapor from [un]holy water will trigger
 		       transformation but won't cure lycanthropy */
-		    if (obj->blessed && youmonst.data == &mons[u.ulycn])
+		    if (obj->blessed && youmonst.data->mtyp == u.ulycn)
 			you_unwere(FALSE);
 		    else if (obj->cursed && !Upolyd)
 			you_were();
@@ -1913,7 +1913,7 @@ register struct obj *obj;
 		} else if (u.ulycn >= LOW_PM) {
 		    /* vapor from [un]holy water will trigger
 		       transformation but won't cure lycanthropy */
-		    if (youmonst.data == &mons[u.ulycn])
+		    if (youmonst.data->mtyp == u.ulycn)
 				you_unwere(FALSE);
 		}
 		break;

--- a/src/potion.c
+++ b/src/potion.c
@@ -1463,7 +1463,7 @@ boolean your_fault;
 	case POT_HEALING:
 	case POT_EXTRA_HEALING:
 	case POT_FULL_HEALING:
-		if (mon->data == &mons[PM_PESTILENCE]) goto do_illness;
+		if (mon->mtyp == PM_PESTILENCE) goto do_illness;
 		/*FALLTHRU*/
 	case POT_GOAT_S_MILK:
 	case POT_RESTORE_ABILITY:
@@ -1477,7 +1477,7 @@ boolean your_fault;
 		}
 		break;
 	case POT_SICKNESS:
-		if (mon->data == &mons[PM_PESTILENCE]) goto do_healing;
+		if (mon->mtyp == PM_PESTILENCE) goto do_healing;
 		if (dmgtype(mon->data, AD_DISE) ||
 			   dmgtype(mon->data, AD_PEST) || /* won't happen, see prior goto */
 			   resists_poison(mon)) {
@@ -1557,14 +1557,14 @@ boolean your_fault;
 				!Protection_from_shape_changers)
 			    new_were(mon);	/* transform into beast */
 		    }
-		} else if(mon->data == &mons[PM_GREMLIN]) {
+		} else if(mon->mtyp == PM_GREMLIN) {
 		    angermon = FALSE;
 		    (void)split_mon(mon, (struct monst *)0);
-		} else if(mon->data == &mons[PM_FLAMING_SPHERE] ||
-			mon->data == &mons[PM_IRON_GOLEM] || mon->data == &mons[PM_CHAIN_GOLEM]) {
+		} else if(mon->mtyp == PM_FLAMING_SPHERE ||
+			mon->mtyp == PM_IRON_GOLEM || mon->mtyp == PM_CHAIN_GOLEM) {
 		    if (canseemon(mon))
 			pline("%s %s.", Monnam(mon),
-				(mon->data == &mons[PM_IRON_GOLEM] || mon->data == &mons[PM_CHAIN_GOLEM]) ?
+				(mon->mtyp == PM_IRON_GOLEM || mon->mtyp == PM_CHAIN_GOLEM) ?
 				"rusts" : "flickers");
 		    mon->mhp -= d(1,6);
 		    if (mon->mhp < 1) {
@@ -1589,14 +1589,14 @@ boolean your_fault;
 			}
 			else if (is_were(mon->data) && !is_human(mon->data))
 			    new_were(mon);	/* revert to human */
-		} else if(mon->data == &mons[PM_GREMLIN]) {
+		} else if(mon->mtyp == PM_GREMLIN) {
 		    angermon = FALSE;
 		    (void)split_mon(mon, (struct monst *)0);
-		} else if(mon->data == &mons[PM_FLAMING_SPHERE] ||
-			mon->data == &mons[PM_IRON_GOLEM] || mon->data == &mons[PM_CHAIN_GOLEM]) {
+		} else if(mon->mtyp == PM_FLAMING_SPHERE ||
+			mon->mtyp == PM_IRON_GOLEM || mon->mtyp == PM_CHAIN_GOLEM) {
 		    if (canseemon(mon))
 			pline("%s %s.", Monnam(mon),
-				(mon->data == &mons[PM_IRON_GOLEM] || mon->data == &mons[PM_CHAIN_GOLEM]) ?
+				(mon->mtyp == PM_IRON_GOLEM || mon->mtyp == PM_CHAIN_GOLEM) ?
 				"rusts" : "flickers");
 		    mon->mhp -= d(1,6);
 		    if (mon->mhp < 1) {

--- a/src/pray.c
+++ b/src/pray.c
@@ -723,7 +723,7 @@ int ga_num;
 	if(ga_num == GA_MOTHER){
 		struct monst *mtmp;
 		for(mtmp = migrating_mons; mtmp; mtmp = mtmp->nmon){
-			if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && (mtmp->data == &mons[PM_BLESSED] || mtmp->data == &mons[PM_MOUTH_OF_THE_GOAT])){
+			if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && (mtmp->mtyp == PM_BLESSED || mtmp->mtyp == PM_MOUTH_OF_THE_GOAT)){
 				mtmp->mpeaceful = 0;
 				mtmp->mtame = 0;
 				set_malign(mtmp);
@@ -3499,7 +3499,7 @@ doturn()
 			    if(!Race_if(PM_VAMPIRE)) pline("Unfortunately, your voice falters.");
 			    else pline("Unfortunately, your concentration falters.");
 			}
-			if(mtmp->data != &mons[PM_BANDERSNATCH]) mtmp->mflee = 0;
+			if(mtmp->mtyp != PM_BANDERSNATCH) mtmp->mflee = 0;
 			mtmp->mfrozen = 0;
 			mtmp->mcanmove = 1;
 		    } else if (!resist(mtmp, '\0', 0, TELL)) {
@@ -4083,7 +4083,7 @@ int x, y;
 {
 	struct monst *mtmp;
 	for(mtmp = migrating_mons; mtmp; mtmp = mtmp->nmon){
-		if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && mtmp->data == &mons[PM_MOUTH_OF_THE_GOAT]){
+		if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && mtmp->mtyp == PM_MOUTH_OF_THE_GOAT){
 			xchar xlocale, ylocale, xyloc;
 			xyloc	= mtmp->mtrack[0].x;
 			xlocale = mtmp->mtrack[1].x;
@@ -4093,7 +4093,7 @@ int x, y;
 		}
 	}
 	for(mtmp = fmon; mtmp; mtmp = mtmp->nmon){
-		if(mtmp->data == &mons[PM_MOUTH_OF_THE_GOAT] && distu(mtmp->mx,mtmp->my) == 1){
+		if(mtmp->mtyp == PM_MOUTH_OF_THE_GOAT && distu(mtmp->mx,mtmp->my) == 1){
 			return TRUE;
 		}
 	}
@@ -4224,7 +4224,7 @@ struct obj *otmp;
 		//The Black Goat is pleased
 		struct monst *mtmp;
 		for(mtmp = migrating_mons; mtmp; mtmp = mtmp->nmon){
-			if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && (mtmp->data == &mons[PM_BLESSED] || mtmp->data == &mons[PM_MOUTH_OF_THE_GOAT])){
+			if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && (mtmp->mtyp == PM_BLESSED || mtmp->mtyp == PM_MOUTH_OF_THE_GOAT)){
 				mtmp->mpeaceful = 1;
 				set_malign(mtmp);
 			}

--- a/src/pray.c
+++ b/src/pray.c
@@ -2565,7 +2565,7 @@ aligntyp alignment;
     register struct permonst *pm;
  */
     const int *minions = god_minions(gptr);
-    int mnum=NON_PM, mlev, num = 0, first, last;
+    int mtyp=NON_PM, mlev, num = 0, first, last;
 	struct monst *mon = (struct monst *)0;
 	
 	mlev = level_difficulty();
@@ -2574,7 +2574,7 @@ aligntyp alignment;
 	    if (!(mvitals[minions[first]].mvflags & G_GONE && !In_quest(&u.uz)) && monstr[minions[first]] > mlev-5) break;
 	if(minions[first] == NON_PM){ //All minions too weak, or no minions
 		if(first == 0) return;
-		else mnum = minions[first-1];
+		else mtyp = minions[first-1];
 	}
 	else for (last = first; minions[last] != NON_PM; last++)
 	    if (!(mvitals[minions[last]].mvflags & G_GONE && !In_quest(&u.uz))) {
@@ -2585,7 +2585,7 @@ aligntyp alignment;
 
 	if(!num){ //All minions too strong, or gap between weak and strong minions
 		if(first == 0) return;
-		else mnum = minions[first-1];
+		else mtyp = minions[first-1];
 	}
 /*	Assumption:	minions are presented in ascending order of strength. */
 	else{
@@ -2599,14 +2599,14 @@ aligntyp alignment;
 			}
 	    }
 		first--; /* correct an off-by-one error */
-		mnum = minions[first];
+		mtyp = minions[first];
 	}
 
 
-    if (mnum == NON_PM) {
+    if (mtyp == NON_PM) {
 		mon = (struct monst *)0;
     }
-	else mon = make_pet_minion(mnum,alignment);
+	else mon = make_pet_minion(mtyp,alignment);
 	
     if (mon) {
 	switch ((int)alignment) {
@@ -2636,11 +2636,11 @@ lawful_god_gives_angel()
     register struct monst *mtmp2;
     register struct permonst *pm;
 */
-    int mnum;
+    int mtyp;
     int mon;
 
-    // mnum = lawful_minion(u.ulevel);
-    // mon = make_pet_minion(mnum,A_LAWFUL);
+    // mtyp = lawful_minion(u.ulevel);
+    // mon = make_pet_minion(mtyp,A_LAWFUL);
     // pline("%s", Blind ? "You feel the presence of goodness." :
 	 // "There is a puff of white fog!");
     // if (u.uhp > (u.uhpmax / 10)) godvoice(Align2gangr(u.ualign.type), "My minion shall serve thee!");

--- a/src/priest.c
+++ b/src/priest.c
@@ -334,21 +334,21 @@ char *pname;		/* caller-supplied output buffer */
 
 	Strcpy(pname, "the ");
 	if (mon->minvis) Strcat(pname, "invisible ");
-	if ((mon->ispriest && !&mons[PM_HIGH_SHAMAN]) || mon->data == &mons[PM_ALIGNED_PRIEST] ||
-					mon->data == &mons[PM_ANGEL]) {
+	if ((mon->ispriest && !&mons[PM_HIGH_SHAMAN]) || mon->mtyp == PM_ALIGNED_PRIEST ||
+					mon->mtyp == PM_ANGEL) {
 		/* use epri */
-		if (mon->mtame && mon->data == &mons[PM_ANGEL])
+		if (mon->mtame && mon->mtyp == PM_ANGEL)
 			Strcat(pname, "guardian ");
-		if (mon->data == &mons[PM_ANGEL]) {
+		if (mon->mtyp == PM_ANGEL) {
 			Strcat(pname, what);
 			Strcat(pname, " ");
 		}
-		if (mon->data != &mons[PM_ANGEL]) {
+		if (mon->mtyp != PM_ANGEL) {
 			if (!mon->ispriest && EPRI(mon)->renegade)
 				Strcat(pname, "renegade ");
-			if (mon->data == &mons[PM_HIGH_PRIEST])
+			if (mon->mtyp == PM_HIGH_PRIEST)
 				Strcat(pname, "high ");
-			if (mon->data == &mons[PM_ELDER_PRIEST])
+			if (mon->mtyp == PM_ELDER_PRIEST)
 				Strcat(pname, "elder ");
 			if (Hallucination)
 				Strcat(pname, "poohbah ");
@@ -359,7 +359,7 @@ char *pname;		/* caller-supplied output buffer */
 		}
 		Strcat(pname, "of ");
 		/* Astral Call bugfix by Patric Muller, tweaked by CM*/
-		if (mon->data == &mons[PM_HIGH_PRIEST] && !Hallucination &&
+		if (mon->mtyp == PM_HIGH_PRIEST && !Hallucination &&
 		            Is_astralevel(&u.uz) && distu(mon->mx, mon->my) > 2) {
 			Strcat(pname, "a whole faith");
 //			Strcat(pname, "?");
@@ -425,10 +425,10 @@ register int roomno;
 	if(!temple_occupied(u.urooms0)) {
 	    if(tended) {
 			shrined = has_shrine(priest);
-			sanctum = ( (priest->data == &mons[PM_HIGH_PRIEST] || priest->data == &mons[PM_ELDER_PRIEST]) &&
+			sanctum = ( (priest->mtyp == PM_HIGH_PRIEST || priest->mtyp == PM_ELDER_PRIEST) &&
 				   (Is_sanctum(&u.uz) || In_endgame(&u.uz)));
 			can_speak = (priest->mcanmove && priest->mnotlaugh && !priest->msleeping &&
-					 flags.soundok && priest->data != &mons[PM_BLASPHEMOUS_LURKER]);
+					 flags.soundok && priest->mtyp != PM_BLASPHEMOUS_LURKER);
 			if (can_speak) {
 				unsigned save_priest = priest->ispriest;
 				/* don't reveal the altar's owner upon temple entry in
@@ -782,7 +782,7 @@ boolean peaceful;
 	register struct monst *roamer;
 	register boolean coaligned = (u.ualign.type == alignment);
 
-	if (ptr != &mons[PM_ALIGNED_PRIEST] && ptr != &mons[PM_ANGEL])
+	if (ptr->mtyp != PM_ALIGNED_PRIEST && ptr->mtyp != PM_ANGEL)
 		return((struct monst *)0);
 	
 	if (MON_AT(x, y)) (void) rloc(m_at(x, y), FALSE);	/* insurance */
@@ -808,8 +808,8 @@ void
 reset_hostility(roamer)
 register struct monst *roamer;
 {
-	if(!(roamer->isminion && (roamer->data == &mons[PM_ALIGNED_PRIEST] ||
-				  roamer->data == &mons[PM_ANGEL])))
+	if(!(roamer->isminion && (roamer->mtyp == PM_ALIGNED_PRIEST ||
+				  roamer->mtyp == PM_ANGEL)))
 	        return;
 
 	if(EPRI(roamer)->shralign != u.ualign.type) {

--- a/src/priest.c
+++ b/src/priest.c
@@ -461,7 +461,7 @@ register int roomno;
 					msg1 = "You are not welcome here!";
 				} else msg1 = "You desecrate this place by your presence!";
 				if(canseemon(priest)) pline("As you approach, the priest suddenly putrefies and melts into a foul-smelling liquid mass!");
-				set_mon_data(priest, &mons[PM_DARKNESS_GIVEN_HUNGER], 0);
+				set_mon_data(priest, PM_DARKNESS_GIVEN_HUNGER, 0);
 				priest->mpeaceful = 0;
 				set_malign(priest);
 			} else if(Is_astralevel(&u.uz) && Role_if(PM_ANACHRONONAUT) && EPRI(priest)->shralign == A_LAWFUL) {
@@ -470,7 +470,7 @@ register int roomno;
 					set_malign(priest);
 				}
 				msg1 = "I SEE YOU!";
-				set_mon_data(priest, &mons[PM_LUGRIBOSSK], 0);
+				set_mon_data(priest, PM_LUGRIBOSSK, 0);
 				//Assumes High Priest is 25, Lugribossk is 27 (archon)
 				priest->m_lev = 27;
 				priest->mhp = 8*26 + rn2(8);

--- a/src/priest.c
+++ b/src/priest.c
@@ -461,7 +461,7 @@ register int roomno;
 					msg1 = "You are not welcome here!";
 				} else msg1 = "You desecrate this place by your presence!";
 				if(canseemon(priest)) pline("As you approach, the priest suddenly putrefies and melts into a foul-smelling liquid mass!");
-				set_mon_data(priest, PM_DARKNESS_GIVEN_HUNGER, 0);
+				set_mon_data(priest, PM_DARKNESS_GIVEN_HUNGER);
 				priest->mpeaceful = 0;
 				set_malign(priest);
 			} else if(Is_astralevel(&u.uz) && Role_if(PM_ANACHRONONAUT) && EPRI(priest)->shralign == A_LAWFUL) {
@@ -470,7 +470,7 @@ register int roomno;
 					set_malign(priest);
 				}
 				msg1 = "I SEE YOU!";
-				set_mon_data(priest, PM_LUGRIBOSSK, 0);
+				set_mon_data(priest, PM_LUGRIBOSSK);
 				//Assumes High Priest is 25, Lugribossk is 27 (archon)
 				priest->m_lev = 27;
 				priest->mhp = 8*26 + rn2(8);

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -181,7 +181,7 @@ boolean impaired;				/* TRUE if throwing/firing slipped OR magr is confused/stun
 	/* determine if thrownobj should return (like Mjollnir) */
 	if (magr && !(hmoncode & HMON_KICKED) && (
 		(Race_if(PM_ANDROID) && !launcher && youagr) ||	/* there's no android monster helper? */
-		(thrownobj->oartifact == ART_MJOLLNIR && (youagr ? (Role_if(PM_VALKYRIE)) : magr ? (magr->data == &mons[PM_VALKYRIE]) : FALSE)) ||
+		(thrownobj->oartifact == ART_MJOLLNIR && (youagr ? (Role_if(PM_VALKYRIE)) : magr ? (magr->mtyp == PM_VALKYRIE) : FALSE)) ||
 		(thrownobj->oartifact == ART_AXE_OF_THE_DWARVISH_LORDS && (youagr ? (Race_if(PM_DWARF)) : magr ? (is_dwarf(magr->data)) : FALSE)) ||
 		thrownobj->oartifact == ART_SICKLE_MOON ||
 		thrownobj->oartifact == ART_ANNULUS ||
@@ -1179,7 +1179,7 @@ boolean * wepgone;				/* pointer to: TRUE if projectile has been destroyed */
 	if (youagr && mdef->mtame) {
 		if (mdef->mcanmove &&
 			(!is_animal(mdef->data)) &&
-			(!mindless_mon(mdef) || (mdef->data == &mons[PM_CROW_WINGED_HALF_DRAGON] && thrownobj->oartifact == ART_YORSHKA_S_SPEAR)) &&
+			(!mindless_mon(mdef) || (mdef->mtyp == PM_CROW_WINGED_HALF_DRAGON && thrownobj->oartifact == ART_YORSHKA_S_SPEAR)) &&
 			!launcher
 			) {
 			if (vis) {
@@ -1398,7 +1398,7 @@ boolean * swapped;
 	at leader.... */
 	pline("%s catches %s.", Monnam(mon), the(xname(obj)));
 	if (mon->mpeaceful) {
-		if (Race_if(PM_ELF) && mon->data == &mons[PM_CELEBORN]){
+		if (Race_if(PM_ELF) && mon->mtyp == PM_CELEBORN){
 			boolean next2u = monnear(mon, u.ux, u.uy);
 			if (obj->oartifact == ART_PALANTIR_OF_WESTERNESSE &&
 				yn("If you prefer, we can use the Palantir to secure the city, and you can use my bow in your travels.") == 'y'
@@ -1428,7 +1428,7 @@ boolean * swapped;
 		else if (Race_if(PM_DROW)){
 			boolean next2u = monnear(mon, u.ux, u.uy);
 			if (quest_status.got_thanks) finish_quest(obj);
-			if (obj->oartifact == ART_SILVER_STARLIGHT && quest_status.got_thanks && mon->data == &mons[PM_ECLAVDRA] &&
+			if (obj->oartifact == ART_SILVER_STARLIGHT && quest_status.got_thanks && mon->mtyp == PM_ECLAVDRA &&
 				yn("Do you wish to take the Wrathful Spider, instead of this?") == 'y'
 				){
 				*swapped = TRUE;
@@ -1446,7 +1446,7 @@ boolean * swapped;
 				obj = addinv(obj);	/* into your inventory */
 				(void)encumber_msg();
 			}
-			else if (obj->oartifact == ART_TENTACLE_ROD && quest_status.got_thanks && mon->data == &mons[PM_SEYLL_AUZKOVYN] &&
+			else if (obj->oartifact == ART_TENTACLE_ROD && quest_status.got_thanks && mon->mtyp == PM_SEYLL_AUZKOVYN &&
 				yn("Do you wish to take the Crescent Blade, instead of this?") == 'y'
 				){
 				*swapped = TRUE;
@@ -1464,7 +1464,7 @@ boolean * swapped;
 				obj = addinv(obj);	/* into your inventory */
 				(void)encumber_msg();
 			}
-			else if (obj->oartifact == ART_DARKWEAVER_S_CLOAK && quest_status.got_thanks && mon->data == &mons[PM_ECLAVDRA] &&
+			else if (obj->oartifact == ART_DARKWEAVER_S_CLOAK && quest_status.got_thanks && mon->mtyp == PM_ECLAVDRA &&
 				yn("Do you wish to take Spidersilk, instead of this?") == 'y'
 				){
 				*swapped = TRUE;
@@ -1482,7 +1482,7 @@ boolean * swapped;
 				obj = addinv(obj);	/* into your inventory */
 				(void)encumber_msg();
 			}
-			else if (obj->oartifact == ART_TENTACLE_ROD && quest_status.got_thanks && mon->data == &mons[PM_DARUTH_XAXOX] &&
+			else if (obj->oartifact == ART_TENTACLE_ROD && quest_status.got_thanks && mon->mtyp == PM_DARUTH_XAXOX &&
 				yn("Do you wish to take the Webweaver's Crook, instead of this?") == 'y'
 				){
 				*swapped = TRUE;
@@ -2642,9 +2642,9 @@ int tary;
 
 	/* Random breath attacks */
 	if (typ == AD_RBRE){
-		if (pa == &mons[PM_CHROMATIC_DRAGON])
+		if (pa->mtyp == PM_CHROMATIC_DRAGON)
 			typ = chromatic_dragon_breaths[rn2(SIZE(chromatic_dragon_breaths))];
-		else if (pa == &mons[PM_PLATINUM_DRAGON])
+		else if (pa->mtyp == PM_PLATINUM_DRAGON)
 			typ = platinum_dragon_breaths[rn2(SIZE(platinum_dragon_breaths))];
 		else 
 			typ = random_breaths[rn2(SIZE(random_breaths))];
@@ -2741,7 +2741,7 @@ int tary;
 	/* cancelled monsters can't spit */
 	if (!youagr && magr->mcan) {
 		/* except for Zeta metroids, which uncancel themselves */
-		if (magr->data == &mons[PM_ZETA_METROID]) //|| mtmp->data==&mons[PM_CRAZY_CHEMIST]) 
+		if (magr->mtyp == PM_ZETA_METROID) //|| mtmp->mtyp==PM_CRAZY_CHEMIST) 
 			magr->mcan = FALSE;
 		else {
 			if (flags.soundok)

--- a/src/quest.c
+++ b/src/quest.c
@@ -464,7 +464,7 @@ STATIC_OVL void
 prisoner_speaks(mtmp)
 	register struct monst *mtmp;
 {
-	if (mtmp->data == &mons[PM_PRISONER] &&
+	if (mtmp->mtyp == PM_PRISONER &&
 			(mtmp->mstrategy & STRAT_WAITMASK)) {
 	    /* Awaken the prisoner */
 	    if (canseemon(mtmp))
@@ -478,7 +478,7 @@ prisoner_speaks(mtmp)
 
 		/* ...But the guards are not */
 	    (void) angry_guards(FALSE);
-	} else if ((mtmp->data == &mons[PM_MINDLESS_THRALL] || mtmp->data == &mons[PM_A_GONE]) &&
+	} else if ((mtmp->mtyp == PM_MINDLESS_THRALL || mtmp->mtyp == PM_A_GONE) &&
 			(mtmp->mstrategy & STRAT_WAITMASK)) {
 	    /* Awaken the prisoner */
 	    if (canseemon(mtmp))
@@ -516,23 +516,23 @@ quest_chat(mtmp)
 		return;
     }
 	
-	if(Role_if(PM_ANACHRONONAUT) && mtmp->data == &mons[PM_ELDER_BRAIN]){
+	if(Role_if(PM_ANACHRONONAUT) && mtmp->mtyp == PM_ELDER_BRAIN){
 		pline("%s",elderBrain[rn2(SIZE(elderBrain))]);
 		return;
 	}
 	
 	if(
 		(Role_if(PM_NOBLEMAN) && 
-			(mtmp->data == &mons[PM_KNIGHT] 
-				|| mtmp->data == &mons[PM_MAID]) && mtmp->mpeaceful)
+			(mtmp->mtyp == PM_KNIGHT 
+				|| mtmp->mtyp == PM_MAID) && mtmp->mpeaceful)
 	  || (Role_if(PM_ANACHRONONAUT) && 
-			(mtmp->data == &mons[PM_MYRKALFAR_WARRIOR] || mtmp->data == &mons[PM_ALIDER] 
-				|| mtmp->data == &mons[PM_MYRKALFAR_MATRON]) && mtmp->mpeaceful)
+			(mtmp->mtyp == PM_MYRKALFAR_WARRIOR || mtmp->mtyp == PM_ALIDER 
+				|| mtmp->mtyp == PM_MYRKALFAR_MATRON) && mtmp->mpeaceful)
 	  || (Race_if(PM_DROW) && is_drow(mtmp->data))
 	  || (Role_if(PM_EXILE) && 
-			mtmp->data == &mons[PM_PEASANT] && mtmp->mpeaceful)
-	  || (Race_if(PM_GNOME) && Role_if(PM_RANGER) && (mtmp->data == &mons[PM_GNOME] || mtmp->data == &mons[PM_GNOME_LORD] || mtmp->data == &mons[PM_GNOME_KING]
-			|| mtmp->data == &mons[PM_TINKER_GNOME] || mtmp->data == &mons[PM_GNOMISH_WIZARD]) && mtmp->mpeaceful)
+			mtmp->mtyp == PM_PEASANT && mtmp->mpeaceful)
+	  || (Race_if(PM_GNOME) && Role_if(PM_RANGER) && (mtmp->mtyp == PM_GNOME || mtmp->mtyp == PM_GNOME_LORD || mtmp->mtyp == PM_GNOME_KING
+			|| mtmp->mtyp == PM_TINKER_GNOME || mtmp->mtyp == PM_GNOMISH_WIZARD) && mtmp->mpeaceful)
 	){
 		chat_with_guardian();
 	} else {
@@ -719,7 +719,7 @@ turn_stag()
 			for(tm = fmon; tm; tm = tm->nmon){
 				if(tm->mfaction == EDDER_SYMBOL || 
 					tm->mfaction == XAXOX || 
-					tm->data == &mons[PM_EDDERKOP]
+					tm->mtyp == PM_EDDERKOP
 				){
 					tm->housealert = 1;
 					tm->mpeaceful = 1;

--- a/src/quest.c
+++ b/src/quest.c
@@ -680,7 +680,7 @@ turn_stag()
 	{
 		struct monst *tm;
 		for(tm = fmon; tm; tm = tm->nmon){
-			if(tm->data == &mons[urole.ldrnum]){
+			if(tm->mtyp == urole.ldrnum){
 				tm->housealert = 1;
 				tm->mpeaceful = 1;
 				tm->mstrategy = STRAT_CLOSE;

--- a/src/read.c
+++ b/src/read.c
@@ -3135,7 +3135,7 @@ int how;
 	    }
 	} else {
 	    Strcpy(buf, ptr->mname); /* make sure we have standard singular */
-	    if ((ptr->geno & G_UNIQ) && ptr != &mons[PM_HIGH_PRIEST])
+	    if ((ptr->geno & G_UNIQ) && ptr->mtyp != PM_HIGH_PRIEST)
 		which = !type_is_pname(ptr) ? "the " : "";
 	}
 	if (how & REALLY) {

--- a/src/region.c
+++ b/src/region.c
@@ -1177,7 +1177,7 @@ genericptr_t p2;
     reg = (NhRegion *) p1;
     dam = (int)(intptr_t)reg->arg;
     if (p2 == NULL) {		/* This means *YOU* Bozo! */
-		if (youracedata == &mons[PM_SENTINEL_OF_MITHARDIR]){
+		if (youracedata->mtyp == PM_SENTINEL_OF_MITHARDIR){
 			healup(dam, 0, FALSE, FALSE);
 		}
 		if (nonliving(youracedata) || Breathless)
@@ -1207,7 +1207,7 @@ genericptr_t p2;
     } else {			/* A monster is inside the cloud */
 		mtmp = (struct monst *) p2;
 
-		if (mtmp->data == &mons[PM_SENTINEL_OF_MITHARDIR]){
+		if (mtmp->mtyp == PM_SENTINEL_OF_MITHARDIR){
 			mtmp->mhp = min(mtmp->mhp+dam, mtmp->mhpmax);
 		}
 		/* Non living or non breathing are not concerned */

--- a/src/restore.c
+++ b/src/restore.c
@@ -275,7 +275,7 @@ boolean ghostly;
 			mtmp->m_id = nid;
 		}
 		if (mtmp->data) {
-			set_mon_data(mtmp, mtmp->mtyp, 0);
+			set_mon_data(mtmp, mtmp->mtyp);
 		}
 		if (ghostly) {
 			int mndx = monsndx(mtmp->data);

--- a/src/restore.c
+++ b/src/restore.c
@@ -401,6 +401,7 @@ unsigned int *stuckid, *steedid;	/* STEED */
 	if (remember_discover) discover = remember_discover;
 
 	role_init(FALSE);	/* Reset the initial role, race, gender, and alignment */
+	id_permonst();		/* re-generate index numbers of the permonst array */
 #ifdef AMII_GRAPHICS
 	amii_setpens(amii_numcolors);	/* use colors from save file */
 #endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -274,9 +274,8 @@ boolean ghostly;
 			add_id_mapping(mtmp->m_id, nid);
 			mtmp->m_id = nid;
 		}
-		if (moved && mtmp->data) {
-			int offset = mtmp->data - monbegin;	/*(ptrdiff_t)*/
-			mtmp->data = mons + offset;  /* new permonst location */
+		if (mtmp->data) {
+			set_mon_data(mtmp, mtmp->mtyp, 0);
 		}
 		if (ghostly) {
 			int mndx = monsndx(mtmp->data);

--- a/src/role.c
+++ b/src/role.c
@@ -1348,7 +1348,7 @@ god_priest(gptr, sx, sy, sanctum)
 			priest->female = FALSE;
 			if(!sanctum){
 				newcham(priest,PM_DROW_ALIENIST,FALSE,FALSE);
-				priest->mfaction = XAXOX;
+				set_faction(priest, XAXOX);
 			}
 			return priest;
 		}
@@ -1356,7 +1356,7 @@ god_priest(gptr, sx, sy, sanctum)
 			priest->female = FALSE;
 			if(!sanctum){
 				newcham(priest,PM_HEDROW_BLADEMASTER,FALSE,FALSE);
-				priest->mfaction = LOLTH_SYMBOL;
+				set_faction(priest, LOLTH_SYMBOL);
 			}
 			return priest;
 		}
@@ -1364,7 +1364,7 @@ god_priest(gptr, sx, sy, sanctum)
 			priest->female = FALSE;
 			if(!sanctum){
 				newcham(priest,PM_DROW_MATRON,FALSE,FALSE);
-				priest->mfaction = LOLTH_SYMBOL;
+				set_faction(priest, LOLTH_SYMBOL);
 			}
 			return priest;
 		}
@@ -1373,7 +1373,7 @@ god_priest(gptr, sx, sy, sanctum)
 			priest->female = FALSE;
 			if(!sanctum){
 				newcham(priest,PM_HEDROW_WIZARD,FALSE,FALSE);
-				priest->mfaction = LOLTH_SYMBOL;
+				set_faction(priest, LOLTH_SYMBOL);
 			}
 			return priest;
 		}
@@ -1381,7 +1381,7 @@ god_priest(gptr, sx, sy, sanctum)
 			if(!sanctum){
 				if(priest->female) newcham(priest,PM_PRIESTESS_OF_GHAUNADAUR,FALSE,FALSE);
 				else newcham(priest,PM_PRIEST_OF_GHAUNADAUR,FALSE,FALSE);
-				priest->mfaction = GHAUNADAUR_SYMBOL;
+				set_faction(priest, GHAUNADAUR_SYMBOL);
 			}
 			return priest;
 		}

--- a/src/role.c
+++ b/src/role.c
@@ -1347,7 +1347,7 @@ god_priest(gptr, sx, sy, sanctum)
 		if(gptr == DrowMaleLgodKnown || gptr == DrowMaleLgodUknwn){
 			priest->female = FALSE;
 			if(!sanctum){
-				newcham(priest,&mons[PM_DROW_ALIENIST],FALSE,FALSE);
+				newcham(priest,PM_DROW_ALIENIST,FALSE,FALSE);
 				priest->mfaction = XAXOX;
 			}
 			return priest;
@@ -1355,7 +1355,7 @@ god_priest(gptr, sx, sy, sanctum)
 		if(gptr == DrowMaleNgod){
 			priest->female = FALSE;
 			if(!sanctum){
-				newcham(priest,&mons[PM_HEDROW_BLADEMASTER],FALSE,FALSE);
+				newcham(priest,PM_HEDROW_BLADEMASTER,FALSE,FALSE);
 				priest->mfaction = LOLTH_SYMBOL;
 			}
 			return priest;
@@ -1363,7 +1363,7 @@ god_priest(gptr, sx, sy, sanctum)
 		if(gptr == DrowMaleCgod){
 			priest->female = FALSE;
 			if(!sanctum){
-				newcham(priest,&mons[PM_DROW_MATRON],FALSE,FALSE);
+				newcham(priest,PM_DROW_MATRON,FALSE,FALSE);
 				priest->mfaction = LOLTH_SYMBOL;
 			}
 			return priest;
@@ -1372,39 +1372,39 @@ god_priest(gptr, sx, sy, sanctum)
 		if(gptr == DrowNobMaleNgod){
 			priest->female = FALSE;
 			if(!sanctum){
-				newcham(priest,&mons[PM_HEDROW_WIZARD],FALSE,FALSE);
+				newcham(priest,PM_HEDROW_WIZARD,FALSE,FALSE);
 				priest->mfaction = LOLTH_SYMBOL;
 			}
 			return priest;
 		}
 		if(gptr == DrowNobMaleCgod){
 			if(!sanctum){
-				if(priest->female) newcham(priest,&mons[PM_PRIESTESS_OF_GHAUNADAUR],FALSE,FALSE);
-				else newcham(priest,&mons[PM_PRIEST_OF_GHAUNADAUR],FALSE,FALSE);
+				if(priest->female) newcham(priest,PM_PRIESTESS_OF_GHAUNADAUR,FALSE,FALSE);
+				else newcham(priest,PM_PRIEST_OF_GHAUNADAUR,FALSE,FALSE);
 				priest->mfaction = GHAUNADAUR_SYMBOL;
 			}
 			return priest;
 		}
 		if(gptr == DrowFemaleLgod){
 			priest->female = TRUE;
-			if(!sanctum) newcham(priest,&mons[PM_STJARNA_ALFR],FALSE,FALSE);
+			if(!sanctum) newcham(priest,PM_STJARNA_ALFR,FALSE,FALSE);
 			return priest;
 		}
 		if(gptr == DrowNobFemaleLgod){
 			priest->female = TRUE;
-			if(!sanctum) newcham(priest,&mons[PM_DROW_MATRON],FALSE,FALSE);
+			if(!sanctum) newcham(priest,PM_DROW_MATRON,FALSE,FALSE);
 			//ver'tas
 			return priest;
 		}
 		if(gptr == DrowFemaleNgod){
 			priest->female = TRUE;
-			if(!sanctum) newcham(priest,&mons[PM_DROW_MATRON],FALSE,FALSE);
+			if(!sanctum) newcham(priest,PM_DROW_MATRON,FALSE,FALSE);
 			//NKiaransali
 			return priest;
 		}
 		if(gptr == DrowFemaleCgod){
 			priest->female = TRUE;
-			if(!sanctum) newcham(priest,&mons[PM_DROW_MATRON],FALSE,FALSE);
+			if(!sanctum) newcham(priest,PM_DROW_MATRON,FALSE,FALSE);
 			//Lolth
 			return priest;
 		}

--- a/src/role.c
+++ b/src/role.c
@@ -2830,7 +2830,7 @@ struct monst *mtmp;
 	case PM_KNIGHT:
 	    return ("Salutations"); /* Olde English */
 	case PM_SAMURAI:
-	    return (mtmp && mtmp->data == &mons[PM_SHOPKEEPER] ?
+	    return (mtmp && mtmp->mtyp == PM_SHOPKEEPER ?
 	    		"Irasshaimase" : "Konnichi wa"); /* Japanese */
 	case PM_PIRATE:
 		return ("Ahoy");
@@ -2841,7 +2841,7 @@ struct monst *mtmp;
 	case PM_VALKYRIE:
 	    return (
 #ifdef MAIL
-	    		mtmp && mtmp->data == &mons[PM_MAIL_DAEMON] ? "Hallo" :
+	    		mtmp && mtmp->mtyp == PM_MAIL_DAEMON ? "Hallo" :
 #endif
 	    		"Velkommen");   /* Norse */
 	default:

--- a/src/seduce.c
+++ b/src/seduce.c
@@ -63,25 +63,25 @@ struct attack *mattk;
 		)
 		return 0;
 
-	if(pagr == &mons[PM_SMALL_GOAT_SPAWN] || pagr == &mons[PM_GOAT_SPAWN] || pagr == &mons[PM_GIANT_GOAT_SPAWN])
+	if(pagr->mtyp == PM_SMALL_GOAT_SPAWN || pagr->mtyp == PM_GOAT_SPAWN || pagr->mtyp == PM_GIANT_GOAT_SPAWN)
 		return 1;
 	
-	if(pagr->mlet == S_NYMPH || pagr == &mons[PM_INCUBUS] || pagr == &mons[PM_SUCCUBUS]
-			|| pagr == &mons[PM_CARMILLA] || pagr == &mons[PM_VLAD_THE_IMPALER] || pagr == &mons[PM_LEVISTUS]){
+	if(pagr->mlet == S_NYMPH || pagr->mtyp == PM_INCUBUS || pagr->mtyp == PM_SUCCUBUS
+			|| pagr->mtyp == PM_CARMILLA || pagr->mtyp == PM_VLAD_THE_IMPALER || pagr->mtyp == PM_LEVISTUS){
 		if(genagr == 1 - gendef)
 			return 1;
 		else
-			return (pagr->mlet == S_NYMPH || pagr == &mons[PM_LEVISTUS]) ? 2 : 0;
+			return (pagr->mlet == S_NYMPH || pagr->mtyp == PM_LEVISTUS) ? 2 : 0;
 	}
-	else if(pagr == &mons[PM_MOTHER_LILITH] || pagr == &mons[PM_BELIAL]
-		 /*|| pagr == &mons[PM_SHAMI_AMOURAE]*/){
+	else if(pagr->mtyp == PM_MOTHER_LILITH || pagr->mtyp == PM_BELIAL
+		 /*|| pagr->mtyp == PM_SHAMI_AMOURAE*/){
 		if(genagr == 1 - gendef) return 1;
 		else return 0;
 	}
-	else if(pagr == &mons[PM_FIERNA]) return 2;
-	else if(pagr == &mons[PM_ALRUNES]) return (genagr == gendef) ? 1 : 2;
-	else if(pagr == &mons[PM_MALCANTHET] || pagr == &mons[PM_GRAZ_ZT]
-		 || pagr == &mons[PM_PALE_NIGHT] || pagr == &mons[PM_AVATAR_OF_LOLTH]) 
+	else if(pagr->mtyp == PM_FIERNA) return 2;
+	else if(pagr->mtyp == PM_ALRUNES) return (genagr == gendef) ? 1 : 2;
+	else if(pagr->mtyp == PM_MALCANTHET || pagr->mtyp == PM_GRAZ_ZT
+		 || pagr->mtyp == PM_PALE_NIGHT || pagr->mtyp == PM_AVATAR_OF_LOLTH) 
 			return 1;
 	else return 0;
 }

--- a/src/shk.c
+++ b/src/shk.c
@@ -3818,10 +3818,10 @@ register struct monst *shkp;
 	    remove_damage(shkp, FALSE);
 
 	if((udist = distu(omx,omy)) < 3 &&
-		((shkp->data != &mons[PM_GRID_BUG] && shkp->data != &mons[PM_BEBELITH]) || (omx==u.ux || omy==u.uy)) &&
-		((shkp->data != &mons[PM_CLOCKWORK_SOLDIER] && shkp->data != &mons[PM_CLOCKWORK_DWARF] && 
-		   shkp->data != &mons[PM_FABERGE_SPHERE] && shkp->data != &mons[PM_FIREWORK_CART] && 
-		   shkp->data != &mons[PM_JUGGERNAUT] && shkp->data != &mons[PM_ID_JUGGERNAUT]) ||
+		((shkp->mtyp != PM_GRID_BUG && shkp->mtyp != PM_BEBELITH) || (omx==u.ux || omy==u.uy)) &&
+		((shkp->mtyp != PM_CLOCKWORK_SOLDIER && shkp->mtyp != PM_CLOCKWORK_DWARF && 
+		   shkp->mtyp != PM_FABERGE_SPHERE && shkp->mtyp != PM_FIREWORK_CART && 
+		   shkp->mtyp != PM_JUGGERNAUT && shkp->mtyp != PM_ID_JUGGERNAUT) ||
 			(omx + xdir[(int)shkp->mvar_vector] == u.ux && 
 			   omy + ydir[(int)shkp->mvar_vector] == u.uy 
 			)
@@ -4463,8 +4463,8 @@ register boolean silent;
 
 	for (mtmp = fmon; mtmp; mtmp = mtmp2) {
 	    mtmp2 = mtmp->nmon;
-	    if (mtmp->data->mlet == S_KETER && (mtmp->data == &mons[PM_MALKUTH_SEPHIRAH] || 
-											mtmp->data == &mons[PM_YESOD_SEPHIRAH])) {
+	    if (mtmp->data->mlet == S_KETER && (mtmp->mtyp == PM_MALKUTH_SEPHIRAH || 
+											mtmp->mtyp == PM_YESOD_SEPHIRAH)) {
 		if (canspotmon(mtmp)) cnt++;
 		mongone(mtmp);
 	    }

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -792,9 +792,9 @@ struct mkroom	*sroom;
 	
 	//Note: these two don't have a shopkeeper struct
 	if(In_outlands(&u.uz) && !Is_gatetown(&u.uz))
-		newcham(shk, &mons[PM_PLUMACH_RILMANI], FALSE, FALSE);
+		newcham(shk, PM_PLUMACH_RILMANI, FALSE, FALSE);
 	else if (ESHK(shk)->shoptype == SEAFOOD)
-		newcham(shk, &mons[PM_DEEP_ONE], FALSE, FALSE);
+		newcham(shk, PM_DEEP_ONE, FALSE, FALSE);
 	
 	return(sh);
 }

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -659,7 +659,7 @@ dosounds()
     if (Is_oracle_level(&u.uz) && !rn2(400)) {
 	/* make sure the Oracle is still here */
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon)
-	    if (!DEADMONSTER(mtmp) && mtmp->data == &mons[PM_ORACLE])
+	    if (!DEADMONSTER(mtmp) && mtmp->mtyp == PM_ORACLE)
 		break;
 	/* and don't produce silly effects when she's clearly visible */
 	if (mtmp && (hallu || !canseemon(mtmp))) {
@@ -678,7 +678,7 @@ dosounds()
 		} else if(messagen == 4){
 			struct monst *tmpm;
 			for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
-				if(tmpm->data == &mons[PM_WOODCHUCK]){
+				if(tmpm->mtyp == PM_WOODCHUCK){
 					if (resists_death(tmpm)) {
 						// if (canseemon(tmpm))
 							// pline("%s seems no deader than before.", Monnam(tmpm));
@@ -690,7 +690,7 @@ dosounds()
 				}
 			}
 			if(!tmpm){ /*pointer is stale, but still nonzero*/
-				if(youracedata == &mons[PM_WOODCHUCK]){
+				if(youracedata->mtyp == PM_WOODCHUCK){
 					You("have an out of body experience."); //You are hallucinating if you got this message
 				}
 			}
@@ -924,7 +924,7 @@ boolean chatting;
 	}
 	
 	/* Make sure its your role's quest quardian; adjust if not */
-	if (ptr->msound == MS_GUARDIAN && ptr != &mons[urole.guardnum] && ptr != &mons[PM_CELEBORN]){
+	if (ptr->msound == MS_GUARDIAN && ptr != &mons[urole.guardnum] && ptr->mtyp != PM_CELEBORN){
 		int mndx = monsndx(ptr);
 		ptr = &mons[genus(mndx,1)];
 	}
@@ -960,12 +960,12 @@ boolean chatting;
 		}
 	}
 	switch (
-		(mtmp->mfaction == SKELIFIED && ptr != &mons[PM_ECHO]) ? MS_BONES : 
+		(mtmp->mfaction == SKELIFIED && ptr->mtyp != PM_ECHO) ? MS_BONES : 
 		is_silent_mon(mtmp) ? MS_SILENT : 
 		(is_dollable(mtmp->data) && mtmp->m_insight_level) ? MS_STATS : 
 		mtmp->ispriest ? MS_PRIEST : 
 		mtmp->isshk ? MS_SELL : 
-		(mtmp->data == &mons[PM_RHYMER] && !mtmp->mspec_used) ? MS_SONG : 
+		(mtmp->mtyp == PM_RHYMER && !mtmp->mspec_used) ? MS_SONG : 
 		ptr->msound
 	) {
 	case MS_ORACLE:
@@ -1053,11 +1053,11 @@ asGuardian:
 	    		};
 			if (kindred)
 			    verbl_msg = "This is my hunting ground that you dare to prowl!";
-			else if (youracedata == &mons[PM_SILVER_DRAGON] ||
-				 youracedata == &mons[PM_BABY_SILVER_DRAGON]) {
+			else if (youracedata->mtyp == PM_SILVER_DRAGON ||
+				 youracedata->mtyp == PM_BABY_SILVER_DRAGON) {
 			    /* Silver dragons are silver in color, not made of silver */
 			    Sprintf(verbuf, "%s! Your silver sheen does not frighten me!",
-					youracedata == &mons[PM_SILVER_DRAGON] ?
+					youracedata->mtyp == PM_SILVER_DRAGON ?
 					"Fool" : "Young Fool");
 			    verbl_msg = verbuf; 
 			} else {
@@ -1079,7 +1079,7 @@ asGuardian:
 		if (flags.moonphase == FULL_MOON && (night() ^ !rn2(13))) {
 			pline("%s throws back %s head and lets out a blood curdling %s!",
 				  Monnam(mtmp), mhis(mtmp),
-				  ptr == &mons[PM_HUMAN_WERERAT] ? "shriek" : "howl");
+				  ptr->mtyp == PM_HUMAN_WERERAT ? "shriek" : "howl");
 			wake_nearto_noisy(mtmp->mx, mtmp->my, 11*11);
 		} else
 			pline_msg =
@@ -1096,7 +1096,7 @@ asGuardian:
 		else if (mtmp->mtame && EDOG(mtmp)->hungrytime > moves + 1000)
 		    pline_msg = "yips.";
 		else {
-		    if (mtmp->data != &mons[PM_DINGO])	/* dingos do not actually bark */
+		    if (mtmp->mtyp != PM_DINGO)	/* dingos do not actually bark */
 			    pline_msg = "barks.";
 		}
 	    } else {
@@ -1129,7 +1129,7 @@ asGuardian:
 	    pline_msg = "squeaks.";
 	    break;
 	case MS_SQAWK:
-	    if (ptr == &mons[PM_RAVEN] && !mtmp->mpeaceful)
+	    if (ptr->mtyp == PM_RAVEN && !mtmp->mpeaceful)
 	    	verbl_msg = "Nevermore!";
 	    else
 	    	pline_msg = "squawks.";
@@ -1424,12 +1424,12 @@ asGuardian:
 		int ix, iy, i;
 		boolean inrange = FALSE;
 		if(noactions(mtmp)) break;
-		if((ptr == &mons[PM_INTONER] && !rn2(5)) || ptr == &mons[PM_BLACK_FLOWER]){
+		if((ptr->mtyp == PM_INTONER && !rn2(5)) || ptr->mtyp == PM_BLACK_FLOWER){
 			if (!canspotmon(mtmp))
 				map_invisible(mtmp->mx, mtmp->my);
 			switch(rnd(4)){
 				case 1:
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s screams melodiously.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s screams melodiously.", Monnam(mtmp));
 					else pline("%s sings the song of broken eyes.", Monnam(mtmp));
 					
 					for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -1449,7 +1449,7 @@ asGuardian:
 					}
 				break;
 				case 2:
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s sings a resonant note.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s sings a resonant note.", Monnam(mtmp));
 					else pline("%s sings a harmless song of ruin.", Monnam(mtmp));
 					ix = rn2(COLNO);
 					iy = rn2(ROWNO);
@@ -1469,7 +1469,7 @@ asGuardian:
 				break;
 				case 3:{
 					struct obj *ispe = mksobj(SPE_TURN_UNDEAD,TRUE,FALSE);
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s wails deafeningly.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s wails deafeningly.", Monnam(mtmp));
 					else pline("%s sings the song of the day of repentance.", Monnam(mtmp));
 					//Rapture invisible creatures
 					for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -1503,7 +1503,7 @@ asGuardian:
 					}
 				}break;
 				case 4:
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s screams furiously.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s screams furiously.", Monnam(mtmp));
 					else pline("%s sings the song of bloodied prayers.", Monnam(mtmp));
 					
 					for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
@@ -1515,7 +1515,7 @@ asGuardian:
 					}
 				break;
 			}
-		} else if(!(mtmp->mspec_used) || mtmp->data == &mons[PM_INTONER]){
+		} else if(!(mtmp->mspec_used) || mtmp->mtyp == PM_INTONER){
 			switch(rnd(3)){
 				case 1:
 					if(mtmp->mtame && distmin(mtmp->mx,mtmp->my,u.ux,u.uy) < 5 && !u.uinvulnerable){
@@ -1533,9 +1533,9 @@ asGuardian:
 					if(!inrange) break;
 					if (!canspotmon(mtmp) && distmin(u.ux,u.uy,mtmp->mx,mtmp->my) < 5)
 						map_invisible(mtmp->mx, mtmp->my);
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s screeches discordantly.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s screeches discordantly.", Monnam(mtmp));
 					else pline("%s sings a song of courage.", Monnam(mtmp));
-					if(mtmp->data != &mons[PM_INTONER]) mtmp->mspec_used = rn1(10,10);
+					if(mtmp->mtyp != PM_INTONER) mtmp->mspec_used = rn1(10,10);
 
 					for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
 						if(tmpm != mtmp && !DEADMONSTER(tmpm)){
@@ -1587,9 +1587,9 @@ asGuardian:
 					if(!inrange) break;
 					if (!canspotmon(mtmp) && distmin(u.ux,u.uy,mtmp->mx,mtmp->my) < 5)
 						map_invisible(mtmp->mx, mtmp->my);
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s whistles shrilly.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s whistles shrilly.", Monnam(mtmp));
 					else pline("%s sings a song of good health.", Monnam(mtmp));
-					if(mtmp->data != &mons[PM_INTONER]) mtmp->mspec_used = rn1(10,10);
+					if(mtmp->mtyp != PM_INTONER) mtmp->mspec_used = rn1(10,10);
 
 					for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
 						if(tmpm != mtmp && !DEADMONSTER(tmpm)){
@@ -1645,9 +1645,9 @@ asGuardian:
 					if(!inrange) break;
 					if (!canspotmon(mtmp) && distmin(u.ux,u.uy,mtmp->mx,mtmp->my) < 5 && !u.uinvulnerable)
 						map_invisible(mtmp->mx, mtmp->my);
-					if(ptr == &mons[PM_INTONER] && u.uinsight > Insanity) pline("%s laughs frantically.", Monnam(mtmp));
+					if(ptr->mtyp == PM_INTONER && u.uinsight > Insanity) pline("%s laughs frantically.", Monnam(mtmp));
 					else pline("%s sings a song of haste.", Monnam(mtmp));
-					if(mtmp->data != &mons[PM_INTONER]) mtmp->mspec_used = rn1(10,10);
+					if(mtmp->mtyp != PM_INTONER) mtmp->mspec_used = rn1(10,10);
 					
 					for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
 						if(tmpm != mtmp && !DEADMONSTER(tmpm)){
@@ -1871,7 +1871,7 @@ asGuardian:
 	case MS_SHRIEK:
 	    pline_msg = "shrieks.";
 	    aggravate();
-		if(mtmp->data == &mons[PM_LAMASHTU]){
+		if(mtmp->mtyp == PM_LAMASHTU){
 			struct monst *tmpm;
 			for(tmpm = fmon; tmpm; tmpm = tmpm->nmon){
 				if(tmpm->mtame > 10){
@@ -1909,21 +1909,21 @@ asGuardian:
 	    pline_msg = "mumbles incomprehensibly.";
 	    break;
 	case MS_DJINNI:
-		if(Role_if(PM_EXILE) && In_quest(&u.uz) && ptr == &mons[PM_PRISONER]){
+		if(Role_if(PM_EXILE) && In_quest(&u.uz) && ptr->mtyp == PM_PRISONER){
 			verbl_msg = woePrisoners[rn2(SIZE(woePrisoners))];
-		} else if (ptr == &mons[PM_EMBRACED_DROWESS]) {
+		} else if (ptr->mtyp == PM_EMBRACED_DROWESS) {
 			verbl_msg = embracedPrisoners[rn2(SIZE(embracedPrisoners))];
-	    } else if(ptr == &mons[PM_A_GONE]) verbl_msg = agonePrisoner[rn2(SIZE(agonePrisoner))];
-	    else if(ptr == &mons[PM_MINDLESS_THRALL]) verbl_msg = thrallPrisoners[rn2(SIZE(thrallPrisoners))];
-	    else if(ptr == &mons[PM_PARASITIZED_ANDROID] || ptr == &mons[PM_PARASITIZED_GYNOID]) verbl_msg = parasitizedDroid[rn2(SIZE(parasitizedDroid))];
+	    } else if(ptr->mtyp == PM_A_GONE) verbl_msg = agonePrisoner[rn2(SIZE(agonePrisoner))];
+	    else if(ptr->mtyp == PM_MINDLESS_THRALL) verbl_msg = thrallPrisoners[rn2(SIZE(thrallPrisoners))];
+	    else if(ptr->mtyp == PM_PARASITIZED_ANDROID || ptr->mtyp == PM_PARASITIZED_GYNOID) verbl_msg = parasitizedDroid[rn2(SIZE(parasitizedDroid))];
 	    else if (mtmp->mtame) {
 			verbl_msg = "Sorry, I'm all out of wishes.";
 	    } else if (mtmp->mpeaceful) {
-			if (ptr == &mons[PM_MARID])
+			if (ptr->mtyp == PM_MARID)
 				pline_msg = "gurgles.";
 			else
 				verbl_msg = "I'm free!";
-		} else if(ptr != &mons[PM_PRISONER]) verbl_msg = "This will teach you not to disturb me!";
+		} else if(ptr->mtyp != PM_PRISONER) verbl_msg = "This will teach you not to disturb me!";
 		else verbl_msg = "I'm free!";
 	    break;
 	case MS_BOAST:	/* giants */
@@ -1944,18 +1944,18 @@ asGuardian:
 	case MS_HUMANOID:
 humanoid_sound:
 		if(Role_if(PM_NOBLEMAN) && 
-			(mtmp->data == &mons[PM_KNIGHT] 
-				|| mtmp->data == &mons[PM_MAID]) && 
+			(mtmp->mtyp == PM_KNIGHT 
+				|| mtmp->mtyp == PM_MAID) && 
 			mtmp->mpeaceful
 		) goto asGuardian; /* Jump up to a different case in this switch statment */
 		else if(Role_if(PM_KNIGHT) && 
-			mtmp->data == &mons[PM_KNIGHT] && 
+			mtmp->mtyp == PM_KNIGHT && 
 			mtmp->mpeaceful
 		) goto asGuardian; /* Jump up to a different case in this switch statment */
 		else if(Role_if(PM_ANACHRONONAUT) && 
-			(mtmp->data == &mons[PM_MYRKALFAR_WARRIOR] 
-				|| mtmp->data == &mons[PM_MYRKALFAR_MATRON] 
-				|| mtmp->data == &mons[PM_ALIDER]) && 
+			(mtmp->mtyp == PM_MYRKALFAR_WARRIOR 
+				|| mtmp->mtyp == PM_MYRKALFAR_MATRON 
+				|| mtmp->mtyp == PM_ALIDER) && 
 			mtmp->mpeaceful
 		) goto asGuardian; /* Jump up to a different case in this switch statment */
 		else if(Race_if(PM_DROW) && 
@@ -1964,13 +1964,13 @@ humanoid_sound:
 			mtmp->mpeaceful
 		) goto asGuardian; /* Jump up to a different case in this switch statment */
 		else if(Role_if(PM_EXILE) && 
-			mtmp->data == &mons[PM_PEASANT] && 
+			mtmp->mtyp == PM_PEASANT && 
 			mtmp->mpeaceful
 		) goto asGuardian; /* Jump up to a different case in this switch statment */
-		else if(Race_if(PM_GNOME) && Role_if(PM_RANGER) && (mtmp->data == &mons[PM_GNOME] || mtmp->data == &mons[PM_GNOME_LORD] || mtmp->data == &mons[PM_GNOME_KING]
-			|| mtmp->data == &mons[PM_TINKER_GNOME] || mtmp->data == &mons[PM_GNOMISH_WIZARD]) && mtmp->mpeaceful
+		else if(Race_if(PM_GNOME) && Role_if(PM_RANGER) && (mtmp->mtyp == PM_GNOME || mtmp->mtyp == PM_GNOME_LORD || mtmp->mtyp == PM_GNOME_KING
+			|| mtmp->mtyp == PM_TINKER_GNOME || mtmp->mtyp == PM_GNOMISH_WIZARD) && mtmp->mpeaceful
 		) goto asGuardian; /* Jump up to a different case in this switch statment */
-		else if(Race_if(PM_GNOME) && Role_if(PM_RANGER) && mtmp->data == &mons[PM_RUGGO_THE_GNOME_HIGH_KING]){
+		else if(Race_if(PM_GNOME) && Role_if(PM_RANGER) && mtmp->mtyp == PM_RUGGO_THE_GNOME_HIGH_KING){
 			verbl_msg = "Ah, comrade!  It is good you are here.  I've hidden the angel behind my throne.";
 			break;
 		}
@@ -2021,7 +2021,7 @@ humanoid_sound:
 			start_clockwinding(key, mtmp, turns);
 			break;
 		}
-		else if(mtmp->mpeaceful && uclockwork && mtmp->data == &mons[PM_TINKER_GNOME] && yn("(Buy clockwork components?)") == 'y'){
+		else if(mtmp->mpeaceful && uclockwork && mtmp->mtyp == PM_TINKER_GNOME && yn("(Buy clockwork components?)") == 'y'){
 			struct obj *comp;
 			int howmany = 0;
 			
@@ -2040,7 +2040,7 @@ humanoid_sound:
 				doname(comp), (const char *)0);
 			break;
 		}
-		else if(mtmp->mpeaceful && uclockwork && mtmp->data == &mons[PM_HOOLOOVOO] && yn("(Buy subethaic components?)") == 'y'){
+		else if(mtmp->mpeaceful && uclockwork && mtmp->mtyp == PM_HOOLOOVOO && yn("(Buy subethaic components?)") == 'y'){
 			struct obj *comp;
 			int howmany = 0;
 			
@@ -2085,7 +2085,7 @@ humanoid_sound:
 #endif
 		default:
 			if(Role_if(PM_RANGER) && Race_if(PM_GNOME) &&
-				mtmp->data == &mons[PM_ARCADIAN_AVENGER] && 
+				mtmp->mtyp == PM_ARCADIAN_AVENGER && 
 				mtmp->m_id == quest_status.leader_m_id
 			) goto asGuardian; /* Jump up to a different case in this switch statment */
 			
@@ -2293,7 +2293,7 @@ humanoid_sound:
 	    }
 	    break;
 	case MS_RIDER:
-	    if (ptr == &mons[PM_DEATH] && !rn2(10))
+	    if (ptr->mtyp == PM_DEATH && !rn2(10))
 		pline_msg = "is busy reading a copy of Sandman #8.";
 	    else verbl_msg = "Who do you think you are, War?";
     break;
@@ -2677,7 +2677,7 @@ int dz;
 		else pline("....");
 	}
 	
-	if(mtmp && mtmp->data == &mons[PM_PRIEST_OF_AN_UNKNOWN_GOD]){
+	if(mtmp && mtmp->mtyp == PM_PRIEST_OF_AN_UNKNOWN_GOD){
 	  if(uwep && uwep->oartifact && uwep->oartifact != ART_SILVER_KEY && uwep->oartifact != ART_ANNULUS
 		&& uwep->oartifact != ART_PEN_OF_THE_VOID && CountsAgainstGifts(uwep->oartifact)
 	  ){
@@ -2926,7 +2926,7 @@ int dz;
 		return (0);
     }
 	
-	if(mtmp->data == &mons[PM_NIGHTGAUNT] && u.umonnum == PM_GHOUL){
+	if(mtmp->mtyp == PM_NIGHTGAUNT && u.umonnum == PM_GHOUL){
 		You("bark the secret passwords known to ghouls.");
 		mtmp->mpeaceful = 1;
 		mtmp = tamedog(mtmp, (struct obj *)0);
@@ -2939,7 +2939,7 @@ int dz;
 		return 1;
 	}
     /* That is IT. EVERYBODY OUT. You are DEAD SERIOUS. */
-    if (mtmp->data == &mons[PM_URANIUM_IMP]) {
+    if (mtmp->mtyp == PM_URANIUM_IMP) {
 		monflee(mtmp, rn1(20,10), TRUE, FALSE);
     }
 	
@@ -3045,7 +3045,7 @@ int tx,ty;
       }
     }
 	
-	if(m_at(tx,ty) && (ep->ward_id != ANDROMALIUS || m_at(tx,ty)->data != &mons[PM_SEWER_RAT])) return 0;
+	if(m_at(tx,ty) && (ep->ward_id != ANDROMALIUS || m_at(tx,ty)->mtyp != PM_SEWER_RAT)) return 0;
 	
 	switch(ep->ward_id){
 	case AHAZU:{
@@ -3185,7 +3185,7 @@ int tx,ty;
 			if (!gldring) gldring = find_gold_ring();
 			
 			rat = m_at(tx,ty);
-			if(rat && rat->data == &mons[PM_SEWER_RAT]) t2=17;
+			if(rat && rat->mtyp == PM_SEWER_RAT) t2=17;
 			else rat = 0;
 			
 			for(otmp = level.objects[tx][ty]; otmp; otmp = otmp->nexthere)

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -924,7 +924,7 @@ boolean chatting;
 	}
 	
 	/* Make sure its your role's quest quardian; adjust if not */
-	if (ptr->msound == MS_GUARDIAN && ptr != &mons[urole.guardnum] && ptr->mtyp != PM_CELEBORN){
+	if (ptr->msound == MS_GUARDIAN && ptr->mtyp != urole.guardnum && ptr->mtyp != PM_CELEBORN){
 		int mndx = monsndx(ptr);
 		ptr = &mons[genus(mndx,1)];
 	}
@@ -960,7 +960,6 @@ boolean chatting;
 		}
 	}
 	switch (
-		(mtmp->mfaction == SKELIFIED && ptr->mtyp != PM_ECHO) ? MS_BONES : 
 		is_silent_mon(mtmp) ? MS_SILENT : 
 		(is_dollable(mtmp->data) && mtmp->m_insight_level) ? MS_STATS : 
 		mtmp->ispriest ? MS_PRIEST : 

--- a/src/spell.c
+++ b/src/spell.c
@@ -3475,7 +3475,7 @@ spiriteffects(power, atme)
 				unbind(SEAL_TENEBROUS, TRUE);
 			} else if(mon->data == &mons[PM_INTONER]){
 				pline("%s screams!", SheHeIt(mon));
-				newcham(mon, &mons[PM_BLACK_FLOWER], FALSE, FALSE);
+				newcham(mon, PM_BLACK_FLOWER, FALSE, FALSE);
 			} else if(resists_drli(mon) || !(mon->data->geno & G_GENO) || resists_death(mon)){
 				int nlev;
 				d_level tolevel;
@@ -3800,7 +3800,7 @@ spiriteffects(power, atme)
 					break;
 				}
 				if (tryct > 100) return 0;	/* Should never happen */
-				newcham(mon, mdat, FALSE, FALSE);
+				newcham(mon, mndx, FALSE, FALSE);
 			}
 		}break;
 		case PWR_PHASE_STEP:{

--- a/src/spell.c
+++ b/src/spell.c
@@ -2567,8 +2567,8 @@ spiriteffects(power, atme)
 							water_damage(mon->minvent, FALSE, FALSE, FALSE, mon);
 						}
 					}
-					if(flaming(mon->data) || mon->data == &mons[PM_EARTH_ELEMENTAL] || mon->data == &mons[PM_IRON_GOLEM] || mon->data == &mons[PM_CHAIN_GOLEM]) dmg *= 2;
-					if(mon->data == &mons[PM_GREMLIN] && rn2(3)){
+					if(flaming(mon->data) || mon->mtyp == PM_EARTH_ELEMENTAL || mon->mtyp == PM_IRON_GOLEM || mon->mtyp == PM_CHAIN_GOLEM) dmg *= 2;
+					if(mon->mtyp == PM_GREMLIN && rn2(3)){
 						(void)split_mon(mon, (struct monst *)0);
 					}
 					mon->mhp -= dmg;
@@ -2757,7 +2757,7 @@ spiriteffects(power, atme)
 				if(!mon) break;
 				dmg = d(rnd(5),dsize);
 				if(haseyes(mon->data) && mon->mcansee && can_blnd(&youmonst, mon, AT_CLAW, (struct obj*)0)){
-					if(mon->data == &mons[PM_FLOATING_EYE]){
+					if(mon->mtyp == PM_FLOATING_EYE){
 						You("claw at %s.", mon_nam(mon));
 						dmg += d(5,dsize); //Bonus damage, since this renders wards inefective and is single target.
 						dmg *= 2;
@@ -2794,7 +2794,7 @@ spiriteffects(power, atme)
 				u.irisAttack = moves;
 				pline("Arcs of iridescent droplets tear free from %s body!", s_suffix(mon_nam(mon)));
 				pline("They merge with and are absorbed by your tentacles!");
-				if(mon->data==&mons[PM_WATER_ELEMENTAL] || mon->data==&mons[PM_FOG_CLOUD] || mon->data==&mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES]) dmg *= 2;
+				if(mon->mtyp==PM_WATER_ELEMENTAL || mon->mtyp==PM_FOG_CLOUD || mon->mtyp==PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES) dmg *= 2;
 				if (mon->mhp <= dmg){
 					dmg = mon->mhp;
 					mon->mhp = 0;
@@ -3470,10 +3470,10 @@ spiriteffects(power, atme)
 			mon = m_at(u.ux+u.dx,u.uy+u.dy);
 			if(!mon) return 0;
 			You("speak an echo of the Last Word of creation.");
-			if(mon->data == &mons[PM_DREAD_SERAPH] || mon->data == &mons[PM_BLACK_FLOWER]){
+			if(mon->mtyp == PM_DREAD_SERAPH || mon->mtyp == PM_BLACK_FLOWER){
 				pline("Its voice harmonizes with your own!");
 				unbind(SEAL_TENEBROUS, TRUE);
-			} else if(mon->data == &mons[PM_INTONER]){
+			} else if(mon->mtyp == PM_INTONER){
 				pline("%s screams!", SheHeIt(mon));
 				newcham(mon, PM_BLACK_FLOWER, FALSE, FALSE);
 			} else if(resists_drli(mon) || !(mon->data->geno & G_GENO) || resists_death(mon)){
@@ -4059,11 +4059,11 @@ int spell;
 						if(mon && !mon->mpeaceful){
 							if(is_elemental(mon->data) 
 								|| is_undead_mon(mon) 
-								|| mon->data == &mons[PM_ASPECT_OF_THE_SILENCE] 
-								|| mon->data == &mons[PM_SENTINEL_OF_MITHARDIR] 
-								|| mon->data == &mons[PM_STONE_GOLEM] 
-								|| mon->data == &mons[PM_CLAY_GOLEM] 
-								|| mon->data == &mons[PM_FLESH_GOLEM]
+								|| mon->mtyp == PM_ASPECT_OF_THE_SILENCE 
+								|| mon->mtyp == PM_SENTINEL_OF_MITHARDIR 
+								|| mon->mtyp == PM_STONE_GOLEM 
+								|| mon->mtyp == PM_CLAY_GOLEM 
+								|| mon->mtyp == PM_FLESH_GOLEM
 							) {
 								mon->mhp -= d(nd,12);
 								if (mon->mhp <= 0){
@@ -5433,7 +5433,7 @@ int spell;
 		struct monst *cmon;
 		int dist = 0;
 		for(cmon = fmon; cmon; cmon = cmon->nmon){
-			if(cmon->data == &mons[PM_ASPECT_OF_THE_SILENCE]){
+			if(cmon->mtyp == PM_ASPECT_OF_THE_SILENCE){
 				dist = (int) (3*sqrt(dist2(u.ux,u.uy,cmon->mx,cmon->my)));
 				break;
 			}
@@ -5696,8 +5696,8 @@ dopseudonatural()
 			!(magr_can_attack_mdef(&youmonst, mon, mon->mx, mon->my, FALSE)))
 			continue;
 		if((!Stone_resistance && (touch_petrifies(mon->data)
-		 || mon->data == &mons[PM_MEDUSA]))
-		 || mon->data == &mons[PM_PALE_NIGHT]
+		 || mon->mtyp == PM_MEDUSA))
+		 || mon->mtyp == PM_PALE_NIGHT
 		) continue;
 		
 		if(mon){

--- a/src/steal.c
+++ b/src/steal.c
@@ -242,8 +242,8 @@ int monkey_business; /* true iff an animal is doing the thievery */
 	struct obj *otmp;
 	int tmp, could_petrify, named = 0, armordelay;
 	boolean charms = (is_neuter(mtmp->data) || flags.female == mtmp->female);
-	if(mtmp->data == &mons[PM_ALRUNES]) charms = !charms;
-	else if(mtmp->data == &mons[PM_FIERNA]) charms = TRUE;
+	if(mtmp->mtyp == PM_ALRUNES) charms = !charms;
+	else if(mtmp->mtyp == PM_FIERNA) charms = TRUE;
 
 	if (objnambuf) *objnambuf = '\0';
 	/* the following is true if successful on first of two attacks. */
@@ -382,7 +382,7 @@ gotobj:
 			if (multi < 0 && is_fainted()) unmul((char *)0);
 			slowly = (armordelay >= 1 || multi < 0);
 			if(!artifact){
-			if(mtmp->data == &mons[PM_DEMOGORGON])
+			if(mtmp->mtyp == PM_DEMOGORGON)
 				pline("%s compels you.  You gladly %s your %s.",
 				  Monnam(mtmp),
 				  curssv ? "let him take" :

--- a/src/steed.c
+++ b/src/steed.c
@@ -42,7 +42,7 @@ can_saddle(mtmp)
 	return ((index(steeds, ptr->mlet) ||
 				(Race_if(PM_ORC) && index(orc_steeds, ptr->mlet)) ||
 				((Race_if(PM_DROW) || Race_if(PM_MYRKALFR)) && index(drow_steeds, ptr->mlet)) ||
-				(ptr == &mons[PM_BYAKHEE])
+				(ptr->mtyp == PM_BYAKHEE)
 			) && 
 			(ptr->msize >= MZ_MEDIUM) &&
 			!humanoid(ptr) &&
@@ -105,7 +105,7 @@ use_saddle(otmp)
 		instapetrify(kbuf);
  	    }
 	}
-	if (ptr == &mons[PM_INCUBUS] || ptr == &mons[PM_SUCCUBUS]) {
+	if (ptr->mtyp == PM_INCUBUS || ptr->mtyp == PM_SUCCUBUS) {
 	    pline("Shame on you!");
 	    exercise(A_WIS, FALSE);
 	    return 1;

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1593,7 +1593,7 @@ boolean give_feedback;
 	coord cc;
 	int illrgrd = FALSE;//teleport will be fatal to target due to ill-regard equipment)
 	
-	if(mtmp->data == &mons[PM_CREATURE_IN_THE_ICE]){
+	if(mtmp->mtyp == PM_CREATURE_IN_THE_ICE){
 	    if (give_feedback){
 			shieldeff(mtmp->mx, mtmp->my);
 			pline("Your magic has no effect on %s!", mon_nam(mtmp));

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -615,7 +615,7 @@ nh_timeout()
 #endif
 
 	for(upp = u.uprops; upp < u.uprops+SIZE(u.uprops); upp++){
-		if((youracedata == &mons[PM_SHOGGOTH] || youracedata == &mons[PM_PRIEST_OF_GHAUNADAUR]) && upp - u.uprops == BLINDED
+		if((youracedata->mtyp == PM_SHOGGOTH || youracedata->mtyp == PM_PRIEST_OF_GHAUNADAUR) && upp - u.uprops == BLINDED
 			&&  upp->intrinsic & TIMEOUT
 		){
 			upp->intrinsic &= ~TIMEOUT;
@@ -1083,7 +1083,7 @@ long timeout;
 		       while it's in your inventory */
 		    if ((yours && !silent) ||
 			(carried(egg) && mon->data->mlet == S_DRAGON) ||
-			(carried(egg) && mon->data == &mons[PM_BABY_METROID]) ) { //metroid egg
+			(carried(egg) && mon->mtyp == PM_BABY_METROID) ) { //metroid egg
 			if ((mon2 = tamedog(mon, (struct obj *)0)) != 0) {
 			    mon = mon2;
 			    if (carried(egg) && mon->data->mlet != S_DRAGON)

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -1056,14 +1056,14 @@ long timeout;
 	xchar x, y;
 	boolean yours, silent, knows_egg = FALSE;
 	boolean cansee_hatchspot = FALSE;
-	int i, mnum, hatchcount = 0;
+	int i, mtyp, hatchcount = 0;
 
 	egg = (struct obj *) arg;
 	/* sterilized while waiting */
 	if (egg->corpsenm == NON_PM) return;
 
 	mon = mon2 = (struct monst *)0;
-	mnum = big_to_little(egg->corpsenm);
+	mtyp = big_to_little(egg->corpsenm);
 	/* The identity of one's father is learned, not innate */
 	yours = (egg->spe || (!flags.female && carried(egg) && !rn2(2)));
 	silent = (timeout != monstermoves);	/* hatched while away */
@@ -1072,11 +1072,11 @@ long timeout;
 	if (get_obj_location(egg, &x, &y, 0)) {
 	    hatchcount = rnd((int)egg->quan);
 	    cansee_hatchspot = cansee(x, y) && !silent;
-	    if (!(mons[mnum].geno & G_UNIQ) &&
-		   !(mvitals[mnum].mvflags & G_GONE && !In_quest(&u.uz))) {
+	    if (!(mons[mtyp].geno & G_UNIQ) &&
+		   !(mvitals[mtyp].mvflags & G_GONE && !In_quest(&u.uz))) {
 		for (i = hatchcount; i > 0; i--) {
-		    if (!enexto(&cc, x, y, &mons[mnum]) ||
-			 !(mon = makemon(&mons[mnum], cc.x, cc.y, NO_MINVENT)))
+		    if (!enexto(&cc, x, y, &mons[mtyp]) ||
+			 !(mon = makemon(&mons[mtyp], cc.x, cc.y, NO_MINVENT)))
 			break;
 		    /* tame if your own egg hatches while you're on the
 		       same dungeon level, or any dragon egg (or metroid) which hatches
@@ -1090,7 +1090,7 @@ long timeout;
 				mon->mtame = 20;
 			}
 		    }
-		    if (mvitals[mnum].mvflags & G_EXTINCT && !In_quest(&u.uz))
+		    if (mvitals[mtyp].mvflags & G_EXTINCT && !In_quest(&u.uz))
 			break;	/* just made last one */
 		    mon2 = mon;	/* in case makemon() fails on 2nd egg */
 		}
@@ -1195,7 +1195,7 @@ long timeout;
 	    }
 
 	    if (cansee_hatchspot && knows_egg)
-		learn_egg_type(mnum);
+		learn_egg_type(mtyp);
 
 	    if (egg->quan > 0) {
 		/* still some eggs left */
@@ -1219,12 +1219,12 @@ long timeout;
 
 /* Learn to recognize eggs of the given type. */
 void
-learn_egg_type(mnum)
-int mnum;
+learn_egg_type(mtyp)
+int mtyp;
 {
 	/* baby monsters hatch from grown-up eggs */
-	mnum = little_to_big(mnum, rn2(2));
-	mvitals[mnum].mvflags |= MV_KNOWS_EGG;
+	mtyp = little_to_big(mtyp, rn2(2));
+	mvitals[mtyp].mvflags |= MV_KNOWS_EGG;
 	/* we might have just learned about other eggs being carried */
 	update_inventory();
 }

--- a/src/trap.c
+++ b/src/trap.c
@@ -2055,8 +2055,8 @@ struct monst *mtmp;
 				      Monnam(mtmp), a_your[trap->madeby_u]);
 				seetrap(trap);
 			    } else {
-				if((mptr == &mons[PM_OWLBEAR]
-				    || mptr == &mons[PM_BUGBEAR])
+				if((mptr->mtyp == PM_OWLBEAR
+				    || mptr->mtyp == PM_BUGBEAR)
 				   && flags.soundok)
 				    You_hear("the roaring of an angry bear!");
 			    }
@@ -2135,7 +2135,7 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 #endif
 			    }
 			}
-			if (mptr == &mons[PM_IRON_GOLEM] || mptr == &mons[PM_CHAIN_GOLEM]) {
+			if (mptr->mtyp == PM_IRON_GOLEM || mptr->mtyp == PM_CHAIN_GOLEM) {
 				if (in_sight)
 				    pline("%s falls to pieces!", Monnam(mtmp));
 				else if(mtmp->mtame)
@@ -2144,13 +2144,13 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 				mondied(mtmp);
 				if (mtmp->mhp <= 0)
 					trapkilled = TRUE;
-			} else if (mptr == &mons[PM_FLAMING_SPHERE]) {
+			} else if (mptr->mtyp == PM_FLAMING_SPHERE) {
 				if (in_sight)
 				    pline("%s is extinguished!", Monnam(mtmp));
 				mondied(mtmp);
 				if (mtmp->mhp <= 0)
 					trapkilled = TRUE;
-			} else if (mptr == &mons[PM_GREMLIN] && rn2(3)) {
+			} else if (mptr->mtyp == PM_GREMLIN && rn2(3)) {
 				(void)split_mon(mtmp, (struct monst *)0);
 			}
 			break;
@@ -2263,7 +2263,7 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 			    pline("%s %s into %s pit!",
 				  Monnam(mtmp), fallverb,
 				  a_your[trap->madeby_u]);
-			    if (mptr == &mons[PM_PIT_VIPER] || mptr == &mons[PM_PIT_FIEND])
+			    if (mptr->mtyp == PM_PIT_VIPER || mptr->mtyp == PM_PIT_FIEND)
 				pline("How pitiful.  Isn't that the pits?");
 			    seetrap(trap);
 			}
@@ -2296,7 +2296,7 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 			}
 			if(mtmp->mhp <= 0) break;
 			if (mon_resistance(mtmp,FLYING) || mon_resistance(mtmp,LEVITATION) ||
-				mptr == &mons[PM_WUMPUS] ||
+				mptr->mtyp == PM_WUMPUS ||
 				(mtmp->wormno && count_wsegs(mtmp) > 5) ||
 				mptr->msize >= MZ_HUGE) {
 			    if (inescapable) {	/* sokoban hole */
@@ -2331,12 +2331,12 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 			if (webmaker(mptr) || (Is_lolth_level(&u.uz) && !mtmp->mpeaceful)) break;
 			if (amorphous(mptr) || is_whirly(mptr) || unsolid(mptr)){
 			    if(acidic(mptr) ||
-			       mptr == &mons[PM_GELATINOUS_CUBE] ||
-			       mptr == &mons[PM_FIRE_ELEMENTAL]) {
+			       mptr->mtyp == PM_GELATINOUS_CUBE ||
+			       mptr->mtyp == PM_FIRE_ELEMENTAL) {
 				if (in_sight)
 				    pline("%s %s %s spider web!",
 					  Monnam(mtmp),
-					  (mptr == &mons[PM_FIRE_ELEMENTAL]) ?
+					  (mptr->mtyp == PM_FIRE_ELEMENTAL) ?
 					    "burns" : "dissolves",
 					  a_your[trap->madeby_u]);
 				if(!Is_lolth_level(&u.uz) && !(u.specialSealsActive&SEAL_BLACK_WEB)){

--- a/src/trap.c
+++ b/src/trap.c
@@ -584,7 +584,7 @@ int *fail_reason;
 				if(statue->spe&STATUE_EPRE && dungeon_topology.eprecursor_typ == PRE_POLYP)
 					mon->ispolyp = TRUE;
 				if (mon->cham == CHAM_DOPPELGANGER)
-					(void) newcham(mon, mptr, FALSE, FALSE);
+					(void) newcham(mon, monsndx(mptr), FALSE, FALSE);
 			}
 	    } else {
 			if(statue->spe&STATUE_FACELESS){
@@ -1498,7 +1498,7 @@ struct obj *otmp;
 		case POLY_TRAP: 
 		    if (!resists_magm(mtmp) && !resists_poly(mtmp->data)) {
 			if (!resist(mtmp, WAND_CLASS, 0, NOTELL)) {
-			(void) newcham(mtmp, (struct permonst *)0,
+			(void) newcham(mtmp, NON_PM,
 				       FALSE, FALSE);
 			if (!can_saddle(mtmp) || !can_ride(mtmp)) {
 				dismount_steed(DISMOUNT_POLY);
@@ -2484,7 +2484,7 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 		    if (resists_magm(mtmp) || resists_poly(mtmp->data)) {
 			shieldeff(mtmp->mx, mtmp->my);
 		    } else if (!resist(mtmp, WAND_CLASS, 0, NOTELL)) {
-			(void) newcham(mtmp, (struct permonst *)0,
+			(void) newcham(mtmp, NON_PM,
 				       FALSE, FALSE);
 			if (in_sight) seetrap(trap);
 		    }

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -212,7 +212,7 @@ struct monst *mon;
 		else tmp += 2;
 	}
 	if (is_spear(otmp) &&
-	   index(kebabable, ptr->mlet)) tmp += (ptr == &mons[PM_SMAUG]) ? 20 : 2;
+	   index(kebabable, ptr->mlet)) tmp += (ptr->mtyp == PM_SMAUG) ? 20 : 2;
 
 	if (is_farm(otmp) &&
 	    ptr->mlet == S_PLANT) tmp += 6;
@@ -633,7 +633,7 @@ int otyp;
 	if (obj && otyp == KAMEREL_VAJRA)
 	{
 		if (litsaber(obj)) {
-			if (obj->where == OBJ_MINVENT && obj->ocarry->data == &mons[PM_ARA_KAMEREL])
+			if (obj->where == OBJ_MINVENT && obj->ocarry->mtyp == PM_ARA_KAMEREL)
 			{
 				spe_mult = 3;
 				ocn *= 3;
@@ -1092,7 +1092,7 @@ int spec;
 	if (otmp->oproperties&OPROP_FLAYW && mon && some_armor(mon))
 		tmp = 1;
 	/* Smaug gets stabbed */
-	if(is_stabbing(otmp) && ptr == &mons[PM_SMAUG])
+	if(is_stabbing(otmp) && ptr->mtyp == PM_SMAUG)
 		tmp += rnd(20);
 	/* axes deal more damage to wooden foes */
 	if (is_axe(otmp) && is_wooden(ptr))
@@ -1145,7 +1145,7 @@ int spot;
 			/* never uncharged lightsabers */
             (!is_lightsaber(otmp) || otmp->age || otmp->oartifact == ART_INFINITY_S_MIRRORED_ARC || otmp->otyp == KAMEREL_VAJRA) &&
 			/* never offhand artifacts (unless you are the Bastard) */
-			(!otmp->oartifact || spot != W_SWAPWEP || mtmp->data == &mons[PM_BASTARD_OF_THE_BOREAL_VALLEY]) &&
+			(!otmp->oartifact || spot != W_SWAPWEP || mtmp->mtyp == PM_BASTARD_OF_THE_BOREAL_VALLEY) &&
 			/* never untouchable artifacts */
 		    (!otmp->oartifact || touch_artifact(otmp, mtmp, 0)) &&
 			/* never unsuitable for mainhand wielding */
@@ -1153,10 +1153,10 @@ int spot;
 			/* never unsuitable for offhand wielding */
 			(spot!=W_SWAPWEP || (!(otmp->owornmask & (W_WEP)) && (!otmp->cursed || is_weldproof_mon(mtmp)) && !bimanual(otmp, mtmp->data) && (mtmp->misc_worn_check & W_ARMS) == 0 && 
 				( (otmp->owt <= (30 + (mtmp->m_lev/5)*5)) 
-				|| (otmp->otyp == CHAIN && mtmp->data == &mons[PM_CATHEZAR]) 
-				|| (otmp->otyp == CHAIN && mtmp->data == &mons[PM_FIERNA])
-				|| (mtmp->data == &mons[PM_BASTARD_OF_THE_BOREAL_VALLEY])
-				|| (mtmp->data == &mons[PM_CORVIAN_KNIGHT])
+				|| (otmp->otyp == CHAIN && mtmp->mtyp == PM_CATHEZAR) 
+				|| (otmp->otyp == CHAIN && mtmp->mtyp == PM_FIERNA)
+				|| (mtmp->mtyp == PM_BASTARD_OF_THE_BOREAL_VALLEY)
+				|| (mtmp->mtyp == PM_CORVIAN_KNIGHT)
 				)
 			)) &&
 			/* never a hated weapon */

--- a/src/were.c
+++ b/src/were.c
@@ -186,7 +186,7 @@ struct monst *mon;
 			an(mons[pm].mname));
 	}
 
-	set_mon_data(mon, &mons[pm], 0);
+	set_mon_data(mon, pm, 0);
 	if (mon->msleeping || !mon->mcanmove) {
 	    /* transformation wakens and/or revitalizes */
 	    mon->msleeping = 0;
@@ -234,28 +234,28 @@ struct monst *mon;
 				switch(rnd(4)){
 					case 1:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, &mons[PM_WATER_ELEMENTAL], 0);
+						set_mon_data(ltnt, PM_WATER_ELEMENTAL, 0);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);
 					break;
 					case 2:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, &mons[PM_AIR_ELEMENTAL], 0);
+						set_mon_data(ltnt, PM_AIR_ELEMENTAL, 0);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);
 					break;
 					case 3:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, &mons[PM_LIGHTNING_PARAELEMENTAL], 0);
+						set_mon_data(ltnt, PM_LIGHTNING_PARAELEMENTAL, 0);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);
 					break;
 					case 4:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, &mons[PM_ICE_PARAELEMENTAL], 0);
+						set_mon_data(ltnt, PM_ICE_PARAELEMENTAL, 0);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);

--- a/src/were.c
+++ b/src/were.c
@@ -14,14 +14,14 @@ register struct monst *mon;
 		&& !(is_heladrin(mon->data) && mon->mhp < .5*mon->mhpmax && rn2(2))
 		&& !(is_eeladrin(mon->data) && mon->mhp > .5*mon->mhpmax)
 		&& !(is_yochlol(mon->data) && mon->mhp < .5*mon->mhpmax)
-		&& !(mon->data == &mons[PM_SELKIE] || mon->data == &mons[PM_SEAL])
-		&& !(mon->data == &mons[PM_INCUBUS] || mon->data == &mons[PM_SUCCUBUS])
+		&& !(mon->mtyp == PM_SELKIE || mon->mtyp == PM_SEAL)
+		&& !(mon->mtyp == PM_INCUBUS || mon->mtyp == PM_SUCCUBUS)
 	) return;
 
-	if(mon->data == &mons[PM_NOVIERE_ELADRIN] && !is_pool(mon->mx, mon->my, FALSE)) return;
+	if(mon->mtyp == PM_NOVIERE_ELADRIN && !is_pool(mon->mx, mon->my, FALSE)) return;
 	
 	if (humanoid_torso(mon->data)) {
-		if (mon->data == &mons[PM_INCUBUS] || mon->data == &mons[PM_SUCCUBUS]){
+		if (mon->mtyp == PM_INCUBUS || mon->mtyp == PM_SUCCUBUS){
 			if(!Protection_from_shape_changers 
 			&& !canseemon(mon) 
 			&& mon->mfaction != INCUBUS_FACTION
@@ -31,7 +31,7 @@ register struct monst *mon;
 				mon->female = !mon->female;
 				new_were(mon);
 			}
-	    } else if (mon->data == &mons[PM_MAMMON] || mon->data == &mons[PM_GREEN_PIT_FIEND]){
+	    } else if (mon->mtyp == PM_MAMMON || mon->mtyp == PM_GREEN_PIT_FIEND){
 			if(!Protection_from_shape_changers 
 			&& mon->mhp < mon->mhpmax
 			&& !rn2(20)
@@ -65,7 +65,7 @@ register struct monst *mon;
 		|| (is_yochlol(mon->data) && !Protection_from_shape_changers)
 		|| (is_eeladrin(mon->data) && mon->mhp >= mon->mhpmax)
 	) {
-		if(mon->data == &mons[PM_BALL_OF_LIGHT]){
+		if(mon->mtyp == PM_BALL_OF_LIGHT){
 			mon->mflee = 0;
 			mon->mfleetim = 0;
 		}
@@ -175,10 +175,10 @@ struct monst *mon;
 		return;
 	
 	if(canseemon(mon) && !Hallucination) {
-		if(mon->data != &mons[PM_ANUBITE] && mon->data != &mons[PM_ANUBAN_JACKAL]
+		if(mon->mtyp != PM_ANUBITE && mon->mtyp != PM_ANUBAN_JACKAL
 		  && !is_eladrin(mon->data) && !is_yochlol(mon->data)
-		  && !(mon->data == &mons[PM_SELKIE] || mon->data == &mons[PM_SEAL])
-		  && !(mon->data == &mons[PM_INCUBUS] || mon->data == &mons[PM_SUCCUBUS])
+		  && !(mon->mtyp == PM_SELKIE || mon->mtyp == PM_SEAL)
+		  && !(mon->mtyp == PM_INCUBUS || mon->mtyp == PM_SUCCUBUS)
 		) pline("%s changes into %s.", Monnam(mon),
 			is_human(&mons[pm]) ? "a human" :
 			an(mons[pm].mname+4));
@@ -228,9 +228,9 @@ struct monst *mon;
 				}
 			}
 		}
-		if(mon->data == &mons[PM_ANCIENT_TEMPEST]){
+		if(mon->mtyp == PM_ANCIENT_TEMPEST){
 			struct monst *ltnt;
-			for(ltnt = fmon; ltnt; ltnt = ltnt->nmon) if(ltnt->data == &mons[PM_WIDE_CLUBBED_TENTACLE]){
+			for(ltnt = fmon; ltnt; ltnt = ltnt->nmon) if(ltnt->mtyp == PM_WIDE_CLUBBED_TENTACLE){
 				switch(rnd(4)){
 					case 1:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);

--- a/src/were.c
+++ b/src/were.c
@@ -186,7 +186,7 @@ struct monst *mon;
 			an(mons[pm].mname));
 	}
 
-	set_mon_data(mon, pm, 0);
+	set_mon_data(mon, pm);
 	if (mon->msleeping || !mon->mcanmove) {
 	    /* transformation wakens and/or revitalizes */
 	    mon->msleeping = 0;
@@ -234,28 +234,28 @@ struct monst *mon;
 				switch(rnd(4)){
 					case 1:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_WATER_ELEMENTAL, 0);
+						set_mon_data(ltnt, PM_WATER_ELEMENTAL);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);
 					break;
 					case 2:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_AIR_ELEMENTAL, 0);
+						set_mon_data(ltnt, PM_AIR_ELEMENTAL);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);
 					break;
 					case 3:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_LIGHTNING_PARAELEMENTAL, 0);
+						set_mon_data(ltnt, PM_LIGHTNING_PARAELEMENTAL);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);
 					break;
 					case 4:
 						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_ICE_PARAELEMENTAL, 0);
+						set_mon_data(ltnt, PM_ICE_PARAELEMENTAL);
 						newsym(ltnt->mx,ltnt->my);
 						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
 								 LS_MONSTER, (genericptr_t)ltnt);

--- a/src/wield.c
+++ b/src/wield.c
@@ -948,9 +948,9 @@ struct permonst * ptr;
 
 	/* Some creatures are specifically always able to wield any weapon in one hand */
 	if (ptr && (
-		ptr == &mons[PM_THRONE_ARCHON] ||
-		ptr == &mons[PM_LUNGORTHIN] ||
-		ptr == &mons[PM_BASTARD_OF_THE_BOREAL_VALLEY]
+		ptr->mtyp == PM_THRONE_ARCHON ||
+		ptr->mtyp == PM_LUNGORTHIN ||
+		ptr->mtyp == PM_BASTARD_OF_THE_BOREAL_VALLEY
 		))
 		return FALSE;
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -545,7 +545,7 @@ nasty(mcast)
 			do {
 				makeindex = pick_nasty();
 			} while(mcast && attacktype(&mons[makeindex], AT_MAGC) &&
-				monstr[makeindex] >= monstr[mcast->mnum]);
+				monstr[makeindex] >= monstr[mcast->mtyp]);
 			/* do this after picking the monster to place */
 			if (mcast &&
 				!enexto(&bypos, mcast->mux, mcast->muy, &mons[makeindex]))

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -274,7 +274,7 @@ strategy(mtmp)
 			return(STRAT_HEAL);
 
 	    case 1:	/* the wiz is less cautious */
-			if(mtmp->data != &mons[PM_WIZARD_OF_YENDOR])
+			if(mtmp->mtyp != PM_WIZARD_OF_YENDOR)
 			    return(STRAT_HEAL);
 			/* else fall through */
 
@@ -327,7 +327,7 @@ tactics(mtmp)
 		/* if wounded, hole up on or near the stairs (to block them) */
 		/* unless, of course, there are no stairs (e.g. endlevel) */
 		mtmp->mavenge = 1; /* covetous monsters attack while fleeing */
-		if(mtmp->data == &mons[PM_AGLAOPE]){
+		if(mtmp->mtyp == PM_AGLAOPE){
 			//don't move from current location, post-theft warp does that for you.
 		} else {
 			if(flags.stag && In_quest(&u.uz)){
@@ -357,8 +357,8 @@ tactics(mtmp)
 		/* fall through :-) */
 
 	    case STRAT_NONE:	/* harrass */
-		if (!rn2((!mtmp->mflee || mtmp->data == &mons[PM_BANDERSNATCH]) ? 5 : 33)){
-			if(mtmp->data == &mons[PM_AGLAOPE]){
+		if (!rn2((!mtmp->mflee || mtmp->mtyp == PM_BANDERSNATCH) ? 5 : 33)){
+			if(mtmp->mtyp == PM_AGLAOPE){
 				coord cc;
 				aglaopesong(mtmp);
 				pline("%s's song warps space to draw you together.",Monnam(mtmp));
@@ -400,7 +400,7 @@ tactics(mtmp)
 		}
 		if((u.ux == tx && u.uy == ty) || where == STRAT_PLAYER) {
 		    /* player is standing on it (or has it) */
-			if(mtmp->data == &mons[PM_AGLAOPE]){
+			if(mtmp->mtyp == PM_AGLAOPE){
 				coord cc;
 				aglaopesong(mtmp);
 				pline("%s's song warps space to draw you together.",Monnam(mtmp));
@@ -408,7 +408,7 @@ tactics(mtmp)
 					teleds(cc.x, cc.y, FALSE);
 					return(0);
 				}
-			} else if(mtmp->data == &mons[PM_GREAT_CTHULHU]){
+			} else if(mtmp->mtyp == PM_GREAT_CTHULHU){
 				pline("%s steps through strange angles.",Monnam(mtmp));
 				mofflin(mtmp);
 				return(0);
@@ -475,7 +475,7 @@ aggravate()
 			mtmp->msleeping = 0;
 			if(!mtmp->mcanmove && !rn2(5)) {
 				mtmp->mfrozen = 0;
-				if(mtmp->data != &mons[PM_GIANT_TURTLE] || !(mtmp->mflee))
+				if(mtmp->mtyp != PM_GIANT_TURTLE || !(mtmp->mflee))
 					mtmp->mcanmove = 1;
 			}
 			mtmp->mux = u.ux;
@@ -634,7 +634,7 @@ illur_resurrect()
 	verb = "elude";
 	mmtmp = &migrating_mons;
 	while ((mtmp = *mmtmp) != 0) {
-		if (mtmp->data==&mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES]) {
+		if (mtmp->mtyp==PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES) {
 			if((elapsed = monstermoves - mtmp->mlstmv) > 0L){
 				mon_catchup_elapsed_time(mtmp, elapsed);
 				if (elapsed >= LARGEST_INT) elapsed = LARGEST_INT - 1;
@@ -673,7 +673,7 @@ coa_arrive()
 	/* look for a migrating CoAll */
 	mmtmp = &migrating_mons;
 	while ((mtmp = *mmtmp) != 0) {
-		if (mtmp->data==&mons[PM_CENTER_OF_ALL]) {
+		if (mtmp->mtyp==PM_CENTER_OF_ALL) {
 			if((elapsed = monstermoves - mtmp->mlstmv) > 0L){
 				mon_catchup_elapsed_time(mtmp, elapsed);
 				if (elapsed >= LARGEST_INT) elapsed = LARGEST_INT - 1;
@@ -1005,17 +1005,17 @@ register struct monst	*mtmp;
 		    verbalize("%s %s!",
 			  random_malediction[rn2(SIZE(random_malediction))],
 			  random_insult[rn2(SIZE(random_insult))]);
-	} else if(mtmp->data == &mons[PM_CHAOS]){
+	} else if(mtmp->mtyp == PM_CHAOS){
 		if(mtmp->mvar3<5){
 			verbalize("%s", random_chaosism[mtmp->mvar3+5]);
 			mtmp->mvar3++;
 		}
 		else verbalize("%s", random_chaosism[rn2(5)]);
-	} else if(mtmp->data == &mons[PM_GARLAND]){
+	} else if(mtmp->mtyp == PM_GARLAND){
 		verbalize("%s", random_chaos_garlandism[rn2(SIZE(random_chaos_garlandism))]);
-	} else if(mtmp->data == &mons[PM_SIR_GARLAND]){
+	} else if(mtmp->mtyp == PM_SIR_GARLAND){
 		verbalize("%s", random_garlandism[rn2(SIZE(random_garlandism))]);
-	} else if(mtmp->data == &mons[PM_APOLLYON]){
+	} else if(mtmp->mtyp == PM_APOLLYON){
 		verbalize("%s", random_apollyon[rn2(SIZE(random_apollyon))]);
 	} else if(is_angel(mtmp->data) && !(is_lminion(mtmp) && rn2(10))){
 		int t = rn2(SIZE(random_angeldiction));
@@ -1027,7 +1027,7 @@ register struct monst	*mtmp;
 					"cleansed" : "purged"
 			);
 		else verbalize("%s", random_angeldiction[t]);
-	} else if(mtmp->data == &mons[PM_IXOTH]){
+	} else if(mtmp->mtyp == PM_IXOTH){
 		verbalize("%s", random_Ixoth[rn2(SIZE(random_Ixoth))]);
 	} else if(is_szcultist(mtmp->data)){
 		verbalize("%s", random_szcult[rn2(SIZE(random_szcult))]);

--- a/src/worm.c
+++ b/src/worm.c
@@ -198,7 +198,7 @@ worm_move(worm)
 {
     register struct wseg *seg, *new_seg;	/* new segment */
     register int	 wnum = worm->wormno;	/* worm number */
-	boolean twoLong, hh = worm->data == &mons[PM_HUNTING_HORROR];
+	boolean twoLong, hh = worm->mtyp == PM_HUNTING_HORROR;
 
 
 /*  if (!wnum) return;  bullet proofing */
@@ -420,7 +420,7 @@ cutworm(worm, x, y, weap)
      */
 
     /* Sometimes the tail end dies. */
-    if (worm->data == &mons[PM_HUNTING_HORROR] ||
+    if (worm->mtyp == PM_HUNTING_HORROR ||
 		rn2(3) || !(new_wnum = get_wormno())
 	) {
 		cutoff(worm, new_tail);
@@ -499,7 +499,7 @@ detect_wsegs(worm, use_detection_glyph)
 /*  if (!mtmp->wormno) return;  bullet proofing */
 
     while (curr != wheads[worm->wormno]) {
-	if(worm->data == &mons[PM_HUNTING_HORROR]) num = use_detection_glyph ?
+	if(worm->mtyp == PM_HUNTING_HORROR) num = use_detection_glyph ?
 		detected_monnum_to_glyph(what_mon(PM_HUNTING_HORROR_TAIL, worm)) :
 		monnum_to_glyph(what_mon(PM_HUNTING_HORROR_TAIL, worm));
 	else num = use_detection_glyph ?

--- a/src/worn.c
+++ b/src/worn.c
@@ -419,7 +419,7 @@ boolean on, silently;
 		switch (which)
 		{
 		case INVIS:
-			if (mon->data != &mons[PM_HELLCAT]){
+			if (mon->mtyp != PM_HELLCAT){
 				mon->invis_blkd = TRUE;
 				update_mon_intrinsic(mon, obj, which, !on, silently);
 			}
@@ -433,7 +433,7 @@ boolean on, silently;
 		switch (which)
 		{
 		case INVIS:
-			if (mon->data != &mons[PM_HELLCAT]){
+			if (mon->mtyp != PM_HELLCAT){
 				mon->invis_blkd = FALSE;
 				if (mon_gets_extrinsic(mon, which, obj))
 					update_mon_intrinsic(mon, obj, which, !on, silently);
@@ -515,7 +515,7 @@ boolean on, silently;
 		switch (which)
 		{
 		case INVIS:
-			if (mon->data != &mons[PM_HELLCAT]){
+			if (mon->mtyp != PM_HELLCAT){
 				mon->mextrinsics[(which-1)/32] |= (1 << (which-1)%32);
 				mon->minvis = !mon->invis_blkd;
 			}
@@ -669,15 +669,15 @@ struct monst *mon;
 	if(!mon->mcan)
 		base -= mon->data->pac;
 	
-	if(mon->data == &mons[PM_ASMODEUS] && base < -9) base = -9 + MONSTER_AC_VALUE(base+9);
-	else if(mon->data == &mons[PM_PALE_NIGHT] && base < -6) base = -6 + MONSTER_AC_VALUE(base+6);
-	else if(mon->data == &mons[PM_BAALPHEGOR] && base < -8) base = -8 + MONSTER_AC_VALUE(base+8);
-	else if(mon->data == &mons[PM_ZAPHKIEL] && base < -8) base = -8 + MONSTER_AC_VALUE(base+8);
-	else if(mon->data == &mons[PM_QUEEN_OF_STARS] && base < -6) base = -6 + MONSTER_AC_VALUE(base+6);
-	else if(mon->data == &mons[PM_ETERNAL_LIGHT] && base < -6) base = -6 + MONSTER_AC_VALUE(base+6);
-	else if(mon->data == &mons[PM_STRANGE_CORPSE] && base < -5) base = -5 + MONSTER_AC_VALUE(base+5);
-	else if(mon->data == &mons[PM_ANCIENT_OF_DEATH] && base < -4) base = -4 + MONSTER_AC_VALUE(base+4);
-	else if(mon->data == &mons[PM_CHOKHMAH_SEPHIRAH]){
+	if(mon->mtyp == PM_ASMODEUS && base < -9) base = -9 + MONSTER_AC_VALUE(base+9);
+	else if(mon->mtyp == PM_PALE_NIGHT && base < -6) base = -6 + MONSTER_AC_VALUE(base+6);
+	else if(mon->mtyp == PM_BAALPHEGOR && base < -8) base = -8 + MONSTER_AC_VALUE(base+8);
+	else if(mon->mtyp == PM_ZAPHKIEL && base < -8) base = -8 + MONSTER_AC_VALUE(base+8);
+	else if(mon->mtyp == PM_QUEEN_OF_STARS && base < -6) base = -6 + MONSTER_AC_VALUE(base+6);
+	else if(mon->mtyp == PM_ETERNAL_LIGHT && base < -6) base = -6 + MONSTER_AC_VALUE(base+6);
+	else if(mon->mtyp == PM_STRANGE_CORPSE && base < -5) base = -5 + MONSTER_AC_VALUE(base+5);
+	else if(mon->mtyp == PM_ANCIENT_OF_DEATH && base < -4) base = -4 + MONSTER_AC_VALUE(base+4);
+	else if(mon->mtyp == PM_CHOKHMAH_SEPHIRAH){
 		base -= u.chokhmah;
 	}
 	else if(is_weeping(mon->data)){
@@ -722,20 +722,20 @@ struct monst *mon;
 	
 	base = base_mac(mon);
 	
-	if(mon->data == &mons[PM_GIANT_TURTLE] && mon->mflee){
+	if(mon->mtyp == PM_GIANT_TURTLE && mon->mflee){
 		base -= 15;
 	}
 	//Block attack with weapon
 	if(mon != &youmonst &&
-		(mon->data == &mons[PM_MARILITH] 
-		|| mon->data == &mons[PM_SHAKTARI]
-		|| mon->data == &mons[PM_CATHEZAR]
+		(mon->mtyp == PM_MARILITH 
+		|| mon->mtyp == PM_SHAKTARI
+		|| mon->mtyp == PM_CATHEZAR
 	)){
 		int wcount = 0;
 		struct obj *otmp;
 		for(otmp = mon->minvent; otmp; otmp = otmp->nobj){
 			if((otmp->oclass == WEAPON_CLASS || is_weptool(otmp)
-				|| (otmp->otyp == CHAIN && mon->data == &mons[PM_CATHEZAR])
+				|| (otmp->otyp == CHAIN && mon->mtyp == PM_CATHEZAR)
 				) && !otmp->oartifact
 				&& otmp != MON_WEP(mon) && otmp != MON_SWEP(mon)
 				&& !otmp->owornmask
@@ -761,7 +761,7 @@ struct monst *mon;
 	
 	
 	//armor AC
-	if(mon->data == &mons[PM_HOD_SEPHIRAH]){
+	if(mon->mtyp == PM_HOD_SEPHIRAH){
 		if(uarm) armac += arm_ac_bonus(uarm);
 		if(uarmf) armac += arm_ac_bonus(uarmf);
 		if(uarmg) armac += arm_ac_bonus(uarmg);
@@ -795,26 +795,26 @@ struct monst *mon;
 	if(!mon->mcan)
 		base -= mon->data->pac;
 	
-	if(mon->data == &mons[PM_CHOKHMAH_SEPHIRAH]){
+	if(mon->mtyp == PM_CHOKHMAH_SEPHIRAH){
 		base -= u.chokhmah;
 	}
 	else if(is_weeping(mon->data)){
 		if(mon->mvar2 & 0x4L) base = -125; //Fully Quantum Locked
 		if(mon->mvar2 & 0x2L) base = -20; //Partial Quantum Lock
 	}
-	else if(mon->data == &mons[PM_GIANT_TURTLE] && mon->mflee){
+	else if(mon->mtyp == PM_GIANT_TURTLE && mon->mflee){
 		base -= 15;
 	}
 	else if(mon != &youmonst &&
-		(mon->data == &mons[PM_MARILITH] 
-		|| mon->data == &mons[PM_SHAKTARI]
-		|| mon->data == &mons[PM_CATHEZAR]
+		(mon->mtyp == PM_MARILITH 
+		|| mon->mtyp == PM_SHAKTARI
+		|| mon->mtyp == PM_CATHEZAR
 	)){
 		int wcount = 0;
 		struct obj *otmp;
 		for(otmp = mon->minvent; otmp; otmp = otmp->nobj){
 			if(otmp->oclass == WEAPON_CLASS || is_weptool(otmp)
-				|| (otmp->otyp == CHAIN && !otmp->owornmask && mon->data == &mons[PM_CATHEZAR])
+				|| (otmp->otyp == CHAIN && !otmp->owornmask && mon->mtyp == PM_CATHEZAR)
 			){
 				base -= 20;
 				break;
@@ -838,7 +838,7 @@ struct monst *mon;
 			base -= def_beastmastery(); // the duster doubles for tame animals
 	}
 	
-	if(mon->data == &mons[PM_HOD_SEPHIRAH]){
+	if(mon->mtyp == PM_HOD_SEPHIRAH){
 		if(uarm) armac += arm_ac_bonus(uarm);
 		if(uarmf) armac += arm_ac_bonus(uarmf);
 		if(uarmg) armac += arm_ac_bonus(uarmg);
@@ -878,15 +878,15 @@ struct monst *mon;
 	int armac = 0;
 	long mwflags = mon->misc_worn_check;
 	
-	if(mon->data == &mons[PM_GIANT_TURTLE] && mon->mflee){
+	if(mon->mtyp == PM_GIANT_TURTLE && mon->mflee){
 		armac += 15;
 	}
 	
-	if(mon->data == &mons[PM_DANCING_BLADE]){
+	if(mon->mtyp == PM_DANCING_BLADE){
 		return -20;
 	}
 	
-	if(mon->data == &mons[PM_HOD_SEPHIRAH]){
+	if(mon->mtyp == PM_HOD_SEPHIRAH){
 		if(uarm) armac += arm_ac_bonus(uarm);
 		if(uarmf) armac += arm_ac_bonus(uarmf);
 		if(uarmg) armac += arm_ac_bonus(uarmg);
@@ -932,7 +932,7 @@ struct monst *mon;
 {
 	int base = 0;
 	
-	if(mon->data == &mons[PM_CHOKHMAH_SEPHIRAH]){
+	if(mon->mtyp == PM_CHOKHMAH_SEPHIRAH){
 		base += u.chokhmah;
 	}
 	
@@ -974,7 +974,7 @@ struct monst *magr;
 	nat_dr = base_nat_mdr(mon);
 	
 	//armor AC
-	if(mon->data == &mons[PM_HOD_SEPHIRAH]){
+	if(mon->mtyp == PM_HOD_SEPHIRAH){
 		armac = roll_udr(magr);
 		if(armac < 0) armac *= -1;
 	} else {
@@ -999,7 +999,7 @@ struct monst *magr;
 			armac += arm_dr_bonus(curarm);
 			if(magr) armac += properties_dr(curarm, agralign, agrmoral);
 		}
-		if(mon->data == &mons[PM_GIANT_TURTLE] && (mon->mflee || rn2(2))){
+		if(mon->mtyp == PM_GIANT_TURTLE && (mon->mflee || rn2(2))){
 			slot = UPPER_TORSO_DR;
 		} else {
 		//Note: Bias this somehow?
@@ -1204,12 +1204,12 @@ boolean racialexception;
 		    if (!is_shirt(obj) || obj->objsize != mon->data->msize || !shirt_match(mon->data,obj)) continue;
 		    break;
 		case W_ARMC:
-			if(mon->data == &mons[PM_CATHEZAR] && obj->otyp == CHAIN)
+			if(mon->mtyp == PM_CATHEZAR && obj->otyp == CHAIN)
 				break;
 		    if (!is_cloak(obj) || (abs(obj->objsize - mon->data->msize) > 1)) continue;
 		    break;
 		case W_ARMH:
-			if(mon->data == &mons[PM_CATHEZAR] && obj->otyp == CHAIN)
+			if(mon->mtyp == PM_CATHEZAR && obj->otyp == CHAIN)
 				break;
 		    if (!is_helmet(obj) || ((!helm_match(mon->data,obj) || !has_head_mon(mon) || obj->objsize != mon->data->msize) && !is_flimsy(obj))) continue;
 		    /* (flimsy exception matches polyself handling) */
@@ -1219,17 +1219,17 @@ boolean racialexception;
 		    if (cantwield(mon->data) || !is_shield(obj)) continue;
 		    break;
 		case W_ARMG:
-			if((mon->data == &mons[PM_CATHEZAR] || mon->data == &mons[PM_WARDEN_ARIANNA]) && obj->otyp == CHAIN)
+			if((mon->mtyp == PM_CATHEZAR || mon->mtyp == PM_WARDEN_ARIANNA) && obj->otyp == CHAIN)
 				break;
 		    if (!is_gloves(obj) || obj->objsize != mon->data->msize || !can_wear_gloves(mon->data)) continue;
 		    break;
 		case W_ARMF:
-			if((mon->data == &mons[PM_WARDEN_ARIANNA]) && obj->otyp == CHAIN)
+			if((mon->mtyp == PM_WARDEN_ARIANNA) && obj->otyp == CHAIN)
 				break;
 		    if (!is_boots(obj) || obj->objsize != mon->data->msize || !can_wear_boots(mon->data)) continue;
 		    break;
 		case W_ARM:
-			if((mon->data == &mons[PM_CATHEZAR] || mon->data == &mons[PM_WARDEN_ARIANNA]) && obj->otyp == CHAIN)
+			if((mon->mtyp == PM_CATHEZAR || mon->mtyp == PM_WARDEN_ARIANNA) && obj->otyp == CHAIN)
 				break;
 		    if (!is_suit(obj) || (!Is_dragon_scales(obj) && (!arm_match(mon->data, obj) || (obj->objsize != mon->data->msize &&
 				!(is_elven_armor(obj) && abs(obj->objsize - mon->data->msize) <= 1))))

--- a/src/worn.c
+++ b/src/worn.c
@@ -684,10 +684,6 @@ struct monst *mon;
 		if(mon->mvar2 & 0x4L) base = -125; //Fully Quantum Locked
 		if(mon->mvar2 & 0x2L) base = -20; //Partial Quantum Lock
 	}
-	if(mon->mfaction == ZOMBIFIED) base += 2;
-	if(mon->mfaction == SKELIFIED) base -= 2;
-	if(mon->mfaction == CRYSTALFIED) base -= 6;
-	if(mon->mfaction == CRANIUM_RAT) base -= 4;
 	
 	if(is_alabaster_mummy(mon->data) && mon->mvar_syllable == SYLLABLE_OF_GRACE__UUR)
 		base -= 10;
@@ -699,15 +695,21 @@ struct monst *mon;
 		
 		if(u.usteed && mon==u.usteed) base -= rnd(def_mountedCombat());
 	}
-	if(helpless(mon))
+
+	if (helpless(mon))
 		base -= 5;
-	else if(which_armor(mon, W_ARM)){
-		if(is_light_armor(which_armor(mon, W_ARM)))
-			base -= mon->data->dac;
-		else if(is_medium_armor(which_armor(mon, W_ARM)))
-			base -= (mon->data->dac)/2;
+	else {
+		struct obj * armor = which_armor(mon, W_ARM);
+		register int mondodgeac = mon->data->dac;
+		if ((mondodgeac < 0)						/* penalties have full effect */
+			|| (!armor)								/* no armor = max mobility */
+			|| (armor && is_light_armor(armor))		/* light armor is also fine  */
+			)
+			base -= mondodgeac;
+		else if (armor && is_medium_armor(armor))	/* medium armor halves dodge AC */
+			base -= mondodgeac/2;
+		/* else no adjustment */
 	}
-	else base -= mon->data->dac;
 	
 	return base;
 }
@@ -750,10 +752,6 @@ struct monst *mon;
 			base -= rnd(20);
 		}
 	}
-	
-	if(mon->mfaction == ZOMBIFIED) base -= 4;
-	if(mon->mfaction == CRYSTALFIED) base -= 10;
-	if(mon->mfaction == TOMB_HERD) base -= 6;
 	
 	if(mon->mtame){
 		if(u.specialSealsActive&SEAL_COSMOS) base -= spiritDsize();	
@@ -822,10 +820,6 @@ struct monst *mon;
 		}
 	}
 	
-	if(mon->mfaction == ZOMBIFIED) base -= 2;
-	if(mon->mfaction == SKELIFIED) base -= 6;
-	if(mon->mfaction == CRYSTALFIED) base -= 16;
-	
 	if(is_alabaster_mummy(mon->data) && mon->mvar_syllable == SYLLABLE_OF_GRACE__UUR)
 		base -= 10;
 	
@@ -856,15 +850,20 @@ struct monst *mon;
 
 	base -= armac;
 	
-	if(helpless(mon))
+	if (helpless(mon))
 		base -= 5;
-	else if(which_armor(mon, W_ARM)){
-		if(is_light_armor(which_armor(mon, W_ARM)))
-			base -= mon->data->dac;
-		else if(is_medium_armor(which_armor(mon, W_ARM)))
-			base -= (mon->data->dac)/2;
+	else {
+		struct obj * armor = which_armor(mon, W_ARM);
+		register int mondodgeac = mon->data->dac;
+		if ((mondodgeac < 0)						/* penalties have full effect */
+			|| (!armor)								/* no armor = max mobility */
+			|| (armor && is_light_armor(armor))		/* light armor is also fine  */
+			)
+			base -= mondodgeac;
+		else if (armor && is_medium_armor(armor))	/* medium armor halves dodge AC */
+			base -= mondodgeac / 2;
+		/* else no adjustment */
 	}
-	else base -= mon->data->dac;
 	
 	/* since arm_ac_bonus is positive, subtracting it increases AC */
 	return base;
@@ -919,9 +918,6 @@ struct monst *mon;
 	if(mon->mtame){
 		if(u.specialSealsActive&SEAL_COSMOS) base += rnd(spiritDsize());
 	}
-	
-	if(mon->mfaction == ZOMBIFIED) base += 2;
-	if(mon->mfaction == CRYSTALFIED) base += 8;
 	
 	return base;
 }

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -4882,7 +4882,7 @@ boolean ranged;
 			}
 			/* monsters only polymorph; never system shock or degenerate */
 			else {
-				newcham(mdef, (struct permonst *) 0, FALSE, vis);
+				newcham(mdef, NON_PM, FALSE, vis);
 			}
 		}
 		return result;
@@ -5401,11 +5401,11 @@ boolean ranged;
 				/* you slimed it */
 				else if (youagr) {
 					You("turn %s into slime.", mon_nam(mdef));
-					(void)newcham(mdef, &mons[PM_GREEN_SLIME], FALSE, FALSE);
+					(void)newcham(mdef, PM_GREEN_SLIME, FALSE, FALSE);
 				}
 				/* monster slimed it */
 				else {
-					(void)newcham(mdef, &mons[PM_GREEN_SLIME], FALSE, vis);
+					(void)newcham(mdef, PM_GREEN_SLIME, FALSE, vis);
 					mdef->mstrategy &= ~STRAT_WAITFORU;
 				}
 			}
@@ -14039,10 +14039,10 @@ boolean endofchain;			/* if the attacker has finished their attack chain */
 						|| resists_poly(pa))) {
 						if (youdef) {
 							Your("%s turns %s into slime.", body_part(BODY_FLESH), mon_nam(mdef));
-							(void)newcham(mdef, &mons[PM_GREEN_SLIME], FALSE, FALSE);
+							(void)newcham(mdef, PM_GREEN_SLIME, FALSE, FALSE);
 						}
 						else {
-							(void)newcham(mdef, &mons[PM_GREEN_SLIME], FALSE, vis);
+							(void)newcham(mdef, PM_GREEN_SLIME, FALSE, vis);
 							mdef->mstrategy &= ~STRAT_WAITFORU;
 						}
 					}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -415,11 +415,11 @@ int tary;
 
 	/*	Special demon/minion handling code */
 	if (youdef && !magr->cham && (is_demon(pa) || is_minion(pa)) && !ranged
-		&& pa != &mons[PM_OONA]
-		&& pa != &mons[PM_BALROG]
-		&& pa != &mons[PM_DURIN_S_BANE]
-		&& pa != &mons[PM_SUCCUBUS]
-		&& pa != &mons[PM_INCUBUS]
+		&& pa->mtyp != PM_OONA
+		&& pa->mtyp != PM_BALROG
+		&& pa->mtyp != PM_DURIN_S_BANE
+		&& pa->mtyp != PM_SUCCUBUS
+		&& pa->mtyp != PM_INCUBUS
 		) {
 		if (!magr->mcan && !rn2(13)) {
 			msummon(magr);
@@ -509,17 +509,17 @@ int tary;
 	}
 
 	/* lillends (that aren't you) can use masks */
-	if (pa == &mons[PM_LILLEND]
+	if (pa->mtyp == PM_LILLEND
 		&& !youagr
 		&& !(magr->mfaction == ZOMBIFIED || magr->mfaction == SKELIFIED)
 		&& rn2(2)){
 		magr->mvar2 = monsndx(find_mask(magr));
-		if (!Blind && pa != &mons[PM_LILLEND] && canseemon(magr))
+		if (!Blind && pa->mtyp != PM_LILLEND && canseemon(magr))
 			pline("%s uses a %s mask!", Monnam(magr), pa->mname);
 	}
 	
 	/* deliriums use random form */
-	if (pa == &mons[PM_WALKING_DELIRIUM] && !youagr){
+	if (pa->mtyp == PM_WALKING_DELIRIUM && !youagr){
 		magr->mvar2 = select_newcham_form(magr);
 	}
 	
@@ -645,10 +645,10 @@ int tary;
 				// loop through attacker's inv to find next allowable weapon to hit with
 				for (otmp = (youagr ? invent : magr->minvent); otmp; otmp = otmp->nobj){
 					if ((otmp->oclass == WEAPON_CLASS || is_weptool(otmp)
-						|| (otmp->otyp == CHAIN && pa == &mons[PM_CATHEZAR])
+						|| (otmp->otyp == CHAIN && pa->mtyp == PM_CATHEZAR)
 						)																	// valid weapon
 						&& !(otmp->oartifact && !always_twoweapable_artifact(otmp))			// ok artifact
-						&& (!bimanual(otmp, pa) || pa == &mons[PM_GYNOID] || pa == &mons[PM_PARASITIZED_GYNOID])// not two-handed
+						&& (!bimanual(otmp, pa) || pa->mtyp == PM_GYNOID || pa->mtyp == PM_PARASITIZED_GYNOID)// not two-handed
 						&& (youagr || (otmp != MON_WEP(magr) && otmp != MON_SWEP(magr)))	// not wielded already (monster)
 						&& (!youagr || (otmp != uwep && (!u.twoweap || otmp != uswapwep)))	// not wielded already (player)
 						&& !(is_ammo(otmp) || is_pole(otmp) || throwing_weapon(otmp))		// not unsuitable for melee (ammo, throwable, polearm)
@@ -1132,7 +1132,7 @@ int tary;
 			if (youagr && aatyp == AT_MMGC)
 				continue;
 			/* Demogorgon casts spells less frequently in melee range */
-			if (pa == &mons[PM_DEMOGORGON] && !ranged && rn2(6) && !(youagr || magr->mflee))
+			if (pa->mtyp == PM_DEMOGORGON && !ranged && rn2(6) && !(youagr || magr->mflee))
 				continue;
 
 			result = xcasty(magr, mdef, attk, vis);
@@ -1143,7 +1143,7 @@ int tary;
 				/* increment number of attacks made */
 				attacksmade++;
 				/* Asmodeus randomly stops his casting early? */
-				if (pa == &mons[PM_ASMODEUS] && !rn2(3))
+				if (pa->mtyp == PM_ASMODEUS && !rn2(3))
 					result |= MM_AGR_STOP;
 			}
 			break;
@@ -1191,9 +1191,9 @@ int tary;
 		allres = xpassivey(magr, mdef, (struct attack *)0, (struct obj *)0, vis, allres, pd, TRUE);
 	
 	/* reset lillend mask usage */
-	if (!youagr && pa == &mons[PM_LILLEND])
+	if (!youagr && pa->mtyp == PM_LILLEND)
 		magr->mvar2 = 0;
-	if (!youagr && pa == &mons[PM_WALKING_DELIRIUM])
+	if (!youagr && pa->mtyp == PM_WALKING_DELIRIUM)
 		magr->mvar2 = 0;
 
 	/* do some things only if attacks were made */
@@ -1530,7 +1530,7 @@ boolean fresh;
 			if (++curindex == indexnum)
 				return &spiritattack[ATTK_IRIS];
 		}
-		if (youracedata == &mons[PM_MARILITH]){
+		if (youracedata->mtyp == PM_MARILITH){
 			/* +4 */
 			for (i = 0; i < 4; i++)
 			if (++curindex == indexnum)
@@ -1619,7 +1619,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 
 	/* lillends are able to use the attacks of another monster */
 	/* modify pa here, but only here (when getting attacks) */
-	if ((pa == &mons[PM_LILLEND] || pa == &mons[PM_WALKING_DELIRIUM]) && magr->mvar2) {
+	if ((pa->mtyp == PM_LILLEND || pa->mtyp == PM_WALKING_DELIRIUM) && magr->mvar2) {
 		pa = &mons[magr->mvar2];
 	}
 
@@ -1665,7 +1665,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 
 	/* players sub out monster claw attacks for weapon attacks */
 	if (youagr && !cantwield(pa)) {
-		if ((*indexnum == 0 || (*indexnum == 1 && (pa == &mons[PM_INCUBUS] || pa == &mons[PM_SUCCUBUS]))) &&
+		if ((*indexnum == 0 || (*indexnum == 1 && (pa->mtyp == PM_INCUBUS || pa->mtyp == PM_SUCCUBUS))) &&
 			(attk->aatyp == AT_CLAW || (attk->aatyp == AT_TUCH && pa->mlet == S_LICH && uwep)))
 		{
 			attk->aatyp = AT_WEAP;
@@ -1675,7 +1675,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		}
 	}
 	/* Grue does not make its later attacks if its square is lit */
-	if (pa == &mons[PM_GRUE] &&
+	if (pa->mtyp == PM_GRUE &&
 		!by_the_book &&
 		*indexnum >= 2 &&
 		!isdark(x(magr), y(magr))
@@ -1714,20 +1714,20 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 
 	/* the Five Fiends spellcasting -- not shown in pokedex */
 	if (!by_the_book && (
-		(pa == &mons[PM_LICH__THE_FIEND_OF_EARTH]) ||
-		(pa == &mons[PM_KARY__THE_FIEND_OF_FIRE]) ||
-		(pa == &mons[PM_KRAKEN__THE_FIEND_OF_WATER]) ||
-		(pa == &mons[PM_TIAMAT__THE_FIEND_OF_WIND]) ||
-		(pa == &mons[PM_CHAOS]))
+		(pa->mtyp == PM_LICH__THE_FIEND_OF_EARTH) ||
+		(pa->mtyp == PM_KARY__THE_FIEND_OF_FIRE) ||
+		(pa->mtyp == PM_KRAKEN__THE_FIEND_OF_WATER) ||
+		(pa->mtyp == PM_TIAMAT__THE_FIEND_OF_WIND) ||
+		(pa->mtyp == PM_CHAOS))
 		){
 		// first index -- determine if using the alternate attack set (solo spellcasting)
 		if (*indexnum == 0){
 			if (
-				(pa == &mons[PM_LICH__THE_FIEND_OF_EARTH] && rn2(4)) ||
-				(pa == &mons[PM_KARY__THE_FIEND_OF_FIRE] && rn2(100)<37) ||
-				(pa == &mons[PM_KRAKEN__THE_FIEND_OF_WATER] && rn2(100)<52) ||
-				(pa == &mons[PM_TIAMAT__THE_FIEND_OF_WIND] && !rn2(4)) ||
-				(pa == &mons[PM_CHAOS] && rn2(3))
+				(pa->mtyp == PM_LICH__THE_FIEND_OF_EARTH && rn2(4)) ||
+				(pa->mtyp == PM_KARY__THE_FIEND_OF_FIRE && rn2(100)<37) ||
+				(pa->mtyp == PM_KRAKEN__THE_FIEND_OF_WATER && rn2(100)<52) ||
+				(pa->mtyp == PM_TIAMAT__THE_FIEND_OF_WIND && !rn2(4)) ||
+				(pa->mtyp == PM_CHAOS && rn2(3))
 				){
 				*subout |= SUBOUT_SPELLS;
 				attk->aatyp = AT_MAGC;
@@ -1741,7 +1741,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 			return &noattack;
 		}
 	}
-	if(!by_the_book && pa == &mons[PM_GAE_ELADRIN]){
+	if(!by_the_book && pa->mtyp == PM_GAE_ELADRIN){
 		// first index -- determine if using the alternate attack set (solo spellcasting)
 		if (*indexnum == 0){
 			if (!magr->mcan
@@ -1760,7 +1760,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 			return &noattack;
 		}
 	}
-	if(!by_the_book && pa == &mons[PM_NITOCRIS]){
+	if(!by_the_book && pa->mtyp == PM_NITOCRIS){
 		if (attk->aatyp == AT_MAGC){
 			if (which_armor(magr, W_ARMC) && which_armor(magr, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF){
 				attk->adtyp = AD_CLRC;
@@ -1768,7 +1768,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		}
 	}
 	if(!by_the_book && 
-		(pa == &mons[PM_SMALL_GOAT_SPAWN] || pa == &mons[PM_GOAT_SPAWN] || pa == &mons[PM_GIANT_GOAT_SPAWN])
+		(pa->mtyp == PM_SMALL_GOAT_SPAWN || pa->mtyp == PM_GOAT_SPAWN || pa->mtyp == PM_GIANT_GOAT_SPAWN)
 	){
 		// first index -- determine if using the alternate attack set (one seduction attack)
 		if (*indexnum == 0){
@@ -1859,7 +1859,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		}
 	}
 	/* Bael has alternate attack routines -- not shown in pokedex */
-	if (pa == &mons[PM_BAEL] && *indexnum < NATTK && !by_the_book) {
+	if (pa->mtyp == PM_BAEL && *indexnum < NATTK && !by_the_book) {
 		static const struct attack marilithHands[6] = {
 			{ AT_MARI, AD_PHYS, 1, 15 },
 			{ AT_MARI, AD_PHYS, 1, 15 },
@@ -2160,7 +2160,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		attk->damn *= 2;
 
 	/* Bandersnatches become frumious instead of fleeing, dealing double damage -- not shown in the pokedex */
-	if (!youagr && magr->mflee && pa == &mons[PM_BANDERSNATCH] && !by_the_book)
+	if (!youagr && magr->mflee && pa->mtyp == PM_BANDERSNATCH && !by_the_book)
 		attk->damn *= 2;
 
 	/* prevent a monster with two consecutive disease or hunger attacks
@@ -2170,7 +2170,7 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		(attk->adtyp == AD_DISE ||
 		// attk->adtyp == AD_PEST ||
 		// attk->adtyp == AD_FAMN ||
-		pa == &mons[PM_ASTRAL_DEVA]) &&
+		pa->mtyp == PM_ASTRAL_DEVA) &&
 		attk->adtyp == prev_attack.adtyp
 		) {
 		attk->adtyp = AD_STUN;
@@ -2184,14 +2184,14 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		/* If player was using 'k' to kick, they are only performing kick attacks (onlykicks is a state variable defined in dokick.c) */
 		(youagr && onlykicks && attk->aatyp != AT_KICK) ||
 		/* Illurien can only engulf targets she is stuck to */
-		(youdef && mdef && pa == &mons[PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES] && attk->aatyp == AT_ENGL && (u.ustuck != magr)) ||
+		(youdef && mdef && pa->mtyp == PM_ILLURIEN_OF_THE_MYRIAD_GLIMPSES && attk->aatyp == AT_ENGL && (u.ustuck != magr)) ||
 		/* Rend attacks only happen if the previous two attacks hit */
 		(attk->aatyp == AT_REND && (prev_res[1] == MM_MISS || prev_res[2] == MM_MISS)) ||
 		/* Hugs attacks are similar, but will still happen if magr and mdef are stuck together */
 		(attk->aatyp == AT_HUGS && (prev_res[1] == MM_MISS || prev_res[2] == MM_MISS)
 			&& !(mdef && ((youdef && u.ustuck == magr) || (youagr && u.ustuck == mdef)))) ||
 		/* Demogorgon's item-stealing gaze only happens if previous two gazes worked AND he is close to his target */
-		(pa == &mons[PM_DEMOGORGON] && mdef && attk->aatyp == AT_GAZE && attk->adtyp == AD_SEDU && (
+		(pa->mtyp == PM_DEMOGORGON && mdef && attk->aatyp == AT_GAZE && attk->adtyp == AD_SEDU && (
 			prev_res[1] == MM_MISS || prev_res[2] == MM_MISS))
 		))
 	{
@@ -2629,7 +2629,7 @@ struct attack *attk;
 			pline("%s %s being %s.",
 				(youdef ? "You" : Monnam(mdef)),
 				(youdef ? "are" : "is"),
-				(pa == &mons[PM_ROPE_GOLEM] ? "choked" : "crushed")
+				(pa->mtyp == PM_ROPE_GOLEM ? "choked" : "crushed")
 				);
 			break;
 		case AT_EXPL:
@@ -3259,11 +3259,11 @@ int flat_acc;
 			if (is_prince(pa))
 				bons_acc += 5;
 			/* these guys are extra accurate */
-			if (is_uvuudaum(pa) || pa == &mons[PM_CLAIRVOYANT_CHANGED])
+			if (is_uvuudaum(pa) || pa->mtyp == PM_CLAIRVOYANT_CHANGED)
 				bons_acc += 20;
-			if (pa == &mons[PM_DANCING_BLADE])
+			if (pa->mtyp == PM_DANCING_BLADE)
 				bons_acc += 7;
-			if (pa == &mons[PM_CHOKHMAH_SEPHIRAH])
+			if (pa->mtyp == PM_CHOKHMAH_SEPHIRAH)
 				bons_acc += u.chokhmah;
 			/* simulate accuracy from stat bonuses from gloves */
 			if ((otmp = which_armor(magr, W_ARMG))) {
@@ -3328,13 +3328,13 @@ int flat_acc;
 			if ((launcher && objects[launcher->otyp].oc_skill == P_BOW) && 
 				(youagr ?
 					((Race_if(PM_ELF) || Role_if(PM_SAMURAI)) && (!Upolyd || your_race(youmonst.data))) :
-					(is_elf(pa) || pa == &mons[PM_SAMURAI]))
+					(is_elf(pa) || pa->mtyp == PM_SAMURAI))
 				)
 			{
 				rang_acc++;
 				/* even more so with their special bow */
 				if (((youagr ? (Race_if(PM_ELF)) : is_elf(pa)) && launcher->otyp == ELVEN_BOW) ||
-					((youagr ? Role_if(PM_SAMURAI) : pa == &mons[PM_SAMURAI]) && launcher->otyp == YUMI))
+					((youagr ? Role_if(PM_SAMURAI) : pa->mtyp == PM_SAMURAI) && launcher->otyp == YUMI))
 					rang_acc++;
 			}
 		}
@@ -3401,7 +3401,7 @@ int flat_acc;
 	if (youdef ? u.usleep : mdef->msleeping)
 		vdef_acc += 2;
 	if (youdef ||
-		!(pd == &mons[PM_GIANT_TURTLE] && mdef->mflee && !mdef->mcanmove)) {	// don't penalize enshelled turtles
+		!(pd->mtyp == PM_GIANT_TURTLE && mdef->mflee && !mdef->mcanmove)) {	// don't penalize enshelled turtles
 		if (youdef ? FALSE : mdef->mflee)
 			vdef_acc += 2;
 		if (youdef ? multi < 0 : !mdef->mcanmove)
@@ -3416,7 +3416,7 @@ int flat_acc;
 		vdef_acc += (pd->msize - MZ_MEDIUM);
 	}
 	/* Smaug is vulnerable to stabbings */
-	if (pd == &mons[PM_SMAUG] && fired && weapon && launcher &&
+	if (pd->mtyp == PM_SMAUG && fired && weapon && launcher &&
 		is_stabbing(weapon) && is_ammo(weapon))
 	{
 		vdef_acc += 20;
@@ -3917,7 +3917,7 @@ boolean ranged;
 		dmg = 0;
 	}
 	/* worms get increased damage on their bite if they are lined up with momentum */
-	if(!youagr && pa == &mons[PM_LONG_WORM] && magr->wormno && attk->aatyp == AT_BITE){
+	if(!youagr && pa->mtyp == PM_LONG_WORM && magr->wormno && attk->aatyp == AT_BITE){
 		if(wormline(magr, bhitpos.x, bhitpos.y))
 			dmg += d(2,4); //Add segment damage
 	}
@@ -3929,19 +3929,19 @@ boolean ranged;
 
 		if ((pa->mlet == S_SNAKE
 			|| pa->mlet == S_NAGA
-			|| pa == &mons[PM_COUATL]
-			|| pa == &mons[PM_LILLEND]
-			|| pa == &mons[PM_MEDUSA]
-			|| pa == &mons[PM_MARILITH]
-			|| pa == &mons[PM_MAMMON]
-			|| pa == &mons[PM_SHAKTARI]
-			|| pa == &mons[PM_DEMOGORGON]
-			|| pa == &mons[PM_GIANT_EEL]
-			|| pa == &mons[PM_ELECTRIC_EEL]
-			|| pa == &mons[PM_KRAKEN]
-			|| pa == &mons[PM_SALAMANDER]
-			|| pa == &mons[PM_KARY__THE_FIEND_OF_FIRE]
-			|| pa == &mons[PM_CATHEZAR]
+			|| pa->mtyp == PM_COUATL
+			|| pa->mtyp == PM_LILLEND
+			|| pa->mtyp == PM_MEDUSA
+			|| pa->mtyp == PM_MARILITH
+			|| pa->mtyp == PM_MAMMON
+			|| pa->mtyp == PM_SHAKTARI
+			|| pa->mtyp == PM_DEMOGORGON
+			|| pa->mtyp == PM_GIANT_EEL
+			|| pa->mtyp == PM_ELECTRIC_EEL
+			|| pa->mtyp == PM_KRAKEN
+			|| pa->mtyp == PM_SALAMANDER
+			|| pa->mtyp == PM_KARY__THE_FIEND_OF_FIRE
+			|| pa->mtyp == PM_CATHEZAR
 			) && u.umadness&MAD_OPHIDIOPHOBIA && !ClearThoughts && u.usanity < 100){
 			dmg += (100 - u.usanity) / 5;
 		}
@@ -3965,10 +3965,10 @@ boolean ranged;
 		}
 
 		if ((is_spider(pa)
-			|| pa == &mons[PM_SPROW]
-			|| pa == &mons[PM_DRIDER]
-			|| pa == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-			|| pa == &mons[PM_AVATAR_OF_LOLTH]
+			|| pa->mtyp == PM_SPROW
+			|| pa->mtyp == PM_DRIDER
+			|| pa->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+			|| pa->mtyp == PM_AVATAR_OF_LOLTH
 			) && u.umadness&MAD_ARACHNOPHOBIA && !ClearThoughts && u.usanity < 100){
 			dmg += (100 - u.usanity) / 5;
 		}
@@ -4254,9 +4254,9 @@ boolean ranged;
 				}
 			}
 			else {	/* potential instakills to some creatures */
-				if (pd == &mons[PM_STRAW_GOLEM] ||
-					pd == &mons[PM_PAPER_GOLEM] ||
-					pd == &mons[PM_SPELL_GOLEM]) {
+				if (pd->mtyp == PM_STRAW_GOLEM ||
+					pd->mtyp == PM_PAPER_GOLEM ||
+					pd->mtyp == PM_SPELL_GOLEM) {
 					if (youdef) {
 						/* assumes the player was polyed and not in natural form */
 						You("burn up!");
@@ -4277,7 +4277,7 @@ boolean ranged;
 						return (MM_HIT | MM_DEF_DIED | ((youagr || grow_up(magr, mdef)) ? 0 : MM_AGR_DIED));	/* grow_up might kill magr */
 					}
 				}
-				else if (pd == &mons[PM_MIGO_WORKER]) {
+				else if (pd->mtyp == PM_MIGO_WORKER) {
 					if (youdef) {
 						/* assumes the player was polyed and not in natural form */
 						You("burn up!");
@@ -4816,13 +4816,13 @@ boolean ranged;
 			&& !u.ustuck							/* can't already be stuck */
 			&& !(sticks(magr) && sticks(mdef)))		/* creatures can't grab other grabbers (gameplay limitation)  */
 		{
-			if (pa == &mons[PM_TOVE])
+			if (pa->mtyp == PM_TOVE)
 				pline("%s %s much too slithy to stick to %s!",
 				(youagr ? "You" : Monnam(magr)),
 				(youagr ? "are" : "is"),
 				((youdef && !youagr) ? "you" : mon_nam_too(mdef, magr))
 				);
-			else if (pd == &mons[PM_TOVE])
+			else if (pd->mtyp == PM_TOVE)
 				pline("%s %s much too slithy to get stuck!",
 				(youagr ? "You" : Monnam(magr)),
 				(youagr ? "are" : "is")
@@ -4895,7 +4895,7 @@ boolean ranged;
 		if (result&(MM_DEF_DIED|MM_DEF_LSVD))
 			return result;
 
-		if ((uncancelled && !rn2(4)) || pa == &mons[PM_PALE_NIGHT]) {
+		if ((uncancelled && !rn2(4)) || pa->mtyp == PM_PALE_NIGHT) {
 			if (youdef)
 				drain_en(dmg);
 			else
@@ -4953,8 +4953,8 @@ boolean ranged;
 		/* no special effect if cancelled */
 		if (notmcan){
 			/* instakills */
-			if (pd == &mons[PM_IRON_GOLEM] ||
-				pd == &mons[PM_CHAIN_GOLEM]) {
+			if (pd->mtyp == PM_IRON_GOLEM ||
+				pd->mtyp == PM_CHAIN_GOLEM) {
 				if (youdef) {
 					You("rust!");
 					/* KMH -- this is okay with unchanging */
@@ -5000,10 +5000,10 @@ boolean ranged;
 		/* no special effect if cancelled */
 		if (notmcan){
 			/* instakills */
-			if (pd == &mons[PM_WOOD_GOLEM] ||
-				pd == &mons[PM_GROVE_GUARDIAN] ||
-				pd == &mons[PM_LIVING_LECTERN] ||
-				pd == &mons[PM_LEATHER_GOLEM])  {
+			if (pd->mtyp == PM_WOOD_GOLEM ||
+				pd->mtyp == PM_GROVE_GUARDIAN ||
+				pd->mtyp == PM_LIVING_LECTERN ||
+				pd->mtyp == PM_LEATHER_GOLEM)  {
 
 				if (youdef) {
 					You("rot!");
@@ -5179,7 +5179,7 @@ boolean ranged;
 		/* Vampiric attacks drain blood, even if those that aren't bites */
 		if (attk->adtyp == AD_VAMP
 			&& has_blood_mon(mdef)
-			&& !(pa == &mons[PM_VAMPIRE_BAT] && !(youdef ? u.usleep : mdef->msleeping))	/* vampire bats need sleeping victims */
+			&& !(pa->mtyp == PM_VAMPIRE_BAT && !(youdef ? u.usleep : mdef->msleeping))	/* vampire bats need sleeping victims */
 			) {
 			/* message for a player being drained */
 			if (youdef) {
@@ -5187,7 +5187,7 @@ boolean ranged;
 			}
 
 			/* blood bloaters heal*/
-			if (pa == &mons[PM_BLOOD_BLOATER]) {
+			if (pa->mtyp == PM_BLOOD_BLOATER) {
 				/* aggressor lifesteals by dmg dealt */
 				heal(magr, min(dmg, *hp(mdef)));
 			}
@@ -5199,7 +5199,7 @@ boolean ranged;
 		/* level-draining effect doesn't actually need blood, it drains life force */
 		if ((uncancelled || (attk->adtyp == AD_VAMP && notmcan))
 			&& !Drain_res(mdef)
-			&& !(pa == &mons[PM_VAMPIRE_BAT] && !(youdef ? u.usleep : mdef->msleeping))	/* vampire bats need sleeping victims */
+			&& !(pa->mtyp == PM_VAMPIRE_BAT && !(youdef ? u.usleep : mdef->msleeping))	/* vampire bats need sleeping victims */
 			&& !rn2(3)
 			) {
 			if(attk->aatyp == AT_VINE && youdef && !HSterile){
@@ -5210,7 +5210,7 @@ boolean ranged;
 				return xmeleehurty(magr, mdef, &alt_attk, originalattk, weapon, FALSE, dmg, dieroll, vis, ranged);
 			}
 			/* blood bloaters split (but not the player) */
-			if (!youagr && pa == &mons[PM_BLOOD_BLOATER]){
+			if (!youagr && pa->mtyp == PM_BLOOD_BLOATER){
 				(void)split_mon(magr, 0);
 			}
 
@@ -5267,8 +5267,8 @@ boolean ranged;
 		}
 
 		/* wraithworms have poisonous negative-energy bites */
-		if ((pa == &mons[PM_WRAITHWORM]
-			|| pa == &mons[PM_FIRST_WRAITHWORM])) {
+		if ((pa->mtyp == PM_WRAITHWORM
+			|| pa->mtyp == PM_FIRST_WRAITHWORM)) {
 			alt_attk.adtyp = AD_DRST;
 		}
 		else {
@@ -5362,7 +5362,7 @@ boolean ranged;
 		if (uncancelled) {
 			/* flaming immunity to slime */
 			if (flaming(pd)
-				|| pd == &mons[PM_RED_DRAGON]
+				|| pd->mtyp == PM_RED_DRAGON
 				|| ((otmp = (youdef ? uarm : which_armor(mdef, W_ARM))) && (otmp->otyp == RED_DRAGON_SCALES || otmp->otyp == RED_DRAGON_SCALE_MAIL))
 				|| ((otmp = (youdef ? uarms : which_armor(mdef, W_ARMS))) && (otmp->otyp == RED_DRAGON_SCALE_SHIELD))
 				) {
@@ -5373,8 +5373,8 @@ boolean ranged;
 			}
 			/* unchanging immunity to slime */
 			else if (Change_res(mdef)
-				|| pd == &mons[PM_GREEN_SLIME]
-				|| pd == &mons[PM_FLUX_SLIME]
+				|| pd->mtyp == PM_GREEN_SLIME
+				|| pd->mtyp == PM_FLUX_SLIME
 				|| is_rider(pd)
 				|| (youdef && GoodHealth)
 				|| resists_poly(pd)) {
@@ -5467,8 +5467,8 @@ boolean ranged;
 		if (vis && dohitmsg) {
 			xyhitmsg(magr, mdef, originalattk);
 		}
-		if ((notmcan && (!rn2(10) || pa == &mons[PM_PALE_NIGHT]))
-			&& !(pa == &mons[PM_GREMLIN] && !night())
+		if ((notmcan && (!rn2(10) || pa->mtyp == PM_PALE_NIGHT))
+			&& !(pa->mtyp == PM_GREMLIN && !night())
 			)
 		{
 			/* message */
@@ -5497,7 +5497,7 @@ boolean ranged;
 				mdef->mstrategy &= ~STRAT_WAITFORU;
 				if (is_were(pd) && pd->mlet != S_HUMAN)
 					were_change(mdef);
-				if (pd == &mons[PM_CLAY_GOLEM] || pd == &mons[PM_SPELL_GOLEM]) {
+				if (pd->mtyp == PM_CLAY_GOLEM || pd->mtyp == PM_SPELL_GOLEM) {
 					if (vis) {
 						pline("Some writing vanishes from %s head!",
 							s_suffix(mon_nam(mdef)));
@@ -5524,7 +5524,7 @@ boolean ranged;
 		/* do NOT immediately print a basic hit message -- vorpality can cause a miss */
 
 		/* 1/20 chance of a vorpal strike (or 20/20 vs jabberwocks) */
-		if (!rn2(20) || pd == &mons[PM_JABBERWOCK])
+		if (!rn2(20) || pd->mtyp == PM_JABBERWOCK)
 			spec = TRUE;
 
 		if (spec &&
@@ -5579,7 +5579,7 @@ boolean ranged;
 				}
 				else {
 					/* destroy the helmet */
-					if (!otmp->oartifact || (pa == &mons[PM_DEMOGORGON])){
+					if (!otmp->oartifact || (pa->mtyp == PM_DEMOGORGON)){
 						if (youdef)
 							claws_destroy_arm(otmp);
 						else
@@ -5665,14 +5665,14 @@ boolean ranged;
 			}
 
 			int i = 1;
-			if (pa == &mons[PM_DEMOGORGON])
+			if (pa->mtyp == PM_DEMOGORGON)
 				i += rnd(4);
 
 			for (; i>0; i--){
 				if (otmp->spe > -1 * objects[(otmp)->otyp].a_ac){
 					damage_item(otmp);
 				}
-				else if (!otmp->oartifact || (pa == &mons[PM_DEMOGORGON] && !rn2(10))){
+				else if (!otmp->oartifact || (pa->mtyp == PM_DEMOGORGON && !rn2(10))){
 					if (youdef)
 						claws_destroy_arm(otmp);
 					else
@@ -5688,7 +5688,7 @@ boolean ranged;
 		/* no armor */
 		else {
 			/* Demogorgon tries to kill */
-			if (pa == &mons[PM_DEMOGORGON]) {
+			if (pa->mtyp == PM_DEMOGORGON) {
 				if (noncorporeal(pd) || amorphous(pd)) {
 					/* custom hit message */
 					if (vis && dohitmsg) {
@@ -5734,7 +5734,7 @@ boolean ranged;
 			&& !u.ustuck						/* can't already be stuck */
 			&& !(sticks(magr) && sticks(mdef))	/* grabbers can't grab other grabbers (gameplay limitation)  */
 			){
-			if (pd == &mons[PM_TOVE])
+			if (pd->mtyp == PM_TOVE)
 			{
 				/* note: assumes player is either agr or def, vis is true */
 				pline("%s, %s %s much too slithy to grab!",
@@ -6268,7 +6268,7 @@ boolean ranged;
 						(youagr ? "curse" : "curses"),
 						(youagr ? "your" : mhis(magr)));
 				}
-				else if (pa == &mons[PM_LEGION] || pa == &mons[PM_LEGIONNAIRE]); //no message
+				else if (pa->mtyp == PM_LEGION || pa->mtyp == PM_LEGIONNAIRE); //no message
 				else if (youagr || canseemon(magr)) {
 					pline("%s %s %s with a level stare.",
 						(youagr ? "You" : Monnam(magr)),
@@ -6296,7 +6296,7 @@ boolean ranged;
 	case AD_SSEX:
 #endif
 	{
-		boolean goatspawn = (pa == &mons[PM_SMALL_GOAT_SPAWN] || pa == &mons[PM_GOAT_SPAWN] || pa == &mons[PM_GIANT_GOAT_SPAWN] || pa == &mons[PM_BLESSED]);
+		boolean goatspawn = (pa->mtyp == PM_SMALL_GOAT_SPAWN || pa->mtyp == PM_GOAT_SPAWN || pa->mtyp == PM_GIANT_GOAT_SPAWN || pa->mtyp == PM_BLESSED);
 		/* make physical attack */
 		alt_attk.adtyp = AD_PHYS;
 		result = xmeleehurty(magr, mdef, &alt_attk, originalattk, weapon, dohitmsg, dmg, dieroll, vis, ranged);
@@ -6340,14 +6340,14 @@ boolean ranged;
 				if ((uleft && uleft->otyp == engagering4) || (uright && uright->otyp == engagering4)) engring = TRUE;
 				if (u.sealsActive&SEAL_ANDROMALIUS) break;
 				//pline("test string!");
-				if (pa == &mons[PM_DEMOGORGON]){
+				if (pa->mtyp == PM_DEMOGORGON){
 					buf[0] = '\0';
 					steal(magr, buf, FALSE, FALSE);
 					m_dowear(magr, FALSE);
 					return MM_HIT;
 				}
-				if ((pa == &mons[PM_FIERNA] || pa == &mons[PM_PALE_NIGHT]) && rnd(20) < 15) return MM_HIT;
-				if (((MON_WEP(magr)) && pa == &mons[PM_ALRUNES]) && !rn2(20)) return MM_HIT;
+				if ((pa->mtyp == PM_FIERNA || pa->mtyp == PM_PALE_NIGHT) && rnd(20) < 15) return MM_HIT;
+				if (((MON_WEP(magr)) && pa->mtyp == PM_ALRUNES) && !rn2(20)) return MM_HIT;
 				if (dmgtype(youracedata, AD_SEDU)
 #ifdef SEDUCE
 					|| dmgtype(youracedata, AD_SSEX) || dmgtype(youracedata, AD_LSEX)
@@ -6399,42 +6399,42 @@ boolean ranged;
 				if ((uleft && uleft->otyp == engagering1) || (uright && uright->otyp == engagering1))
 					break;
 
-				if (pa == &mons[PM_MOTHER_LILITH] && could_seduce(magr, &youmonst, attk) == 1){
+				if (pa->mtyp == PM_MOTHER_LILITH && could_seduce(magr, &youmonst, attk) == 1){
 					magr->mcan = 0;	/* Question for Chris: is this intentional? It's different from all others here. */
 					if (!rn2(4)) return MM_HIT;
 					if (dolilithseduce(magr)) return MM_AGR_STOP;
 				}
-				else if (pa == &mons[PM_BELIAL] && could_seduce(magr, &youmonst, attk) == 1){
+				else if (pa->mtyp == PM_BELIAL && could_seduce(magr, &youmonst, attk) == 1){
 					if (!rn2(4)) return MM_HIT;
 					if (dobelialseduce(magr)) return MM_AGR_STOP;
 				}
-				//	else if(pa == &mons[PM_SHAMI_AMOURAE] && could_seduce(magr, &youmonst, attk) == 1 
+				//	else if(pa->mtyp == PM_SHAMI_AMOURAE && could_seduce(magr, &youmonst, attk) == 1 
 				//		&& notmcan){
 				//		if(dosflseduce(magr)) return MM_AGR_STOP;
 				//	}
-				//	else if(pa == &mons[PM_THE_DREAMER] && could_seduce(magr, &youmonst, attk) == 2 
+				//	else if(pa->mtyp == PM_THE_DREAMER && could_seduce(magr, &youmonst, attk) == 2 
 				//		&& notmcan){
 				//	}
-				//	else if(pa == &mons[PM_XINIVRAE] && could_seduce(magr, &youmonst, attk) == 2 
+				//	else if(pa->mtyp == PM_XINIVRAE && could_seduce(magr, &youmonst, attk) == 2 
 				//		&& notmcan){
 				//	}
-				//	else if(pa == &mons[PM_LYNKHAB] && could_seduce(magr, &youmonst, attk) 
+				//	else if(pa->mtyp == PM_LYNKHAB && could_seduce(magr, &youmonst, attk) 
 				//		&& notmcan){
 				//	}
-				else if (pa == &mons[PM_MALCANTHET] && could_seduce(magr, &youmonst, attk)
+				else if (pa->mtyp == PM_MALCANTHET && could_seduce(magr, &youmonst, attk)
 					&& notmcan){
 					if (domlcseduce(magr)) return MM_AGR_STOP;
 				}
-				else if (pa == &mons[PM_GRAZ_ZT] && could_seduce(magr, &youmonst, attk)
+				else if (pa->mtyp == PM_GRAZ_ZT && could_seduce(magr, &youmonst, attk)
 					&& notmcan){
 					if (dograzseduce(magr)) return MM_AGR_STOP;
 				}
-				else if (pa == &mons[PM_PALE_NIGHT] && could_seduce(magr, &youmonst, attk)
+				else if (pa->mtyp == PM_PALE_NIGHT && could_seduce(magr, &youmonst, attk)
 					&& notmcan){
 					dopaleseduce(magr);
 					return MM_AGR_STOP;
 				}
-				else if (pa == &mons[PM_AVATAR_OF_LOLTH] && could_seduce(magr, &youmonst, attk)
+				else if (pa->mtyp == PM_AVATAR_OF_LOLTH && could_seduce(magr, &youmonst, attk)
 					&& notmcan){
 					dololthseduce(magr);
 					return MM_AGR_STOP;
@@ -6668,7 +6668,7 @@ boolean ranged;
 				}
 				break;
 			case AD_ABDC:
-				if (armuncancel || (pa == &mons[PM_PALE_NIGHT] && !rn2(3))) {
+				if (armuncancel || (pa->mtyp == PM_PALE_NIGHT && !rn2(3))) {
 					(void)safe_teleds(FALSE);
 				}
 				break;
@@ -6877,7 +6877,7 @@ boolean ranged;
 		}
 		/* maybe print glowy message */
 		if (!Blind && (youdef || canseemon(mdef))){
-			const char * glow = ((pa == &mons[PM_SWORD_ARCHON] || pa == &mons[PM_BAEL]) ?
+			const char * glow = ((pa->mtyp == PM_SWORD_ARCHON || pa->mtyp == PM_BAEL) ?
 				"faintly blue" : "sickly green");
 			if (youdef)
 				You("glow %s!", glow);
@@ -6937,7 +6937,7 @@ boolean ranged;
 		/* Special case for Migo.
 		 * Migo only scoop out brains some of the time (1/20)
 		 * Otherwise, they do a basic physical attack */
-		if (pa == &mons[PM_MIGO_PHILOSOPHER] || pa == &mons[PM_MIGO_QUEEN]) {
+		if (pa->mtyp == PM_MIGO_PHILOSOPHER || pa->mtyp == PM_MIGO_QUEEN) {
 			if (rn2(20)) {
 				/* make physical attack */
 				alt_attk.adtyp = AD_PHYS;
@@ -7061,7 +7061,7 @@ boolean ranged;
 					nomul(-1 * rnd(6), "panicking");
 				}
 				/* if a migo scooped out your brain, it stops attacking */
-				if (pa == &mons[PM_MIGO_PHILOSOPHER] || pa == &mons[PM_MIGO_QUEEN])
+				if (pa->mtyp == PM_MIGO_PHILOSOPHER || pa->mtyp == PM_MIGO_QUEEN)
 					return MM_AGR_STOP;
 			}
 		}
@@ -7278,7 +7278,7 @@ boolean ranged;
 							);
 					}
 
-					if (pd == &mons[PM_TOVE])
+					if (pd->mtyp == PM_TOVE)
 					{
 						pline("%s, %s %s much too slithy to grab!",
 							(youagr ? "Unfortunately" : "Fortunately"),
@@ -8235,11 +8235,11 @@ int vis;
 
 	/* determine spellcasting range of attacker */
 	if (is_orc(pa) ||
-		pa == &mons[PM_HEDROW_WARRIOR] ||
-		pa == &mons[PM_MINOTAUR_PRIESTESS]
+		pa->mtyp == PM_HEDROW_WARRIOR ||
+		pa->mtyp == PM_MINOTAUR_PRIESTESS
 		)
 		range = (BOLT_LIM*BOLT_LIM) / 2;
-	else if (pa == &mons[PM_CHROMATIC_DRAGON] || pa == &mons[PM_PLATINUM_DRAGON])
+	else if (pa->mtyp == PM_CHROMATIC_DRAGON || pa->mtyp == PM_PLATINUM_DRAGON)
 		range = 2;
 	else
 		range = (BOLT_LIM*BOLT_LIM);
@@ -8439,7 +8439,7 @@ int vis;
 			else if (tary - y(magr) > 0) dy = +1;
 
 			/* get monid */
-			if (magr->data == &mons[PM_HOOLOOVOO]){
+			if (magr->mtyp == PM_HOOLOOVOO){
 				if (rn2(4))
 					monid = PM_GOLDEN_HEART;
 				else
@@ -8684,7 +8684,7 @@ int vis;
 		/* the most important and most special case */
 	case AD_DGST:
 		if (youdef) {
-			if (pa == &mons[PM_METROID_QUEEN] && !Drain_resistance) {
+			if (pa->mtyp == PM_METROID_QUEEN && !Drain_resistance) {
 				losexp("life force drain", TRUE, FALSE, FALSE);
 				magr->mhpmax += d(1, 4);
 				magr->mhp += d(1, 6);
@@ -8781,7 +8781,7 @@ int vis;
 						nomovemsg = buf;
 					}
 					else pline("%s", buf);
-					if (pd == &mons[PM_GREEN_SLIME] || pd == &mons[PM_FLUX_SLIME]) {
+					if (pd->mtyp == PM_GREEN_SLIME || pd->mtyp == PM_FLUX_SLIME) {
 						Sprintf(buf, "%s isn't sitting well with you.",
 							The(pd->mname));
 						if (!Unchanging && !GoodHealth) {
@@ -8799,9 +8799,9 @@ int vis;
 			if (is_rider(mdef->data)) {
 				if (vis)
 					pline("%s %s!", Monnam(magr),
-					mdef->data == &mons[PM_FAMINE] ?
+					mdef->mtyp == PM_FAMINE ?
 					"belches feebly, shrivels up and dies" :
-					mdef->data == &mons[PM_PESTILENCE] ?
+					mdef->mtyp == PM_PESTILENCE ?
 					"coughs spasmodically and collapses" :
 					"vomits violently and drops dead");
 				mondied(magr);
@@ -9000,7 +9000,7 @@ int vis;
 			result = xdamagey(magr, mdef, attk, dmg);
 		}
 		else {
-			if (pd == &mons[PM_IRON_GOLEM] || pd == &mons[PM_CHAIN_GOLEM]) {
+			if (pd->mtyp == PM_IRON_GOLEM || pd->mtyp == PM_CHAIN_GOLEM) {
 				if (youdef) {
 					You("are laden with moisture and rust away!");
 					/* KMH -- this is okay with unchanging */
@@ -9064,7 +9064,7 @@ int vis;
 		break;
 		/* basic damage engulf types */
 	case AD_PHYS:
-		if (pa == &mons[PM_FOG_CLOUD]) {
+		if (pa->mtyp == PM_FOG_CLOUD) {
 			if (youdef) {
 				You("are laden with moisture and %s",
 					flaming(youracedata) ? "are smoldering out!" :
@@ -9087,7 +9087,7 @@ int vis;
 				}
 			}
 		}
-		else if (pa == &mons[PM_DREADBLOSSOM_SWARM]) {
+		else if (pa->mtyp == PM_DREADBLOSSOM_SWARM) {
 			if (youdef) {
 				You("are sliced by the whirling stems!");
 				exercise(A_DEX, FALSE);
@@ -9426,9 +9426,9 @@ int vis;
 			/* they also create real explosions */
 			if(!youagr)
 				mondead(magr);
-			if (pa == &mons[PM_SWAMP_FERN_SPORE])
+			if (pa->mtyp == PM_SWAMP_FERN_SPORE)
 				explode(x(magr), y(magr), AD_DISE, MON_EXPLODE, dmg, EXPL_MAGICAL, 1);
-			else if (pa == &mons[PM_BURNING_FERN_SPORE])
+			else if (pa->mtyp == PM_BURNING_FERN_SPORE)
 				explode(x(magr), y(magr), AD_PHYS, MON_EXPLODE, dmg, EXPL_YELLOW, 1);
 			else
 				explode(x(magr), y(magr), AD_ACID, MON_EXPLODE, dmg, EXPL_NOXIOUS, 1);
@@ -9483,7 +9483,7 @@ int vis;
 						You("are caught in a blast of kaleidoscopic light!");
 					chg = make_hallucinated(HHallucination + (long)dmg, FALSE, 0L);
 					You("%s.", chg ? "are freaked out" : "seem unaffected");
-					if (chg && Hallucination && magr->data == &mons[PM_DAUGHTER_OF_BEDLAM]){
+					if (chg && Hallucination && magr->mtyp == PM_DAUGHTER_OF_BEDLAM){
 						u.umadness |= MAD_DELUSIONS;
 						change_usanity(-1*rnd(6)); //Deals sanity damage
 					}
@@ -9790,7 +9790,7 @@ int vis;
 		break;
 	}
 	/* special cases */
-	if (pa == &mons[PM_MEDUSA] && adtyp == AD_STON) {	// Medusa's petrification curse
+	if (pa->mtyp == PM_MEDUSA && adtyp == AD_STON) {	// Medusa's petrification curse
 		needs_magr_eyes = FALSE;
 		maybe_not = FALSE;
 	}
@@ -9798,7 +9798,7 @@ int vis;
 	if (adtyp == AD_STON) {
 		needs_magr_eyes = needs_mdef_eyes = maybe_not = needs_uncancelled = FALSE;
 	}
-	if ((is_angel(pa) || pa == &mons[PM_BLESSED]) && adtyp == AD_BLND) {				// Angels' blinding radiance
+	if ((is_angel(pa) || pa->mtyp == PM_BLESSED) && adtyp == AD_BLND) {				// Angels' blinding radiance
 		needs_magr_eyes = FALSE;
 		maybe_not = FALSE;
 	}
@@ -9807,7 +9807,7 @@ int vis;
 		needs_uncancelled = FALSE;
 		maybe_not = FALSE;
 	}
-	if (pa == &mons[PM_DEMOGORGON]) {					// Demogorgon is special
+	if (pa->mtyp == PM_DEMOGORGON) {					// Demogorgon is special
 		needs_mdef_eyes = TRUE;
 		needs_uncancelled = FALSE;
 		maybe_not = FALSE;
@@ -9875,7 +9875,7 @@ int vis;
 	case AD_VAMP:
 	case AD_DRLI:
 		/* Demogorgon's gaze is special, of course*/
-		if (youdef && pa == &mons[PM_DEMOGORGON]){
+		if (youdef && pa->mtyp == PM_DEMOGORGON){
 			if (!Drain_resistance || !rn2(3)){
 				You("meet the gaze of Hethradiah, right head of Demogorgon!");
 				You("feel a primal darkness fall upon your soul!");
@@ -10092,7 +10092,7 @@ int vis;
 	case AD_STON:
 		/* STRAIGHT COPY-PASTE FROM ORIGINAL. */
 		if (youdef) {
-			if (pa == &mons[PM_MEDUSA]){
+			if (pa->mtyp == PM_MEDUSA){
 				static boolean tamemedusa = FALSE;
 				if (magr->mcan){
 					if (!canseemon(magr)) break;	/* silently */
@@ -10144,7 +10144,7 @@ int vis;
 				pline("%s gazes ineffectually.", Monnam(magr));
 				break;
 			}
-			else if (pa == &mons[PM_PALE_NIGHT]){
+			else if (pa->mtyp == PM_PALE_NIGHT){
 				if (canseemon(magr)) pline("%s parts her shroud!", Monnam(magr));
 				if (magr->mcan || Stone_resistance) {
 					if (!canseemon(magr)) break;	/* silently */
@@ -10186,7 +10186,7 @@ int vis;
 				}
 				return 0;
 			}
-			else if (pa == &mons[PM_BEHOLDER]){
+			else if (pa->mtyp == PM_BEHOLDER){
 				if (umetgaze(magr) && !Stone_resistance) {
 					You("meet %s gaze.", s_suffix(mon_nam(magr)));
 					stop_occupation();
@@ -10299,7 +10299,7 @@ int vis;
 		/* paralysis */
 	case AD_PLYS:
 		/* Demogorgon's gaze is special, of course*/
-		if (youdef && pa == &mons[PM_DEMOGORGON]){
+		if (youdef && pa->mtyp == PM_DEMOGORGON){
 			if ((!Free_action || rn2(2)) && (!Sleep_resistance || rn2(4))){
 				You("meet the gaze of Aameul, left head of Demogorgon!");
 				You("are mesmerized!");
@@ -10364,7 +10364,7 @@ int vis;
 		break;
 
 	case AD_ENCH:
-		if (youdef && pa == &mons[PM_DEMOGORGON]){		/* has this been depricated? */
+		if (youdef && pa->mtyp == PM_DEMOGORGON){		/* has this been depricated? */
 			struct obj *obj = some_armor(&youmonst);
 			if (drain_item(obj)) {
 				You("meet Demogorgon's gaze!");
@@ -10481,7 +10481,7 @@ int vis;
 			return MM_MISS;
 
 		/* assumes that angels with AD_BLND have a blinding radiance, which is limited range and stunning */
-		if (is_angel(pa) || pa == &mons[PM_BLESSED]) {
+		if (is_angel(pa) || pa->mtyp == PM_BLESSED) {
 			if (dist2(x(magr), y(magr), x(mdef), y(mdef)) > BOLT_LIM*BOLT_LIM)
 				return MM_MISS;
 			if (youdef) {
@@ -10653,7 +10653,7 @@ int vis;
 			if (dmg > *study) {	// reduce message spam by only showing when study is actually increased
 				if (is_orc(pa))
 					pline("%s curses and urges %s followers on.", Monnam(magr), mhis(magr));
-				else if (pa == &mons[PM_LEGION] || pa == &mons[PM_LEGIONNAIRE])
+				else if (pa->mtyp == PM_LEGION || pa->mtyp == PM_LEGIONNAIRE)
 					/* no message */;
 				else if (vis&VIS_MAGR) {
 					pline("%s studies %s with a level stare.",
@@ -10786,7 +10786,7 @@ int vis;
 				forget(10);	/* lose 10% of memory per point lost*/
 				exercise(A_WIS, FALSE);
 				/* Great Cthulhu permanently drains wisdom */
-				if ((pa == &mons[PM_GREAT_CTHULHU]) && (AMAX(A_WIS) > ATTRMIN(A_WIS)))
+				if ((pa->mtyp == PM_GREAT_CTHULHU) && (AMAX(A_WIS) > ATTRMIN(A_WIS)))
 					AMAX(A_WIS) -= 1;
 			}
 			if (dmg > 0) {
@@ -10812,7 +10812,7 @@ int vis;
 				is_blind(magr)
 				) return MM_MISS;//fail
 			//else
-			if (pa == &mons[PM_DEMOGORGON]){
+			if (pa->mtyp == PM_DEMOGORGON){
 				You("have met the twin gaze of Demogorgon, Prince of Demons!");
 				You("feel his command within you!");
 				buf[0] = '\0';
@@ -10820,8 +10820,8 @@ int vis;
 				m_dowear(magr, FALSE);
 				return MM_HIT;
 			}
-			if ((pa == &mons[PM_FIERNA] || pa == &mons[PM_PALE_NIGHT]) && rnd(20) < 15) return MM_HIT;
-			if (pa == &mons[PM_ALRUNES]){
+			if ((pa->mtyp == PM_FIERNA || pa->mtyp == PM_PALE_NIGHT) && rnd(20) < 15) return MM_HIT;
+			if (pa->mtyp == PM_ALRUNES){
 				if (MON_WEP(magr) && rn2(20)) return MM_HIT;
 			}
 			if (is_animal(pa)) {
@@ -10930,22 +10930,22 @@ int vis;
 		else {
 			int i = 0;
 			int n = 0;
-			if (pa == &mons[PM_MIGO_SOLDIER]){
+			if (pa->mtyp == PM_MIGO_SOLDIER){
 				n = rn2(4);
 				if (cansee(magr->mx, magr->my)) You("see fog billow out from around %s.", mon_nam(magr));
 				for (i = 0; i < n; i++) makemon(&mons[PM_FOG_CLOUD], magr->mx, magr->my, MM_ADJACENTOK | MM_ADJACENTSTRICT);
 			}
-			else if (pa == &mons[PM_MIGO_PHILOSOPHER]){
+			else if (pa->mtyp == PM_MIGO_PHILOSOPHER){
 				n = rn2(4);
 				if (cansee(magr->mx, magr->my)) You("see whirling snow swirl out from around %s.", mon_nam(magr));
 				for (i = 0; i < n; i++) makemon(&mons[PM_ICE_VORTEX], magr->mx, magr->my, MM_ADJACENTOK | MM_ADJACENTSTRICT);
 			}
-			else if (pa == &mons[PM_MIGO_QUEEN]){
+			else if (pa->mtyp == PM_MIGO_QUEEN){
 				n = rn2(2);
 				if (cansee(magr->mx, magr->my)) You("see scalding steam swirl out from around %s.", mon_nam(magr));
 				for (i = 0; i < n; i++) makemon(&mons[PM_STEAM_VORTEX], magr->mx, magr->my, MM_ADJACENTOK | MM_ADJACENTSTRICT);
 			}
-			else if (pa == &mons[PM_ANCIENT_TEMPEST]){
+			else if (pa->mtyp == PM_ANCIENT_TEMPEST){
 				switch (rnd(4)){
 				case 1:
 					if (cansee(magr->mx, magr->my)) You("see a whisp of cloud swirl out from %s.", mon_nam(magr));
@@ -10979,18 +10979,18 @@ int vis;
 			coord mm;
 			mm.x = magr->mx; mm.y = magr->my;
 			enexto(&mm, mm.x, mm.y, &mons[PM_DUNGEON_FERN_SPORE]);
-			if (pa == &mons[PM_DUNGEON_FERN] ||
-				pa == &mons[PM_DUNGEON_FERN_SPROUT]
+			if (pa->mtyp == PM_DUNGEON_FERN ||
+				pa->mtyp == PM_DUNGEON_FERN_SPROUT
 				) {
 				makemon(&mons[PM_DUNGEON_FERN_SPORE], mm.x, mm.y, NO_MM_FLAGS);
 			}
-			else if (pa == &mons[PM_SWAMP_FERN] ||
-				pa == &mons[PM_SWAMP_FERN_SPROUT]
+			else if (pa->mtyp == PM_SWAMP_FERN ||
+				pa->mtyp == PM_SWAMP_FERN_SPROUT
 				) {
 				makemon(&mons[PM_SWAMP_FERN_SPORE], mm.x, mm.y, NO_MM_FLAGS);
 			}
-			else if (pa == &mons[PM_BURNING_FERN] ||
-				pa == &mons[PM_BURNING_FERN_SPROUT]
+			else if (pa->mtyp == PM_BURNING_FERN ||
+				pa->mtyp == PM_BURNING_FERN_SPROUT
 				) {
 				makemon(&mons[PM_BURNING_FERN_SPORE], mm.x, mm.y, NO_MM_FLAGS);
 			}
@@ -11009,15 +11009,15 @@ int vis;
 						 magr->mfleetim = 2;
 					 }
 					 for (tmon = fmon; tmon; tmon = tmon->nmon){
-						 if (pa == &mons[PM_WATCHER_IN_THE_WATER]){
-							 if (tmon->data == &mons[PM_SWARM_OF_SNAKING_TENTACLES]) stnt++;
-							 else if (tmon->data == &mons[PM_LONG_SINUOUS_TENTACLE]) ltnt++;
+						 if (pa->mtyp == PM_WATCHER_IN_THE_WATER){
+							 if (tmon->mtyp == PM_SWARM_OF_SNAKING_TENTACLES) stnt++;
+							 else if (tmon->mtyp == PM_LONG_SINUOUS_TENTACLE) ltnt++;
 						 }
-						 else if (pa == &mons[PM_KETO]){
-							 if (tmon->data == &mons[PM_WIDE_CLUBBED_TENTACLE]) ltnt++;
+						 else if (pa->mtyp == PM_KETO){
+							 if (tmon->mtyp == PM_WIDE_CLUBBED_TENTACLE) ltnt++;
 						 }
 					 }
-					 if (pa == &mons[PM_WATCHER_IN_THE_WATER]){
+					 if (pa->mtyp == PM_WATCHER_IN_THE_WATER){
 						 if (stnt<6){
 							 makemon(&mons[PM_SWARM_OF_SNAKING_TENTACLES], magr->mx, magr->my, MM_ADJACENTOK | MM_ADJACENTSTRICT | MM_NOCOUNTBIRTH);
 						 }
@@ -11025,7 +11025,7 @@ int vis;
 							 makemon(&mons[PM_LONG_SINUOUS_TENTACLE], magr->mx, magr->my, MM_ADJACENTOK | MM_ADJACENTSTRICT | MM_NOCOUNTBIRTH);
 						 }
 					 }
-					 else if (pa == &mons[PM_KETO]){
+					 else if (pa->mtyp == PM_KETO){
 						 if (ltnt<2){
 							 makemon(&mons[PM_WIDE_CLUBBED_TENTACLE], magr->mx, magr->my, MM_ADJACENTOK | MM_ADJACENTSTRICT | MM_NOCOUNTBIRTH);
 						 }
@@ -11105,8 +11105,8 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	if (magr == &youmonst &&
 		mdef->mpeaceful &&
 		(mdef->ispriest || mdef->isshk ||
-		mdef->data == &mons[PM_WATCHMAN] ||
-		mdef->data == &mons[PM_WATCH_CAPTAIN])
+		mdef->mtyp == PM_WATCHMAN ||
+		mdef->mtyp == PM_WATCH_CAPTAIN)
 		)
 		u_anger_guards = TRUE;
 	else
@@ -11489,7 +11489,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 				sneak_attack |= SNEAK_TRAPPED;
 			if ((sgn(mdef->mx - u.ux) != sgn(mdef->mx - mdef->mux) && sgn(mdef->my - u.uy) != sgn(mdef->my - mdef->muy)) ||
 				(mdef->mux == 0 && mdef->muy == 0) ||
-				(mdef->mflee && pd != &mons[PM_BANDERSNATCH]))
+				(mdef->mflee && pd->mtyp != PM_BANDERSNATCH))
 				sneak_attack |= SNEAK_BEHIND;
 			if (((mdef->mux != u.ux || mdef->muy != u.uy) &&
 				((weapon && weapon == uwep && uwep->oartifact == ART_LIFEHUNT_SCYTHE && has_head(pd) && !is_unalive(pd))
@@ -11512,7 +11512,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 				sneak_attack |= SNEAK_HELPLESS;
 		}
 		else {
-			if (mdef->mflee && pd != &mons[PM_BANDERSNATCH])
+			if (mdef->mflee && pd->mtyp != PM_BANDERSNATCH)
 				sneak_attack |= SNEAK_BEHIND;
 			if (is_blind(mdef))
 				sneak_attack |= SNEAK_BLINDED;
@@ -11528,7 +11528,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 		int snekdie = mlev(magr);
 		/* some things increase sneak attack die size */
 		if ((weapon && weapon->oartifact == ART_SILVER_STARLIGHT) ||
-			(pa == &mons[PM_CUPRILACH_RILMANI]))
+			(pa->mtyp == PM_CUPRILACH_RILMANI))
 			snekdie = snekdie * 3 / 2;
 
 		/* some things increase the number of sneak dice even further */
@@ -11774,7 +11774,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			if(is_holy_mon(magr)) {
 				holyobj |= W_SKIN;
 				seardmg += d(3, 7);
-			} else if(magr->data == &mons[PM_UVUUDAUM]){
+			} else if(magr->mtyp == PM_UVUUDAUM){
 				uuvuglory |= W_SKIN;
 				seardmg += d(4, 9);
 			}
@@ -11783,7 +11783,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			if(is_unholy_mon(magr)) {
 				unholyobj |= W_SKIN;
 				seardmg += d(4, 9);
-			} else if(magr->data == &mons[PM_UVUUDAUM]){
+			} else if(magr->mtyp == PM_UVUUDAUM){
 				uuvuglory |= W_SKIN;
 				seardmg += d(3, 7);
 			}
@@ -12041,9 +12041,9 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			mdef->zombify = 1;
 		}
 
-		if ((magr->data == &mons[PM_UNDEAD_KNIGHT]
-			|| magr->data == &mons[PM_WARRIOR_OF_SUNLIGHT]
-			|| magr->data == &mons[PM_DREAD_SERAPH]
+		if ((magr->mtyp == PM_UNDEAD_KNIGHT
+			|| magr->mtyp == PM_WARRIOR_OF_SUNLIGHT
+			|| magr->mtyp == PM_DREAD_SERAPH
 			) && can_undead_mon(mdef)){
 			mdef->zombify = 1;
 		}
@@ -12381,7 +12381,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 								if (melee && weapon->quan > 1)
 									what = An(singular(weapon, xname));
 								/* note: s_suffix returns a modifiable buffer */
-								if (haseyes(pd) && pd != &mons[PM_FLOATING_EYE])
+								if (haseyes(pd) && pd->mtyp != PM_FLOATING_EYE)
 									whom = strcat(strcat(s_suffix(whom), " "),
 									mbodypart(mdef, FACE));
 								pline("%s %s over %s!",
@@ -12529,7 +12529,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			else
 				basedmg = 1;
 			/* martial players are much better at kicking */
-			if (youagr && (martial_bonus() || (youracedata == &mons[PM_SASQUATCH]) || (uarmf && uarmf->otyp == KICKING_BOOTS)))
+			if (youagr && (martial_bonus() || (youracedata->mtyp == PM_SASQUATCH) || (uarmf && uarmf->otyp == KICKING_BOOTS)))
 				basedmg += rn2(ACURR(A_DEX)/2 + 1);
 		}
 
@@ -12990,7 +12990,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	}
 	/* Apply DR */
 	if (subtotl > 0){
-		if(pd == &mons[PM_DEEP_DWELLER] && !rn2(10)){
+		if(pd->mtyp == PM_DEEP_DWELLER && !rn2(10)){
 			/*Brain struck.  Ouch.*/
 			if(youdef)
 				pline("Your brain-organ is struck!");
@@ -13015,8 +13015,8 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	won't swallow the corpse; but if the target survives,
 	the subsequent engulf attack should accomplish that */
 	if (!youdef && !youagr &&
-		pa == &mons[PM_PURPLE_WORM] &&
-		pd == &mons[PM_SHRIEKER] &&
+		pa->mtyp == PM_PURPLE_WORM &&
+		pd->mtyp == PM_SHRIEKER &&
 		(subtotl > *hp(mdef)))
 		subtotl = max(*hp(mdef) - 1, 1);
 
@@ -13805,7 +13805,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	}
 
 	/* pudding division */
-	if ((pd == &mons[PM_BLACK_PUDDING] || pd == &mons[PM_BROWN_PUDDING] || pd == &mons[PM_DARKNESS_GIVEN_HUNGER])
+	if ((pd->mtyp == PM_BLACK_PUDDING || pd->mtyp == PM_BROWN_PUDDING || pd->mtyp == PM_DARKNESS_GIVEN_HUNGER)
 		&& weapon && (valid_weapon_attack || invalid_weapon_attack)
 		&& weapon->obj_material == IRON
 		&& melee && (youdef || !mdef->mcan)) {
@@ -13830,7 +13830,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	}
 
 	/* uranium imp warping -- not implemented for the player defending */
-	if (pd == &mons[PM_URANIUM_IMP] && !mdef->mcan && !youdef){
+	if (pd->mtyp == PM_URANIUM_IMP && !mdef->mcan && !youdef){
 		/* avoid mysterious force message by not using tele_restrict() */
 		if (canseemon(mdef)) {
 			pline("%s %s reality!",
@@ -13948,7 +13948,7 @@ boolean endofchain;			/* if the attacker has finished their attack chain */
 		vis = getvis(magr, mdef, 0, 0);
 
 	/* Lillends can use masks to counterattack (but only at the end of the chain) */
-	if (!youdef && pd == &mons[PM_LILLEND] && !(mdef->mfaction == ZOMBIFIED || mdef->mfaction == SKELIFIED) && rn2(2) && endofchain){
+	if (!youdef && pd->mtyp == PM_LILLEND && !(mdef->mfaction == ZOMBIFIED || mdef->mfaction == SKELIFIED) && rn2(2) && endofchain){
 		pd = find_mask(mdef);
 		/* message moved to AFTER getting passive attack, to avoid printing a useless message 
 		 * like "The lillend uses a rothe mask!" */
@@ -13972,7 +13972,7 @@ boolean endofchain;			/* if the attacker has finished their attack chain */
 			continue;
 
 		/* Only make noise about the lillend mask if applicable */
-		if (!youdef && mdef->data == &mons[PM_LILLEND] && passive != &noattack && pd != mdef->data && !Blind && canseemon(mdef) &&
+		if (!youdef && mdef->mtyp == PM_LILLEND && passive != &noattack && pd != mdef->data && !Blind && canseemon(mdef) &&
 			!usedmask) {
 			usedmask = TRUE;
 			pline("%s uses a %s mask!", Monnam(mdef), pd->mname);
@@ -14030,11 +14030,11 @@ boolean endofchain;			/* if the attacker has finished their attack chain */
 					if (newres&MM_DEF_LSVD)
 						result |= MM_AGR_STOP;	/* attacker lifesaved */
 				}
-				else if (pd == &mons[PM_GREEN_SLIME] || pd == &mons[PM_FLUX_SLIME]) {
+				else if (pd->mtyp == PM_GREEN_SLIME || pd->mtyp == PM_FLUX_SLIME) {
 					/* slime it */
 					if (!(Change_res(magr)
-						|| pa == &mons[PM_GREEN_SLIME]
-						|| pa == &mons[PM_FLUX_SLIME]
+						|| pa->mtyp == PM_GREEN_SLIME
+						|| pa->mtyp == PM_FLUX_SLIME
 						|| is_rider(pa)
 						|| resists_poly(pa))) {
 						if (youdef) {
@@ -14317,7 +14317,7 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 			case AD_RUST:
 				if (youdef || !mdef->mcan) {
 					/* naiads have additional limitations */
-					if (pd == &mons[PM_NAIAD]){
+					if (pd->mtyp == PM_NAIAD){
 						if (((*hp(mdef) < *hpmax(mdef) / 2) && rn2(3)) ||
 							result&MM_DEF_DIED) {
 							if (youdef) {
@@ -14448,11 +14448,11 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 			case AD_BARB:
 				/* message */
 				if (youagr) {
-					if (pd == &mons[PM_RAZORVINE]) You("are hit by the springing vines!");
+					if (pd->mtyp == PM_RAZORVINE) You("are hit by the springing vines!");
 					else You("are hit by %s barbs!", s_suffix(mon_nam(mdef)));
 				}
 				else if (vis) {
-					if (pd == &mons[PM_RAZORVINE]) {
+					if (pd->mtyp == PM_RAZORVINE) {
 						pline("%s is hit by %s springing vines!",
 							Monnam(mdef),
 							(youdef ? "your" : s_suffix(mon_nam(mdef)))
@@ -14545,7 +14545,7 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 				break;
 			case AD_HLBD:
 				/* Legion gets many zombies and legionnaires */
-				if (pd == &mons[PM_LEGION]) {
+				if (pd->mtyp == PM_LEGION) {
 					int n = rnd(4);
 					for (; n > 0; n--) {
 						mtmp = (rn2(7) ? makemon(mkclass(S_ZOMBIE, G_NOHELL | G_HELL), x(mdef), y(mdef), NO_MINVENT|MM_ADJACENTOK|MM_ADJACENTSTRICT|maketame)
@@ -14600,7 +14600,7 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 			case AD_DISE:
 				if (youdef || !mdef->mcan) {
 					/* swamp nymphs have additional limitations, like naiads */
-					if (pd == &mons[PM_SWAMP_NYMPH]){
+					if (pd->mtyp == PM_SWAMP_NYMPH){
 						if (((*hp(mdef) < *hpmax(mdef) / 2) && rn2(3)) ||
 							result&MM_DEF_DIED) {
 							if (youdef) {
@@ -14628,7 +14628,7 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 					{
 						if ((youdef && !rn2(4)) || !mdef->mspec_used) {
 							if (!rn2(3) ||
-								pd == &mons[PM_ZUGGTMOY]) {
+								pd->mtyp == PM_ZUGGTMOY) {
 								if (canseemon(mdef))
 									pline("A cloud of spores is released!");
 								if (!youdef)
@@ -14849,9 +14849,9 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 							result |= MM_AGR_STOP;	/* attacker lifesaved */
 
 						/* some monsters get stronger, and split! */
-						if (pd == &mons[PM_BROWN_MOLD] ||
-							pd == &mons[PM_BLUE_JELLY] ||
-							pd == &mons[PM_ASPECT_OF_THE_SILENCE]
+						if (pd->mtyp == PM_BROWN_MOLD ||
+							pd->mtyp == PM_BLUE_JELLY ||
+							pd->mtyp == PM_ASPECT_OF_THE_SILENCE
 							) {
 							*hp(mdef) += dmg / 2;
 							if (*hpmax(mdef) < *hp(mdef))

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -1596,17 +1596,16 @@ int * indexnum;					/* index number to use, incremented HERE (if actually pullin
 struct attack * prev_and_buf;	/* double-duty pointer: 1st, is the previous attack; 2nd, is a pointer to allocated memory */
 boolean by_the_book;			/* if true, gives the "standard" attacks for [magr]. Useful for the pokedex. */
 int * subout;					/* records what attacks have been subbed out */
-#define SUBOUT_UNDEAD	0x0001	/* derived undead special attack */
-#define SUBOUT_SPELLS	0x0002	/* Spellcasting attack instead (Five Fiends of Chaos1 and Gae) */
-#define SUBOUT_BAEL1	0x0004	/* Bael's Sword Archon attack chain */
-#define SUBOUT_BAEL2	0x0008	/* Bael's marilith-hands attack chain */
-#define SUBOUT_SPIRITS	0x0010	/* Player's bound spirits */
-#define SUBOUT_BARB1	0x0020	/* 1st bit of barbarian bonus attacks */
-#define SUBOUT_BARB2	0x0040	/* 2nd bit of barbarian bonus attacks, must directly precede the 1st bit */
-#define SUBOUT_MAINWEPB	0x0080	/* Bonus attack caused by the wielded *mainhand* weapon */
-#define SUBOUT_XWEP		0x0100	/* when giving additional attacks, whether or not to use AT_XWEP or AT_WEAP this call */
-#define SUBOUT_GOATSPWN	0x0200	/* Goat spawn: seduction */
-#define SUBOUT_GRAPPLE	0x0400	/* Grappler's Grasp crushing damage */
+#define SUBOUT_SPELLS	0x0001	/* Spellcasting attack instead (Five Fiends of Chaos1 and Gae) */
+#define SUBOUT_BAEL1	0x0002	/* Bael's Sword Archon attack chain */
+#define SUBOUT_BAEL2	0x0004	/* Bael's marilith-hands attack chain */
+#define SUBOUT_SPIRITS	0x0008	/* Player's bound spirits */
+#define SUBOUT_BARB1	0x0010	/* 1st bit of barbarian bonus attacks */
+#define SUBOUT_BARB2	0x0020	/* 2nd bit of barbarian bonus attacks, must directly precede the 1st bit */
+#define SUBOUT_MAINWEPB	0x0040	/* Bonus attack caused by the wielded *mainhand* weapon */
+#define SUBOUT_XWEP		0x0080	/* when giving additional attacks, whether or not to use AT_XWEP or AT_WEAP this call */
+#define SUBOUT_GOATSPWN	0x0100	/* Goat spawn: seduction */
+#define SUBOUT_GRAPPLE	0x0200	/* Grappler's Grasp crushing damage */
 int * tohitmod;					/* some attacks are made with decreased accuracy */
 {
 	struct attack * attk;
@@ -2055,7 +2054,6 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 	}
 	return attk;
 }
-#undef SUBOUT_UNDEAD
 #undef SUBOUT_SPELLS
 #undef SUBOUT_BAEL1
 #undef SUBOUT_BAEL2

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -72,15 +72,15 @@ boolean active;
 
 	/* some creatures are limited in *where* they can attack */
 	/* Grid bugs and Bebeliths cannot attack at an angle. */
-	if ((pa == &mons[PM_GRID_BUG] || pa == &mons[PM_BEBELITH])
+	if ((pa->mtyp == PM_GRID_BUG || pa->mtyp == PM_BEBELITH)
 		&& x(magr) != tarx && y(magr) != tary)
 		return FALSE;
 
 	/* limited attack angles (monster-agressor only) */
 	if (!youagr && (
-		pa == &mons[PM_CLOCKWORK_SOLDIER] || pa == &mons[PM_CLOCKWORK_DWARF] ||
-		pa == &mons[PM_FABERGE_SPHERE] || pa == &mons[PM_FIREWORK_CART] ||
-		pa == &mons[PM_JUGGERNAUT] || pa == &mons[PM_ID_JUGGERNAUT]))
+		pa->mtyp == PM_CLOCKWORK_SOLDIER || pa->mtyp == PM_CLOCKWORK_DWARF ||
+		pa->mtyp == PM_FABERGE_SPHERE || pa->mtyp == PM_FIREWORK_CART ||
+		pa->mtyp == PM_JUGGERNAUT || pa->mtyp == PM_ID_JUGGERNAUT))
 	{
 		if (x(magr) + xdir[(int)magr->mvar1] != tarx ||
 			y(magr) + ydir[(int)magr->mvar1] != tary)
@@ -324,19 +324,19 @@ struct monst * mon;
 
 	if ((mon->data->mlet == S_SNAKE
 		|| mon->data->mlet == S_NAGA
-		|| mon->data == &mons[PM_COUATL]
-		|| mon->data == &mons[PM_LILLEND]
-		|| mon->data == &mons[PM_MEDUSA]
-		|| mon->data == &mons[PM_MARILITH]
-		|| mon->data == &mons[PM_MAMMON]
-		|| mon->data == &mons[PM_SHAKTARI]
-		|| mon->data == &mons[PM_DEMOGORGON]
-		|| mon->data == &mons[PM_GIANT_EEL]
-		|| mon->data == &mons[PM_ELECTRIC_EEL]
-		|| mon->data == &mons[PM_KRAKEN]
-		|| mon->data == &mons[PM_SALAMANDER]
-		|| mon->data == &mons[PM_KARY__THE_FIEND_OF_FIRE]
-		|| mon->data == &mons[PM_CATHEZAR]
+		|| mon->mtyp == PM_COUATL
+		|| mon->mtyp == PM_LILLEND
+		|| mon->mtyp == PM_MEDUSA
+		|| mon->mtyp == PM_MARILITH
+		|| mon->mtyp == PM_MAMMON
+		|| mon->mtyp == PM_SHAKTARI
+		|| mon->mtyp == PM_DEMOGORGON
+		|| mon->mtyp == PM_GIANT_EEL
+		|| mon->mtyp == PM_ELECTRIC_EEL
+		|| mon->mtyp == PM_KRAKEN
+		|| mon->mtyp == PM_SALAMANDER
+		|| mon->mtyp == PM_KARY__THE_FIEND_OF_FIRE
+		|| mon->mtyp == PM_CATHEZAR
 		) && roll_madness(MAD_OPHIDIOPHOBIA)){
 		pline("You're afraid to go near that horrid serpent!");
 		return TRUE;
@@ -348,10 +348,10 @@ struct monst * mon;
 	}
 
 	if ((is_spider(mon->data)
-		|| mon->data == &mons[PM_SPROW]
-		|| mon->data == &mons[PM_DRIDER]
-		|| mon->data == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-		|| mon->data == &mons[PM_AVATAR_OF_LOLTH]
+		|| mon->mtyp == PM_SPROW
+		|| mon->mtyp == PM_DRIDER
+		|| mon->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+		|| mon->mtyp == PM_AVATAR_OF_LOLTH
 		) && roll_madness(MAD_ARACHNOPHOBIA)){
 		pline("You're afraid to go near that terrifying spider!");
 		return TRUE;
@@ -435,7 +435,7 @@ struct monst *mtmp;
 	
 	if (Role_if(PM_KNIGHT) && u.ualign.type == A_LAWFUL &&
 	    (!mtmp->mcanmove || !mtmp->mnotlaugh || mtmp->msleeping ||
-		(mtmp->mflee && mtmp->data != &mons[PM_BANDERSNATCH] && !mtmp->mavenge))){
+		(mtmp->mflee && mtmp->mtyp != PM_BANDERSNATCH && !mtmp->mavenge))){
 		    You("caitiff!");
 			if(u.ualign.record > 10) {
 				u.ualign.sins++;
@@ -486,7 +486,7 @@ demonpet()
 	i = (!is_demon(youracedata) || !rn2(6)) 
 	     ? ndemon(u.ualign.type) : NON_PM;
 	pm = i != NON_PM ? &mons[i] : youracedata;
-	if(pm == &mons[PM_ANCIENT_OF_ICE] || pm == &mons[PM_ANCIENT_OF_DEATH]) {
+	if(pm->mtyp == PM_ANCIENT_OF_ICE || pm->mtyp == PM_ANCIENT_OF_DEATH) {
 	    pm = rn2(4) ? &mons[PM_METAMORPHOSED_NUPPERIBO] : &mons[PM_ANCIENT_NUPPERIBO];
 	}
 	if ((dtmp = makemon(pm, u.ux, u.uy, NO_MM_FLAGS)) != 0)
@@ -1214,10 +1214,10 @@ struct permonst * pd;
 
 	/* consuming the defender is fatal */
 	if ((is_deadly(pd) || 
-		((pd == &mons[PM_GREEN_SLIME] || pd == &mons[PM_FLUX_SLIME]) &&
+		((pd->mtyp == PM_GREEN_SLIME || pd->mtyp == PM_FLUX_SLIME) &&
 			!(Change_res(magr)
-			|| pa == &mons[PM_GREEN_SLIME]
-			|| pa == &mons[PM_FLUX_SLIME]
+			|| pa->mtyp == PM_GREEN_SLIME
+			|| pa->mtyp == PM_FLUX_SLIME
 			|| is_rider(pa)
 			|| resists_poly(pa)))
 		) && (

--- a/src/zap.c
+++ b/src/zap.c
@@ -285,7 +285,7 @@ struct obj *otmp;
 			/* flags.bypasses = TRUE; ## for make_corpse() */
 			/* no corpse after system shock */
 			xkilled(mtmp, 3);
-		    } else if (newcham(mtmp, (struct permonst *)0,
+		    } else if (newcham(mtmp, NON_PM,
 				       (otyp != POT_POLYMORPH), FALSE)) {
 			if (!Hallucination && canspotmon(mtmp))
 			    makeknown(otyp);
@@ -398,7 +398,7 @@ struct obj *otmp;
 		if (monsndx(mtmp->data) == PM_STONE_GOLEM) {
 		    char *name = Monnam(mtmp);
 		    /* turn into flesh golem */
-		    if (newcham(mtmp, &mons[PM_FLESH_GOLEM], FALSE, FALSE)) {
+		    if (newcham(mtmp, PM_FLESH_GOLEM, FALSE, FALSE)) {
 			if (canseemon(mtmp))
 			    pline("%s turns to flesh!", name);
 		    } else {
@@ -4529,25 +4529,25 @@ int type;
 		fix_object(otmp);
 	}
 	if(mon->data == &mons[PM_PARASITIZED_ANDROID]){
-		newcham(mon, &mons[PM_ANDROID], FALSE, FALSE);
+		newcham(mon, PM_ANDROID, FALSE, FALSE);
 		mon->m_lev = 7;
 		mon->mhpmax = d(7,8);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
 	else if(mon->data == &mons[PM_PARASITIZED_GYNOID]){
-		newcham(mon, &mons[PM_GYNOID], FALSE, FALSE);
+		newcham(mon, PM_GYNOID, FALSE, FALSE);
 		mon->m_lev = 14;
 		mon->mhpmax = d(14,8);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
 	else if(mon->data == &mons[PM_PARASITIZED_OPERATOR]){
-		newcham(mon, &mons[PM_OPERATOR], FALSE, FALSE);
+		newcham(mon, PM_OPERATOR, FALSE, FALSE);
 		mon->m_lev = 7;
 		mon->mhpmax = d(7,8);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
 	else if(mon->data == &mons[PM_PARASITIZED_COMMANDER]){
-		newcham(mon, &mons[PM_COMMANDER], FALSE, FALSE);
+		newcham(mon, PM_COMMANDER, FALSE, FALSE);
 		mon->m_lev = 3;
 		mon->mhpmax = 20+rn2(4);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
@@ -4561,7 +4561,7 @@ int type;
 		mon->movement = 0;
 	}
 	else if(mon->data == &mons[PM_PARASITIZED_DOLL]){
-		newcham(mon, &mons[PM_LIVING_DOLL], FALSE, FALSE);
+		newcham(mon, PM_LIVING_DOLL, FALSE, FALSE);
 		mon->m_lev = 15;
 		mon->mhpmax = 60;
 		mon->mhp = min(mon->mhp, mon->mhpmax);

--- a/src/zap.c
+++ b/src/zap.c
@@ -588,8 +588,7 @@ coord *cc;
 	if (obj->oxlth && (obj->oattached == OATTACHED_MONST))
 		mtmp2 = get_mtraits(obj, TRUE);
 	if (mtmp2) {
-		/* save_mtraits() validated mtmp2->mtyp */
-		mtmp2->data = &mons[mtmp2->mtyp];
+		set_mon_data(mtmp2, mtmp2->mtyp, 0);
 		if (mtmp2->mhpmax <= 0 && !is_rider(mtmp2->data))
 			return (struct monst *)0;
 		mtmp = makemon(mtmp2->data,
@@ -798,7 +797,7 @@ boolean dolls;
 				if (obj->onamelth)
 					mtmp = christen_monst(mtmp, ONAME(obj));
 				/* flag the quest leader as alive. */
-				if (mtmp->data == &mons[urole.ldrnum] || mtmp->m_id ==
+				if (mtmp->mtyp == urole.ldrnum || mtmp->m_id ==
 					quest_status.leader_m_id) {
 					quest_status.leader_m_id = mtmp->m_id;
 					quest_status.leader_is_dead = FALSE;
@@ -850,7 +849,7 @@ boolean dolls;
 				panic("revive");
 			}
 			if(wasfossil){
-				mtmp->mfaction = SKELIFIED;
+				set_faction(mtmp, SKELIFIED);
 				newsym(mtmp->mx,mtmp->my);
 			}
 		}
@@ -3503,7 +3502,7 @@ struct obj **ootmp;	/* to return worn armor for caller to disintegrate */
 		else if(is_delouseable(mon->data)){
 			if (canseemon(mon))
 				pline("The parasite is killed!");
-			mon->mfaction = DELOUSED;
+			set_faction(mon, DELOUSED);
 			break;
 		}
 		if (mon->mtyp == PM_DEATH) {
@@ -4566,7 +4565,7 @@ int type;
 		mon->mhpmax = 60;
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
-	mon->mfaction = DELOUSED;
+	set_faction(mon, DELOUSED);
 	mon->mtame = 0;
 	mon->mpeaceful = 1;
 	mon->mcanmove = 1;
@@ -4578,9 +4577,9 @@ delouse_tame(mon)
 struct monst *mon;
 {
 	struct monst *mtmp;
-	mon->mfaction = 0;
+	set_faction(mtmp, 0);
 	if(mon->mtyp == PM_COMMANDER){
-		mon->mfaction = M_GREAT_WEB;
+		set_faction(mon, M_GREAT_WEB);
 	}
 	if(mon->mtyp == PM_LIVING_DOLL){
 		mon->mpeaceful = 1;

--- a/src/zap.c
+++ b/src/zap.c
@@ -349,7 +349,7 @@ struct obj *otmp;
 	case SPE_HEALING:
 	case SPE_EXTRA_HEALING:
 		reveal_invis = TRUE;
-	    if (mtmp->data != &mons[PM_PESTILENCE]) {
+	    if (mtmp->mtyp != PM_PESTILENCE) {
 		wake = FALSE;		/* wakeup() makes the target angry */
 		mtmp->mhp += d(6, otyp == SPE_EXTRA_HEALING ? 8 : 4);
 		if (mtmp->mhp > mtmp->mhpmax)
@@ -630,7 +630,7 @@ coord *cc;
 		mtmp2->mtrapped = 0;
 		mtmp2->msleeping = 0;
 		mtmp2->mfrozen = 0;
-      if(mtmp->data == &mons[PM_GIANT_TURTLE] && (mtmp->mflee))
+      if(mtmp->mtyp == PM_GIANT_TURTLE && (mtmp->mflee))
         mtmp2->mcanmove=0;
       else
 		mtmp2->mcanmove = 1;
@@ -779,7 +779,7 @@ boolean dolls;
 					(void) memcpy((genericptr_t)&m_id,
 						(genericptr_t)obj->oextra, sizeof(m_id));
 					ghost = find_mid(m_id, FM_FMON);
-						if (ghost && ghost->data == &mons[PM_GHOST]) {
+						if (ghost && ghost->mtyp == PM_GHOST) {
 							int x2, y2;
 							x2 = ghost->mx; y2 = ghost->my;
 							if (ghost->mtame)
@@ -2812,7 +2812,7 @@ int gaze_cancel;
 	    if (is_were(mdef->data) && mdef->data->mlet != S_HUMAN)
 		were_change(mdef);
 
-	    if (mdef->data == &mons[PM_CLAY_GOLEM] || mdef->data == &mons[PM_SPELL_GOLEM]) {
+	    if (mdef->mtyp == PM_CLAY_GOLEM || mdef->mtyp == PM_SPELL_GOLEM) {
 		if (canseemon(mdef))
 		    pline(writing_vanishes, s_suffix(mon_nam(mdef)));
 
@@ -3474,25 +3474,25 @@ struct obj **ootmp;	/* to return worn armor for caller to disintegrate */
 		break;
 
 	case AD_DEAD:		/* death*/
-		if(mon->data==&mons[PM_METROID]){
+		if(mon->mtyp==PM_METROID){
 			if (canseemon(mon))
 				pline("The metroid is irradiated with pure energy!  It divides!");
 			makemon(&mons[PM_METROID], mon->mx, mon->my, MM_ADJACENTOK);
 			break;
 		}
-		else if(mon->data==&mons[PM_ALPHA_METROID]||mon->data==&mons[PM_GAMMA_METROID]){
+		else if(mon->mtyp==PM_ALPHA_METROID||mon->mtyp==PM_GAMMA_METROID){
 			if (canseemon(mon))
 				pline("The metroid is irradiated with pure energy!  It buds off a baby metroid!");
 			makemon(&mons[PM_BABY_METROID], mon->mx, mon->my, MM_ADJACENTOK);
 			break;
 		}
-		else if(mon->data==&mons[PM_ZETA_METROID]||mon->data==&mons[PM_OMEGA_METROID]){
+		else if(mon->mtyp==PM_ZETA_METROID||mon->mtyp==PM_OMEGA_METROID){
 			if (canseemon(mon))
 				pline("The metroid is irradiated with pure energy!  It buds off another metroid!");
 			makemon(&mons[PM_METROID], mon->mx, mon->my, MM_ADJACENTOK);
 			break;
 		}
-		else if(mon->data==&mons[PM_METROID_QUEEN]){
+		else if(mon->mtyp==PM_METROID_QUEEN){
 			if (canseemon(mon))
 				pline("The metroid queen is irradiated with pure energy!  She buds off more metroids!");
 			makemon(&mons[PM_METROID], mon->mx, mon->my, MM_ADJACENTOK);
@@ -3506,7 +3506,7 @@ struct obj **ootmp;	/* to return worn armor for caller to disintegrate */
 			mon->mfaction = DELOUSED;
 			break;
 		}
-		if (mon->data == &mons[PM_DEATH]) {
+		if (mon->mtyp == PM_DEATH) {
 			mon->mhpmax += mon->mhpmax / 2;
 			if (mon->mhpmax >= MAGIC_COOKIE)
 				mon->mhpmax = MAGIC_COOKIE - 1;
@@ -3650,10 +3650,10 @@ struct obj **ootmp;	/* to return worn armor for caller to disintegrate */
 	    tmp /= 6;
 	}
 	if(yours && (is_spider(mon->data) 
-		|| mon->data == &mons[PM_SPROW]
-		|| mon->data == &mons[PM_DRIDER]
-		|| mon->data == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-		|| mon->data == &mons[PM_AVATAR_OF_LOLTH]
+		|| mon->mtyp == PM_SPROW
+		|| mon->mtyp == PM_DRIDER
+		|| mon->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+		|| mon->mtyp == PM_AVATAR_OF_LOLTH
 	) && roll_madness(MAD_ARACHNOPHOBIA)){
 	    tmp /= 4;
 	}
@@ -3776,7 +3776,7 @@ xchar sx, sy;
 			break;
 		} else {
 			struct obj *itemp, *inext;
-			if (!Golded && !(Stone_resistance && youracedata != &mons[PM_STONE_GOLEM])
+			if (!Golded && !(Stone_resistance && youracedata->mtyp != PM_STONE_GOLEM)
 				&& !is_gold(youracedata)
 				&& !(poly_when_golded(youracedata) &&
 				polymon(PM_GOLD_GOLEM))
@@ -3937,7 +3937,7 @@ struct obj *otmp;	/* source of flash */
 		    pline("%s is blinded by the flash!", Monnam(mtmp));
 		    res = 1;
 		}
-		if (mtmp->data == &mons[PM_GREMLIN]) {
+		if (mtmp->mtyp == PM_GREMLIN) {
 		    /* Rule #1: Keep them out of the light. */
 		    amt = otmp->otyp == WAN_LIGHT ? d(1 + otmp->spe, 4) :
 		          rn2(min(mtmp->mhp,4));
@@ -4220,13 +4220,13 @@ int dx, dy, range, flat;
 						mon->mhp = mon->mhpmax;
 						break; /* Out of while loop */
 					}
-					if((mon->data == &mons[PM_DEMOGORGON] || mon->data == &mons[PM_LAMASHTU] || mon->data == &mons[PM_ASMODEUS]) && 
+					if((mon->mtyp == PM_DEMOGORGON || mon->mtyp == PM_LAMASHTU || mon->mtyp == PM_ASMODEUS) && 
 						(adtyp == AD_DISN)
 					){
 						shieldeff(sx, sy);
 						break; /* Out of while loop */
 					}
-					if (mon->data == &mons[PM_DEATH] && adtyp == AD_DEAD) {
+					if (mon->mtyp == PM_DEATH && adtyp == AD_DEAD) {
 					if (canseemon(mon)) {
 						hit(fltxt, mon, ".");
 						pline("%s absorbs the deadly %s!", Monnam(mon),
@@ -4236,10 +4236,10 @@ int dx, dy, range, flat;
 					}
 					break; /* Out of while loop */
 					}
-					if(adtyp == AD_DEAD && (mon->data == &mons[PM_METROID]
-					 ||mon->data == &mons[PM_ALPHA_METROID]||mon->data == &mons[PM_GAMMA_METROID]
-					 ||mon->data == &mons[PM_ZETA_METROID]||mon->data == &mons[PM_OMEGA_METROID]
-					 ||mon->data == &mons[PM_METROID_QUEEN])
+					if(adtyp == AD_DEAD && (mon->mtyp == PM_METROID
+					 ||mon->mtyp == PM_ALPHA_METROID||mon->mtyp == PM_GAMMA_METROID
+					 ||mon->mtyp == PM_ZETA_METROID||mon->mtyp == PM_OMEGA_METROID
+					 ||mon->mtyp == PM_METROID_QUEEN)
 					) range=0;//end while loop after this
 					if(adtyp == AD_GOLD){
 						if(otmp){
@@ -4525,28 +4525,28 @@ int type;
 	struct obj *otmp;
 	if(type != AD_DGST){
 		otmp = mksobj_at(CORPSE, mon->mx, mon->my, FALSE, FALSE);
-		otmp->corpsenm = mon->data==&mons[PM_PARASITIZED_COMMANDER] ? PM_PARASITIC_MASTER_MIND_FLAYER : PM_PARASITIC_MIND_FLAYER;
+		otmp->corpsenm = mon->mtyp==PM_PARASITIZED_COMMANDER ? PM_PARASITIC_MASTER_MIND_FLAYER : PM_PARASITIC_MIND_FLAYER;
 		fix_object(otmp);
 	}
-	if(mon->data == &mons[PM_PARASITIZED_ANDROID]){
+	if(mon->mtyp == PM_PARASITIZED_ANDROID){
 		newcham(mon, PM_ANDROID, FALSE, FALSE);
 		mon->m_lev = 7;
 		mon->mhpmax = d(7,8);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
-	else if(mon->data == &mons[PM_PARASITIZED_GYNOID]){
+	else if(mon->mtyp == PM_PARASITIZED_GYNOID){
 		newcham(mon, PM_GYNOID, FALSE, FALSE);
 		mon->m_lev = 14;
 		mon->mhpmax = d(14,8);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
-	else if(mon->data == &mons[PM_PARASITIZED_OPERATOR]){
+	else if(mon->mtyp == PM_PARASITIZED_OPERATOR){
 		newcham(mon, PM_OPERATOR, FALSE, FALSE);
 		mon->m_lev = 7;
 		mon->mhpmax = d(7,8);
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
-	else if(mon->data == &mons[PM_PARASITIZED_COMMANDER]){
+	else if(mon->mtyp == PM_PARASITIZED_COMMANDER){
 		newcham(mon, PM_COMMANDER, FALSE, FALSE);
 		mon->m_lev = 3;
 		mon->mhpmax = 20+rn2(4);
@@ -4560,7 +4560,7 @@ int type;
 		mon->entangled = SHACKLES;
 		mon->movement = 0;
 	}
-	else if(mon->data == &mons[PM_PARASITIZED_DOLL]){
+	else if(mon->mtyp == PM_PARASITIZED_DOLL){
 		newcham(mon, PM_LIVING_DOLL, FALSE, FALSE);
 		mon->m_lev = 15;
 		mon->mhpmax = 60;
@@ -4579,10 +4579,10 @@ struct monst *mon;
 {
 	struct monst *mtmp;
 	mon->mfaction = 0;
-	if(mon->data == &mons[PM_COMMANDER]){
+	if(mon->mtyp == PM_COMMANDER){
 		mon->mfaction = M_GREAT_WEB;
 	}
-	if(mon->data == &mons[PM_LIVING_DOLL]){
+	if(mon->mtyp == PM_LIVING_DOLL){
 		mon->mpeaceful = 1;
 	} else {
 		mtmp = tamedog(mon,(struct obj *) 0);
@@ -5280,7 +5280,7 @@ int damage, tell;
 	if (dlev > 50) dlev = 50;
 	else if (dlev < 1) dlev = 1;
 
-	if(mtmp->data == &mons[PM_CHOKHMAH_SEPHIRAH]) dlev+=u.chokhmah;
+	if(mtmp->mtyp == PM_CHOKHMAH_SEPHIRAH) dlev+=u.chokhmah;
 	resisted = rn2(100 + alev - dlev) < mtmp->data->mr;
 	if (resisted) {
 	    if (tell) {
@@ -5297,10 +5297,10 @@ int damage, tell;
 		damage /= 6;
 	}
 	if(!flags.mon_moving && (is_spider(mtmp->data) 
-		|| mtmp->data == &mons[PM_SPROW]
-		|| mtmp->data == &mons[PM_DRIDER]
-		|| mtmp->data == &mons[PM_PRIESTESS_OF_GHAUNADAUR]
-		|| mtmp->data == &mons[PM_AVATAR_OF_LOLTH]
+		|| mtmp->mtyp == PM_SPROW
+		|| mtmp->mtyp == PM_DRIDER
+		|| mtmp->mtyp == PM_PRIESTESS_OF_GHAUNADAUR
+		|| mtmp->mtyp == PM_AVATAR_OF_LOLTH
 	) && roll_madness(MAD_ARACHNOPHOBIA)){
 		damage /= 4;
 	}

--- a/src/zap.c
+++ b/src/zap.c
@@ -588,8 +588,8 @@ coord *cc;
 	if (obj->oxlth && (obj->oattached == OATTACHED_MONST))
 		mtmp2 = get_mtraits(obj, TRUE);
 	if (mtmp2) {
-		/* save_mtraits() validated mtmp2->mnum */
-		mtmp2->data = &mons[mtmp2->mnum];
+		/* save_mtraits() validated mtmp2->mtyp */
+		mtmp2->data = &mons[mtmp2->mtyp];
 		if (mtmp2->mhpmax <= 0 && !is_rider(mtmp2->data))
 			return (struct monst *)0;
 		mtmp = makemon(mtmp2->data,
@@ -1599,7 +1599,7 @@ poly_obj(obj, id)
 
 	/* avoid abusing eggs laid by you */
 	if (obj->otyp == EGG && obj->spe) {
-		int mnum, tryct = 100;
+		int mtyp, tryct = 100;
 
 		/* first, turn into a generic egg */
 		if (otmp->otyp == EGG)
@@ -1613,10 +1613,10 @@ poly_obj(obj, id)
 
 		/* now change it into something layed by the hero */
 		while (tryct--) {
-		    mnum = can_be_hatched(random_monster());
-		    if (mnum != NON_PM && !dead_species(mnum, TRUE)) {
+		    mtyp = can_be_hatched(random_monster());
+		    if (mtyp != NON_PM && !dead_species(mtyp, TRUE)) {
 			otmp->spe = 1;	/* layed by hero */
-			otmp->corpsenm = mnum;
+			otmp->corpsenm = mtyp;
 			attach_egg_hatch_timeout(otmp);
 			break;
 		    }

--- a/src/zap.c
+++ b/src/zap.c
@@ -588,7 +588,7 @@ coord *cc;
 	if (obj->oxlth && (obj->oattached == OATTACHED_MONST))
 		mtmp2 = get_mtraits(obj, TRUE);
 	if (mtmp2) {
-		set_mon_data(mtmp2, mtmp2->mtyp, 0);
+		set_mon_data(mtmp2, mtmp2->mtyp);
 		if (mtmp2->mhpmax <= 0 && !is_rider(mtmp2->data))
 			return (struct monst *)0;
 		mtmp = makemon(mtmp2->data,


### PR DESCRIPTION
1) Remove all dependence of pointers pointing exactly to the mons[] array
2) Create permonst entries for each monster x faction combination that's needed
3) Read directly from permonst entries instead of modifying at point of use (as much as possible)