### PR TITLE
Change staff of necromancy + POTV reading messages

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -2284,9 +2284,12 @@ struct obj *obj;
 	else if (obj->oartifact == ART_ITLACHIAYAQUE)
 				add_menu(win, NO_GLYPH, &any, 'r', 0, ATR_NONE,
 				"Read into the smoky depths of this shield", MENU_UNSELECTED);
+	else if (obj->oartifact == ART_STAFF_OF_NECROMANCY)
+				add_menu(win, NO_GLYPH, &any, 'r', 0, ATR_NONE,
+				"Study the forbidden secrets of necromancy", MENU_UNSELECTED);
 	else if (obj->oartifact == ART_PEN_OF_THE_VOID)
 				add_menu(win, NO_GLYPH, &any, 'r', 0, ATR_NONE,
-				"Inspect this weapon", MENU_UNSELECTED);
+				(mvitals[PM_ACERERAK].died > 0) ? "Inspect the twin blades" : "Inspect the blade", MENU_UNSELECTED);
 	/* R: rub */
 	any.a_void = (genericptr_t)dorub;
 	if (obj->otyp == OIL_LAMP || obj->otyp == MAGIC_LAMP)

--- a/src/read.c
+++ b/src/read.c
@@ -246,7 +246,7 @@ doread()
 				return 0;
 			} else {
 				int i;
-				You("read the forbidden secrets of time and decay!");
+				You("read the dark secrets inscribed on the staff.");
 				for (i = 0; i < MAXSPELL; i++)  {
 					if (spellid(i) == SPE_DRAIN_LIFE)  {
 						if (spellknow(i) <= 1000) {


### PR DESCRIPTION
Adjusts the message for reading the staff to "read the dark secrets inscribed on the staff" and add the inspect prompt of "Study the forbidden secrets of necromancy". Less of a copypaste from the necro book.

Adjusts the POTV inspect prompt to label reading "Inspect the blade" or "Inspect the twin blades" (based off acererak's vital signs), from "Inspect this weapon"