### PR TITLE
Add "Plague", an artifact bow

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -355,6 +355,7 @@ struct artifact {
 #define DEATH_TCH		(LAST_PROP+71)
 #define SKELETAL_MINION		(LAST_PROP+72)
 #define ORACLE          (LAST_PROP+73)
+#define FILTH_ARROWS	(LAST_PROP+74)
 
 
 #define MASTERY_ARTIFACT_LEVEL 20

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -901,6 +901,18 @@ A("Yoichi no yumi",		YUMI,							(const char *)0,
 	),
 
 /*Needs encyc entry*/
+/* all arrows fired from it are treated as poisoned (or filthed for a short period after invoking) */
+A("Plague",				BOW,							(const char *)0,
+	4000L, BONE, MZ_DEFAULT, WT_DEFAULT,
+	A_CHAOTIC, NON_PM, NON_PM, TIER_B, (ARTG_GIFT),
+	NO_MONS(),
+	ATTK(AD_DRST, 5, 7), NOFLAG,
+	PROP2(POISON_RES, SICK_RES), NOFLAG,
+	PROP0(), NOFLAG,
+	FILTH_ARROWS, NOFLAG
+	),
+
+/*Needs encyc entry*/
 /* die size set to 1d8 in weapon.c */
 A("The Fluorite Octahedron",		BLUE_FLUORITE,		(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,

--- a/include/obj.h
+++ b/include/obj.h
@@ -287,6 +287,7 @@ struct obj {
 #define FULL_MOON	 	4
 
 	/* Songs that the Singing Sword has heard */
+	/* Last-invoked time for Plague's filthed arrows */
 	/* Spirits bound into the Pen of the Void */
 	/* The ema of damage taken for gloves of the berserker */
 	/* Life/Death for the scalpel of life and death */
@@ -294,6 +295,7 @@ struct obj {
 	/* Misc data for the artifact spellbooks */
 #define obj_art_uses_ovar1(otmp) (\
 	   (otmp)->oartifact == ART_SINGING_SWORD \
+	|| (otmp)->oartifact == ART_PLAGUE \
 	|| (otmp)->oartifact == ART_PEN_OF_THE_VOID \
 	|| (otmp)->oartifact == ART_GAUNTLETS_OF_THE_BERSERKER \
 	|| (otmp)->oartifact == ART_SCALPEL_OF_LIFE_AND_DEATH \

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3873,6 +3873,40 @@ boolean * messaged;
 			}
 		}
 	} 
+	/* while Plague is invoked, lethal-filth arrows cause victims to virulently explode.
+	 * Not you, though. You just die. It's simpler that way.
+	 * Slightly different from actual Vorpal; the dieroll is hacked in xhity to ==1 if and only if we have lethal filth. */
+	if (oartifact == ART_PLAGUE && (monstermoves < otmp->ovar1) && (dieroll == 1) && !youdef) {
+		int mx, my;
+		if (vis&VIS_MAGR && vis&VIS_MDEF) {
+			pline_The("tainted %s strikes true!", xname(msgr));
+		}
+		if (vis&VIS_MDEF) {
+			pline("%s %s bubbles, and %s explodes!",
+				s_suffix(Monnam(mdef)),
+				mbodypart(mdef, BODY_SKIN),
+				mon_nam(mdef)
+				);
+			*messaged = TRUE;
+		}
+		/* we want to avoid catching mdef in this explosion -- kludge time */
+		/* note: long worms still get caught in the explosion, because of course they do, so don't kludge at all to be on the safe side */
+		if (!is_longworm(mdef->data)) {
+			mx = x(mdef);
+			my = y(mdef);
+			level.monsters[mx][my] = (struct monst *)0;
+		}
+
+		killer = "virulent explosion";
+		explode(mx, my, AD_DISE, MON_EXPLODE, d(6, 6), EXPL_NOXIOUS,
+			((mdef->data->msize + 3) / 4));	/* tiny -> R0; gigantic -> R2; others -> R1 */
+
+		if (!is_longworm(mdef->data)) {
+			level.monsters[mx][my] = mdef;
+		}
+
+		return xdamagey(magr, mdef, (struct attack *)0, *hp(mdef)); /* instakill */
+	}
 
 	/* vorpal weapons */
 	if (arti_attack_prop(otmp, ARTA_VORPAL) || (oproperties&OPROP_VORPW)) {
@@ -7252,6 +7286,22 @@ arti_invoke(obj)
 			}
 			return 1;
 		}break;
+		case FILTH_ARROWS:
+			if ((!uwep && uwep == obj)){
+				You_feel("that you should be wielding %s.", the(xname(obj)));;
+				obj->age = monstermoves;
+				return(0);
+			}
+			/* message */
+			if (flags.soundok) {
+				pline("%s keens quietly.", The(xname(obj)));
+			}
+			else {
+				pline("%s vibrates softly.", The(xname(obj)));
+			}
+			/* if time < ovar1, arrows will be filthed (done in xhity.c) */
+			obj->ovar1 = monstermoves + 13;
+			break;
 		default: pline("Program in dissorder.  Artifact invoke property not recognized");
 		break;
 	} //end of first case:  Artifact Specials!!!!

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -11820,6 +11820,13 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			artipoisons |= OPOISON_FILTH;
 		if (poisonedobj->oartifact == ART_MOONBEAM)
 			artipoisons |= OPOISON_SLEEP;
+		/* Plague adds poisons to its launched ammo */
+		if (launcher && launcher->oartifact == ART_PLAGUE) {
+			if (monstermoves < launcher->ovar1)
+				artipoisons |= OPOISON_FILTH;
+			else
+				artipoisons |= OPOISON_BASIC;
+		}
 		poisons |= artipoisons;
 
 		/* Penalties for you using a poisoned weapon */
@@ -12795,6 +12802,9 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 		if (fired && launcher && valid_weapon_attack) {
 			otmp = launcher;
 			if (otmp) {
+				/* kludge for Plague: artifact_hit() needs to know if lethal filth occured */
+				if (otmp->oartifact == ART_PLAGUE)
+					dieroll = (poisons_majoreff&OPOISON_FILTH) ? 1 : (dieroll == 1) ? 2 : dieroll;
 				returnvalue = apply_hit_effects(magr, mdef, otmp, weapon, basedmg, &artidmg, &elemdmg, dieroll, &hittxt);
 				if (returnvalue == MM_MISS || (returnvalue & (MM_DEF_DIED | MM_DEF_LSVD)))
 					return returnvalue;


### PR DESCRIPTION
Has +d5 to-hit, +d7 damage to non-poison-resistant enemies per arrow.
Treats all arrows fired as poisoned.

Invoke for 13 turns of treating all arrows as filthed.
While invoked, all filth instakills cause monsters to explode.