### PR TITLE
Add "The Wallet of Perseus", an artifact bag of holding

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1117,6 +1117,17 @@ A("Hellrider's Saddle",				SADDLE,					(const char *)0,
 	PROP0(), NOFLAG,
 	INVIS, (ARTI_PLUSSEV)
 	),
+
+/*Needs encyc entry*/
+A("The Wallet of Perseus",			BAG_OF_HOLDING,			(const char *)0,
+	10000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	A_NONE, NON_PM, NON_PM, TIER_B, (ARTG_NOGEN),
+	NO_MONS(),
+	NO_ATTK(), NOFLAG,
+	PROP0(), NOFLAG,
+	PROP0(), NOFLAG,
+	NOINVOKE, NOFLAG
+	),
 /*
  *	The artifacts for the quest dungeon, all self-willed.
  */

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2277,9 +2277,10 @@ register struct obj *obj;
 		 *	   cursed (not supposed to happen), it will be treated
 		 *	   as cursed.
 		 */
-		if (obj->otyp == BAG_OF_HOLDING)
-		    cwt = obj->cursed ? (cwt * 2) :
-					(1 + (cwt / (obj->blessed ? 4 : 2)));
+		if (obj->oartifact == ART_WALLET_OF_PERSEUS)
+			cwt = obj->cursed ? (cwt * 4) : (1 + (cwt / (obj->blessed ? 6 : 3)));
+		else if (obj->otyp == BAG_OF_HOLDING)
+		    cwt = obj->cursed ? (cwt * 2) : (1 + (cwt / (obj->blessed ? 4 : 2)));
 
 		return wt + cwt;
 	}


### PR DESCRIPTION
True to source, it cannot be found randomly in the dungeon.
Unlike the source, it cannot be gifted by your god.
You'll have to wish for it, if you want the packrat carrying capacity so badly.

Take care not to blow it up!