### PR TITLE
Enhance engulf attacks and attackers

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3017,6 +3017,7 @@ E int FDECL(xdamagey, (struct monst *, struct monst *, struct attack *, int));
 E int FDECL(xmeleehurty, (struct monst *, struct monst *, struct attack *, struct attack *, struct obj *, boolean, int, int, int, boolean));
 E void FDECL(getgazeinfo, (int, int, struct permonst *, boolean *, boolean *, boolean *));
 E int FDECL(xgazey, (struct monst *, struct monst *, struct attack *, int));
+E int FDECL(xengulfhity, (struct monst *, struct monst *, struct attack *, int));
 E void FDECL(passive_obj2, (struct monst *, struct monst *, struct obj *, struct attack *, struct attack *));
 E int FDECL(hmon2point0, (struct monst *, struct monst *, struct attack *, struct attack *, struct obj *, void *, int, int, int, boolean, int, boolean, int, boolean *));
 E void FDECL(wakeup2, (struct monst *, boolean));

--- a/src/hack.c
+++ b/src/hack.c
@@ -1867,7 +1867,13 @@ stillinwater:;
 					Amonnam(mtmp));
 			break;
 		}
-		mnexto(mtmp); /* have to move the monster */
+		if (attacktype(mtmp->data, AT_ENGL)) {
+			/* engulf the player */
+			(void)xengulfhity(mtmp, &youmonst, attacktype_fordmg(mtmp->data, AT_ENGL, AD_ANY), 6);	/* vis == VIS_MDEF|VIS_NONE */
+		}
+		else {
+			mnexto(mtmp); /* have to move the monster */
+		}
 	}
 }
 


### PR DESCRIPTION
 - Stationary engulfers won't move off of their own square -- they'll pluck you from yours, instead.
 - Hidden engulfers immediately engulf you when they surprise you
 - Bugfix: engulfers can't engulf anyone else while they're engulfing the player