### PR TITLE
Horrors that can phase should not dig

### DIFF
--- a/src/u_init.c
+++ b/src/u_init.c
@@ -3012,6 +3012,8 @@ u_init()
 		horrors[j]->mflagsg &= ~MG_PNAME;				/* not a proper name */
 
 		/* some cleanup to reduce the trainwreck*/
+		if (horrors[j]->mflagsm & MM_WALLWALK)
+			horrors[j]->mflagsm &= ~(MM_TUNNEL | MM_NEEDPICK);
 		if (horrors[j]->mflagsm & MM_TUNNEL)
 			horrors[j]->mflagsm &= ~MM_NEEDPICK;
 		if (horrors[j]->mflagsm & MM_STATIONARY)


### PR DESCRIPTION
Remove cause of impossible() spam when digging creature enters no-dig area via phasing.