### PR TITLE
potion of speed auto-IDs if you got faster

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -942,9 +942,11 @@ peffects(otmp)
 		}
 	    if (!(HFast & INTRINSIC)) {
 			if (!Fast) You("speed up.");
-			else Your("quickness feels more natural.");
+			else {
+				Your("quickness feels more natural.");
+				unkn++;
+			}
 			HFast |= FROMOUTSIDE;
-			unkn++;
 	    } else nothing++;
 		exercise(A_DEX, TRUE);
 	break;


### PR DESCRIPTION
doesn't auto-ID for healing legs, or when you get "your quickness feels more natural". also doesn't if you got the peculiar feeling because you're already fast.

for the love of god, if it tells me "You speed up." then like wtf do you think it is? gain level? acid? polymorph?