### PR TITLE
"Killed by foo" end message should specifiy zombies/etc

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -454,6 +454,7 @@ E struct obj *FDECL(oname, (struct obj *,const char *));
 E int NDECL(ddocall);
 E void FDECL(docall, (struct obj *));
 E const char *NDECL(rndghostname);
+E void FDECL(append_faction_desc, (struct monst *, char *, boolean));
 E char *FDECL(x_monnam, (struct monst *,int,const char *,int,BOOLEAN_P));
 E char *FDECL(l_monnam, (struct monst *));
 E char *FDECL(mon_nam, (struct monst *));

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -15,7 +15,6 @@ STATIC_DCL struct artifact artilist[];
 //STATIC_DCL void FDECL(do_oname, (struct obj *));//moved to extern.h
 static void FDECL(getpos_help, (BOOLEAN_P,const char *));
 
-STATIC_DCL void FDECL(append_faction_desc, (struct monst *, char *, boolean));
 STATIC_DCL boolean FDECL(maybe_append_injury_desc, (struct monst *, char *));
 
 extern const char what_is_an_unknown_object[];		/* from pager.c */

--- a/src/end.c
+++ b/src/end.c
@@ -424,13 +424,19 @@ register struct monst *mtmp;
 		Sprintf(eos(buf), "%s %s, the shopkeeper",
 			(mtmp->female ? "Ms." : "Mr."), shkname(mtmp));
 		killer_format = KILLED_BY;
+		if (mtmp->mfaction)
+			append_faction_desc(mtmp, buf, TRUE);
 	} else if (mtmp->ispriest || mtmp->isminion) {
 		/* m_monnam() suppresses "the" prefix plus "invisible", and
 		   it overrides the effect of Hallucination on priestname() */
 		killer = m_monnam(mtmp);
 		Strcat(buf, killer);
+		if (mtmp->mfaction)
+			append_faction_desc(mtmp, buf, type_is_pname(mtmp->data));
 	} else {
 		Strcat(buf, mtmp->data->mname);
+		if (mtmp->mfaction)
+			append_faction_desc(mtmp, buf, type_is_pname(mtmp->data));
 		if (mtmp->mnamelth)
 		    Sprintf(eos(buf), " called %s", NAME(mtmp));
 	}


### PR DESCRIPTION
I love reused code.
I really hate git sometimes.
Fixes #594.
_(hint: don't pronounce the '#')_