### PR TITLE
Adjust Free Action + Stoning interaction

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -1798,7 +1798,7 @@ int spellnum;
 		   verbalize(rn2(2) ? "I shall make a statue of thee!" :
 							  "I condemn thee to eternity unmoving!");
         if (!(poly_when_stoned(youracedata) && polymon(PM_STONE_GOLEM))) {
-           if(!Stone_resistance && !Free_action && (!rn2(10) || !have_lizard()) ){
+           if(!Stone_resistance && (!rn2(10) || !have_lizard()) ){
 			You_feel("less limber.");
 			Stoned = 5;
 		   }else{

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -118,7 +118,7 @@ stoned_dialogue()
 	}
 	if (i == 5L)
 		HFast = 0L;
-	if (i == 3L)
+	if (i == 3L && !Free_action)
 		nomul(-3, "getting stoned");
 	exercise(A_DEX, FALSE);
 }
@@ -142,7 +142,7 @@ golded_dialogue()
 	}
 	if (i == 5L)
 		HFast = 0L;
-	if (i == 3L)
+	if (i == 3L && !Free_action)
 		nomul(-3, "turning to gold");
 	exercise(A_DEX, FALSE);
 }


### PR DESCRIPTION
Free Action now gives you 3 more turns to take actions when afflicted by delayed stoning.
However, free action no longer protects against the "Turn to Stone" monster spell -- better carry lizard corpses!