### PR TITLE
Nerf vorpal weapons [vs bosses]

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3877,7 +3877,7 @@ boolean * messaged;
 	/* vorpal weapons */
 	if (arti_attack_prop(otmp, ARTA_VORPAL) || (oproperties&OPROP_VORPW)) {
 		char buf[BUFSZ];
-		int vorpaldamage = (basedmg * 12) + d(3, 20);
+		int vorpaldamage = (basedmg * 12) + d(5, 20);
 		int method = 0;
 #define VORPAL_BEHEAD	1
 #define VORPAL_BISECT	2
@@ -3929,6 +3929,8 @@ boolean * messaged;
 			wepdesc = "vorpal blade";
 			if (dieroll == 1 || pd->mtyp == PM_JABBERWOCK) {
 				method = VORPAL_BEHEAD;
+				if (pd->mtyp == PM_JABBERWOCK)
+					vorpaldamage *= 2;
 			}
 			break;
 		case ART_OGRESMASHER:
@@ -4015,8 +4017,6 @@ boolean * messaged;
 				if (armor->spe > -1 * objects[(armor)->otyp].a_ac){
 					damage_item(armor);
 					vorpaldamage -= (armor->spe + objects[(armor)->otyp].a_ac)*5;
-					if (armor->oartifact)
-						vorpaldamage -= 20;
 				}
 				else {
 					claws_destroy_marm(mdef, armor);


### PR DESCRIPTION
Bonus damage = 12X base + 3d20, instead of instakill.

Bonus damage can be reduced by relevant armor (helmets vs vorpal blade, etc), which damages and destroys armor. If the armor isn't strong enough, the vorpal attack can still be lethal after destroying the armor.
Armor does not have an effect if the vorpal weapon is arti_shining (Shadowlock).

Exact numbers may need tweaking (how much bonus damage? how effective is armor?).

Closes #444