### PR TITLE
Patch buff xiuhcoatl

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -445,7 +445,7 @@ A("The Singing Sword",	LONG_SWORD,						"softly singing %s",
 	),
 
 /*Needs encyc entry*/
-A("Xiuhcoatl",			BULLWHIP,							"turquoise scaled %s",
+A("Xiuhcoatl",			BULLWHIP,							(const char *)0,
 	4000L, DRAGON_HIDE, MZ_DEFAULT, WT_DEFAULT,
 	A_LAWFUL, PM_ARCHEOLOGIST, NON_PM, TIER_B, (ARTG_GIFT),
 	NO_MONS(),

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -6305,8 +6305,23 @@ arti_invoke(obj)
 		break;
 		case LORDLY:
 			if(uwep && uwep == obj){
-				//struct obj *otmp;
-				int lordlydictum = dolordsmenu("What is your command, my Lord?", obj);
+				
+				int lordlydictum;
+				
+				if (obj->oartifact == ART_ROD_OF_LORDLY_MIGHT ||
+						obj->oartifact == ART_ROD_OF_THE_ELVISH_LORDS ||
+						obj->oartifact == ART_SCEPTRE_OF_LOLTH){
+					
+					if (flags.female)
+						lordlydictum = dolordsmenu("What is your command, my Lady?", obj);
+					else
+						lordlydictum = dolordsmenu("What is your command, my Lord?", obj);
+				
+				} else {
+					lordlydictum = dolordsmenu("What is your command?", obj);
+				}
+				
+				
 				switch(lordlydictum){
 					case 0:
 					break;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -6365,7 +6365,7 @@ arti_invoke(obj)
 					case COMMAND_WHIP:
 						uwep->otyp = BULLWHIP;
 						if (uwep->oartifact == ART_XIUHCOATL)
-							uwep->obj_material = LEATHER;
+							uwep->obj_material = artilist[uwep->oartifact].material;
 					break;
 					case COMMAND_ATLATL:
 						uwep->otyp = ATLATL;

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1000,6 +1000,8 @@ boolean adjective;
 		/* for some reason, this is dragonhide? */
 		if (obj->otyp == LEO_NEMAEUS_HIDE)
 			return "lionhide";
+		if (obj->oartifact && obj->oartifact == ART_XIUHCOATL)
+			return "serpenthide";
 		/* hard object made of dragonhide (or described as being dragon-bone) -> bone or tooth */
 		else if ((objects[obj->otyp].oc_material > LEATHER && objects[obj->otyp].oc_material != DRAGON_HIDE)
 			|| ((s = OBJ_DESCR(objects[obj->otyp])) != (char *)0 && !strncmp(s, "dragonbone", 10))

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1000,7 +1000,7 @@ boolean adjective;
 		/* for some reason, this is dragonhide? */
 		if (obj->otyp == LEO_NEMAEUS_HIDE)
 			return "lionhide";
-		if (obj->oartifact && obj->oartifact == ART_XIUHCOATL)
+		if (obj->oartifact == ART_XIUHCOATL)
 			return "serpenthide";
 		/* hard object made of dragonhide (or described as being dragon-bone) -> bone or tooth */
 		else if ((objects[obj->otyp].oc_material > LEATHER && objects[obj->otyp].oc_material != DRAGON_HIDE)

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -519,7 +519,7 @@ int otyp;
 			ocn = 1;
 			ocd = 2;
 			bonn = 2;
-			bond = max(4 + 2 * dmod, 2);
+			bond = 4
 		}
 		else if (obj->oartifact == ART_LIECLEAVER) {
 			ocn = 1;	/* plus another 1d10 from being an artifact */

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -513,6 +513,14 @@ int otyp;
 			bonn = 1;
 			bond = 4;
 		}
+		else if (obj->oartifact == ART_XIUHCOATL && otyp == BULLWHIP)
+		{
+			// couatl bite 
+			ocn = 1;
+			ocd = 2;
+			bonn = 2;
+			bond = max(4 + 2 * dmod, 2);
+		}
 		else if (obj->oartifact == ART_LIECLEAVER) {
 			ocn = 1;	/* plus another 1d10 from being an artifact */
 			ocd = 10;


### PR DESCRIPTION
It's "serpenthide" (still dragonhide but a new description) now, and it deals a bonus 2d4 damage. The 2d4 is from the couatl bite attack damage. No poison, since that would suck if you're lawful.

Also fix a minor bug - Y'ha-Talla and Xiuhcoatl both say "What is your command, my Lord" when invoked (since it uses the LORDLY invoke for toggling forms), and they'd refer to you as a "Lord" regardless of gender. Now only the 3 actual lordly weapons (lordly might, elvish lords, sceptre of lolth) give you a title, and they'll gender you correctly. 