### PR TITLE
Fix empty lightsabers crashing

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -1619,6 +1619,13 @@ struct obj *obj;
 		else pline("This %s has no %s.", xname(obj), obj->otyp != GNOMISH_POINTY_HAT ? "oil" : "wax");
 		return;
 	}
+	if (is_lightsaber(obj) && !obj->cobj && !(
+		obj->oartifact == ART_INFINITY_S_MIRRORED_ARC ||
+		obj->oartifact == ART_ANNULUS
+		)) {
+		pline1(nothing_happens);
+		return;
+	}
 	if(is_lightsaber(obj) && 
 		obj->cursed && 
 		obj->oartifact == ART_ATMA_WEAPON

--- a/src/zap.c
+++ b/src/zap.c
@@ -1729,6 +1729,14 @@ poly_obj(obj, id)
 	    break;
 	}
 
+	/* add focusing gems to lightsabers */
+	if (is_lightsaber(otmp)) {
+		struct obj *gem = mksobj(rn2(6) ? BLUE_FLUORITE : GREEN_FLUORITE, TRUE, FALSE);
+		gem->quan = 1;
+		gem->owt = weight(gem);
+		add_to_container(otmp, gem);
+	}
+
 	/* update the weight */
 	otmp->owt = weight(otmp);
 


### PR DESCRIPTION
1) when polying objects into lightsabers, generate a gem to fill them
2) handle attempts to light an empty lightsaber ("Nothing happens.")