### PR TITLE
Split ^V leveltele menu into 2 inputs

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -689,7 +689,7 @@ E boolean FDECL(Invocation_lev, (d_level *));
 E int NDECL(level_difficulty);
 E schar FDECL(lev_by_name, (const char *));
 #ifdef WIZARD
-E schar FDECL(print_dungeon, (BOOLEAN_P,schar *,int *));
+E schar FDECL(print_dungeon, (BOOLEAN_P,BOOLEAN_P,schar *,int *));
 #endif
 E int NDECL(donamelevel);
 E int NDECL(dooverview);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1344,7 +1344,7 @@ wiz_genesis()
 STATIC_PTR int
 wiz_where()
 {
-	if (wizard) (void) print_dungeon(FALSE, (schar *)0, (int *)0);
+	if (wizard) (void) print_dungeon(FALSE, FALSE, (schar *)0, (int *)0);
 	else	    pline("Unavailable command '^O'.");
 	return 0;
 }

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1928,10 +1928,11 @@ print_branch(win, dnum, lower_bound, upper_bound, bymenu, lchoices)
 
 /* Print available dungeon information. */
 schar
-print_dungeon(bymenu, rlev, rdgn)
-boolean bymenu;
-schar *rlev;
-int *rdgn;
+print_dungeon(bymenu, gotdgn, rlev, rdgn)
+boolean bymenu;	/* If TRUE, ask for input to select a level */
+boolean gotdgn;	/* Requires bymenu. If FALSE, select dungeon. If TRUE, select a level within rdgn. */
+schar *rlev;	/* returns selected level depth */
+int *rdgn;		/* returns selected level dungeon number */
 {
     int     i, last_level, nlev;
     char    buf[BUFSZ];
@@ -1967,7 +1968,17 @@ int *rdgn;
 	}
 	if (bymenu) {
 	    any.a_void = 0;
-	    add_menu(win, NO_GLYPH, &any, 0, 0, iflags.menu_headings, buf, MENU_UNSELECTED);
+		if (!gotdgn) {
+			any.a_int = lchoices.idx + 1;
+			lchoices.dgn[lchoices.idx] = i;
+			add_menu(win, NO_GLYPH, &any, lchoices.menuletter, 0, iflags.menu_headings, buf, iflags.menu_headings);
+			if (lchoices.menuletter == 'z') lchoices.menuletter = 'A';
+			else lchoices.menuletter++;
+			lchoices.idx++;
+		}
+		else {
+			add_menu(win, NO_GLYPH, &any, 0, 0, iflags.menu_headings, buf, MENU_UNSELECTED);
+		}
 	} else
 	    putstr(win, 0, buf);
 
@@ -1979,35 +1990,45 @@ int *rdgn;
 		if (slev->dlevel.dnum != i) continue;
 		
 		/* print any branches before this level */
-		print_branch(win, i, last_level, slev->dlevel.dlevel, bymenu, &lchoices);
+		print_branch(win, i, last_level, slev->dlevel.dlevel, (bymenu && gotdgn && i == *rdgn), &lchoices);
 		
 		Sprintf(buf, "   %s: %d", slev->proto, depth(&slev->dlevel));
 		if (Is_stronghold(&slev->dlevel))
 		Sprintf(eos(buf), " (tune %s)", tune);
+
 		if (bymenu) {
-			/* If other floating branches are added, this will need to change */
-			if (i != knox_level.dnum) {
-			lchoices.lev[lchoices.idx] = slev->dlevel.dlevel;
-			lchoices.dgn[lchoices.idx] = i;
-		} else {
-			lchoices.lev[lchoices.idx] = depth(&slev->dlevel);
-			lchoices.dgn[lchoices.idx] = 0;
-		}
-		lchoices.playerlev[lchoices.idx] = depth(&slev->dlevel);
-		any.a_void = 0;
-		any.a_int = lchoices.idx + 1;
-		add_menu(win, NO_GLYPH, &any, lchoices.menuletter,
-				0, ATR_NONE, buf, MENU_UNSELECTED);
-		if (lchoices.menuletter == 'z') lchoices.menuletter = 'A';
-		else lchoices.menuletter++;
-		lchoices.idx++;
+			if (gotdgn && i == *rdgn) {
+				/* If other floating branches are added, this will need to change */
+				if (i != knox_level.dnum) {
+					lchoices.lev[lchoices.idx] = slev->dlevel.dlevel;
+					lchoices.dgn[lchoices.idx] = i;
+				}
+				else {
+					/* note: choosing to go to Knox instead brings you to the level 
+					 * in the main dungeon that has the magic portal */
+					lchoices.lev[lchoices.idx] = depth(&slev->dlevel);
+					lchoices.dgn[lchoices.idx] = 0;
+				}
+				lchoices.playerlev[lchoices.idx] = depth(&slev->dlevel);
+				any.a_void = 0;
+				any.a_int = lchoices.idx + 1;
+				add_menu(win, NO_GLYPH, &any, lchoices.menuletter,
+					0, ATR_NONE, buf, MENU_UNSELECTED);
+				if (lchoices.menuletter == 'z') lchoices.menuletter = 'A';
+				else lchoices.menuletter++;
+				lchoices.idx++;
+			}
+			else {
+				any.a_void = 0;
+				add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE, buf, MENU_UNSELECTED);
+			}
 		} else
 		putstr(win, 0, buf);
 		
 		last_level = slev->dlevel.dlevel;
 	}
 	/* print branches after the last special level */
-	print_branch(win, i, last_level, MAXLEVEL, bymenu, &lchoices);
+	print_branch(win, i, last_level, MAXLEVEL, (bymenu && gotdgn && i == *rdgn), &lchoices);
     }
 
     /* Print out floating branches (if any). */
@@ -2031,12 +2052,26 @@ int *rdgn;
 	menu_item *selected;
 	int idx;
 
-	end_menu(win, "Level teleport to where:");
-	n = select_menu(win, PICK_ONE, &selected);
-	destroy_nhwindow(win);
+	if (lchoices.idx > 1) {
+		end_menu(win, "Level teleport to where:");
+		n = select_menu(win, PICK_ONE, &selected);
+		destroy_nhwindow(win);
+		if (n > 0)
+			idx = selected[0].item.a_int - 1;
+	}
+	else {
+		/* only one choice; don't bother showing it */
+		end_menu(win, "");
+		destroy_nhwindow(win);
+		idx = 0;
+		n = 1;
+	}
 	if (n > 0) {
-		idx = selected[0].item.a_int - 1;
 		free((genericptr_t)selected);
+		if (!gotdgn) {
+			*rdgn = lchoices.dgn[idx];
+			return print_dungeon(bymenu, TRUE, rlev, rdgn);
+		}
 		if (rlev && rdgn) {
 			*rlev = lchoices.lev[idx];
 			*rdgn = lchoices.dgn[idx];

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -855,7 +855,7 @@ level_tele()
 		    schar destlev = 0;
 		    int destdnum = 0;
 
-		    if ((newlev = (int)print_dungeon(TRUE, &destlev, &destdnum))) {
+		    if ((newlev = (int)print_dungeon(TRUE, FALSE, &destlev, &destdnum))) {
 			newlevel.dnum = (xchar) destdnum;
 			newlevel.dlevel = destlev;
 			if (In_endgame(&newlevel) && !In_endgame(&u.uz)) {


### PR DESCRIPTION
So you can actually levelteleport via menu to somewhere that isn't the main dungeon or gehennom.

There appears to be further issues related to the teleportation itself that *hopefully* this addition has only exposed, not created. Teleporting to Vlad's Tower via the menu is spotty, for one.