### PR TITLE
Make Plague's invoke stronger

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -11902,6 +11902,8 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			case OPOISON_FILTH:
 				resists = Sick_res(mdef);
 				majoreff = !rn2(10);
+				if (launcher && launcher->oartifact == ART_PLAGUE && monstermoves < launcher->ovar1)
+					majoreff = !rn2(5);	/* while invoked, Plague's arrows are twice as likely to instakill (=20%) */
 				break;
 			case OPOISON_SLEEP:
 				resists = Sleep_res(mdef);


### PR DESCRIPTION
Filthed arrows from it while invoked instakill twice as often as usual (=20% of hits). This should make its special effect more consistent, and a player should be able to make a few explosions happen.