### PR TITLE
Nagas/mariliths/etc have a "rear region" like a snake, not a "leg".

### DIFF
--- a/src/polyself.c
+++ b/src/polyself.c
@@ -2025,7 +2025,7 @@ int part;
 		"scales", "blood", "gill", "nostril", "stomach","heart","scales",
 		"flesh","beat","bones","ear","creak","crack" },
 	*snakeleg_humanoid_parts[] = { "arm", "eye", "face", "finger",
-		"fingertip", "serpentine lower body", "hand", "handed", "head", "leg",
+		"fingertip", "serpentine lower body", "hand", "handed", "head", "rear region",
 		"light headed", "neck", "spine", "tail-tip", "scales",
 		"blood", "lung", "nose", "stomach","heart","scales",
 		"flesh","beat","bones","ear","creak","crack" },


### PR DESCRIPTION
Now after a beartrap gives the message `A beartrap closes on your serpentine lower body!`, when your "leg" heals you get the message `Your rear region feels somewhat better.`. Fixes #581.