### PR TITLE
`stop_occupation()` should interrupt multi-tile movements

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -2373,6 +2373,9 @@ void
 stop_occupation()
 {
 	struct monst *mtmp;
+	
+	flags.travel = iflags.travel1 = flags.mv = flags.run = 0;
+
 	if(occupation) {
 		if (!maybe_finished_meal(TRUE))
 		    You("stop %s.", occtxt);


### PR DESCRIPTION
This should fix many of our long-standing bugs of "X doesn't interrupt travel".

Fixes #496.