### PR TITLE
Monsters follow the player better

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2626,7 +2626,7 @@ E void NDECL(write_HUP_file);
 
 E void NDECL(initrack);
 E void NDECL(settrack);
-E coord *FDECL(gettrack, (int,int));
+E coord *FDECL(gettrack, (int,int,int));
 
 /* ### trap.c ### */
 

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -780,7 +780,7 @@ int after, udist, whappr;
 	if (gx == u.ux && gy == u.uy && !in_masters_sight) {
 	    register coord *cp;
 
-	    cp = gettrack(omx,omy);
+	    cp = gettrack(omx,omy,0);
 	    if (cp) {
 		gx = cp->x;
 		gy = cp->y;

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1982,7 +1982,7 @@ not_special:
 	gx = mtmp->mux;
 	gy = mtmp->muy;
 	appr = (mtmp->mflee && mtmp->mtyp != PM_BANDERSNATCH) ? -1 : 1;
-	if (mtmp->mconf || (u.uswallow && mtmp == u.ustuck) || (gx == 0 && gy == 0))
+	if (mtmp->mconf || (u.uswallow && mtmp == u.ustuck))
 		appr = 0;
 	else {
 #ifdef GOLDOBJ
@@ -2006,16 +2006,20 @@ not_special:
 #endif
 			appr = -1;
 
-		if (!should_see && can_track(ptr) && (goodsmeller(ptr) || (mtmp)->mcansee)) {
+		/* monsters can track you */
+		if (!should_see && (goodsmeller(ptr) || (mtmp)->mcansee)) {
 			register coord *cp;
-
-			cp = gettrack(omx,omy);
+			/* good trackers can follow your trail up to 200 turns, others just for your few most recent steps */
+			cp = gettrack(omx, omy, can_track(ptr) ? 0 : rnd(mtmp->mint/3));
 			if (cp) {
 				gx = cp->x;
 				gy = cp->y;
 			}
 		}
 	}
+	/* if monster has no idea where you could be, set appr to 0 */
+	if (gx == 0 && gy == 0)
+		appr = 0;
 
 	if (( !mtmp->mpeaceful || mtmp->mtyp == PM_MAID || !rn2(10) )
 #ifdef REINCARNATION

--- a/src/track.c
+++ b/src/track.c
@@ -36,12 +36,12 @@ settrack()
 #ifdef OVL0
 
 coord *
-gettrack(x, y)
-register int x, y;
+gettrack(x, y, maxtrack)
+register int x, y, maxtrack;
 {
     int cnt, ndist;
     coord *tc;
-    cnt = utcnt;
+    cnt = !maxtrack ? utcnt : min(maxtrack, utcnt);
     for(tc = &utrack[utpnt]; cnt--; ){
 		if(tc == utrack) tc = &utrack[UTSZ-1];
 	


### PR DESCRIPTION
All monsters follow your trail like they had MG_TRACKER, but only your very most recent movements.

Fixes ridiculous behaviour of monsters wandering aimlessly the very turn they lose sight of the player, which happens all the time in corridors.
Now you need at least a 1-tile gap between you and it.
Smarter monsters can follow a colder trail, but due to rnd() even a 1-tile gap will make them lose you fairly quickly.