### PR TITLE
Don't give monsters cav/ymir bonuses

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -808,16 +808,16 @@ carrying_readable_weapon()
 	register struct obj *otmp;
 
 	for(otmp = invent; otmp; otmp = otmp->nobj)
-		if((otmp->oclass == WEAPON_CLASS && (otmp)->obj_material == WOOD && otmp->oward)
-		  || otmp->oartifact && 
-			(otmp->oartifact == ART_EXCALIBUR || 
-			 otmp->oartifact == ART_GLAMDRING || 
-			 otmp->oartifact == ART_ITLACHIAYAQUE || 
-			 otmp->oartifact == ART_ROD_OF_SEVEN_PARTS ||
-			 otmp->oartifact == ART_BOW_OF_SKADI ||
-			 otmp->oartifact == ART_PEN_OF_THE_VOID ||
-			 otmp->oartifact == ART_STAFF_OF_NECROMANCY
-			)
+		if((otmp->oclass == WEAPON_CLASS && otmp->obj_material == WOOD && otmp->oward) || 
+			(otmp->oartifact && (
+				otmp->oartifact == ART_EXCALIBUR || 
+				otmp->oartifact == ART_GLAMDRING || 
+				otmp->oartifact == ART_ITLACHIAYAQUE || 
+				otmp->oartifact == ART_ROD_OF_SEVEN_PARTS ||
+				otmp->oartifact == ART_BOW_OF_SKADI ||
+				otmp->oartifact == ART_PEN_OF_THE_VOID ||
+				otmp->oartifact == ART_STAFF_OF_NECROMANCY
+			))
 		)
 			return TRUE;
 	return FALSE;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3342,10 +3342,12 @@ int flat_acc;
 			/* -4 accuracy per weapon size too large (not for thrown objects) */
 			if (!thrown){
 				int size_penalty = weapon->objsize - pa->msize;
-				if (Role_if(PM_CAVEMAN))
-					size_penalty = max(0, size_penalty-1);
-				if (u.sealsActive&SEAL_YMIR)
-					size_penalty = max(0, size_penalty-1);
+				if (youagr){
+					if (Role_if(PM_CAVEMAN))
+						size_penalty = max(0, size_penalty-1);
+					if (u.sealsActive&SEAL_YMIR)
+						size_penalty = max(0, size_penalty-1);
+				}
 				
 				wepn_acc += -4 * max(0, size_penalty);
 			}


### PR DESCRIPTION
I forgot a youagr check, so monsters were getting the size bonuses of your role/seals. 
Also fixes a parens warning in invent.c that I saw while compiling (god bless clang), no code change there though.