### PR TITLE
Re-enable artifact tiers affecting god gifts

### DIFF
--- a/src/pray.c
+++ b/src/pray.c
@@ -792,16 +792,16 @@ int ga_num;
 boolean
 maybe_god_gives_gift()
 {
-	int nartifacts = u.ugifts + (Role_if(PM_PRIEST) ? 0 : u.uconduct.wisharti);
 	/* previous: 1 in (10 + (2 * gifts * (gifts+wishes))) */
 	/* Role_if(PM_PRIEST) ? !rn2(10 + (2 * u.ugifts * u.ugifts)) : !rn2(10 + (2 * u.ugifts * nartifacts)) */
 	/* the average giftable artifact has a value of 4 (TIER_B), plus any bonuses for the player being good with it */
 	/* uartisval isn't increased for priests when wishing */
 
-//Disable while tiering and full behaviour is still under discussion
-//	return !rn2(10 + (u.uartisval * u.uartisval / 10));
-
-	return !rn2(10 + (2 * u.ugifts * nartifacts));
+	//New:
+	return !rn2(10 + (u.uartisval * u.uartisval * 2 / 25));
+	//Old:
+	//int nartifacts = u.ugifts + (Role_if(PM_PRIEST) ? 0 : u.uconduct.wisharti);
+	//return !rn2(10 + (2 * u.ugifts * nartifacts));
 }
 
 
@@ -3206,8 +3206,8 @@ dosacrifice()
 			otmp->gifted = Align2gangr(u.ualign.type);
 			u.ugifts++;
 			u.uartisval += arti_value(otmp);
-		    //u.ublesscnt = rnz(300 + (u.uartisval * 10));
-			u.ublesscnt = rnz(300 + (u.ugifts * 50));
+		    u.ublesscnt = rnz(300 + (u.uartisval * 10));
+			//u.ublesscnt = rnz(300 + (u.ugifts * 50));
 			u.lastprayed = moves;
 			u.reconciled = REC_NONE;
 			u.lastprayresult = PRAY_GIFT;


### PR DESCRIPTION
How is this similar to vanilla behaviour?
- if all artifacts had a value of '5' there would be no functional difference from vanilla behaviour.

How does it compare to vanilla behaviour?
- a hypothetical artifact with a value of '10' would affect your likelihood to get new artifacts from sacrificing equivalently to getting two artifacts.
- a hypothetical artifact with a value of '0' would not affect your likelihood to get new artifacts from sacrificing at all.

What is this "value" you keep mentioning?
- Each artifact is assigned a value in artilist.h, which is then modified in-game.
- Unmodified, the average value of a giftable artifact is 4.0.
- The modification assigns extra value to artifacts that are particularly useful for a given character.

What are the value modifications?
- Monks get extra value for particular unarmed-boosting artifacts (input welcome)
- Weapons that the player can reach Expert skill in are more valuable
- Weapons that the player can reach Skilled skill in are more valuable... if the artifact is strong.
- Weapons that the player isn't Skilled in aren't as valuable.

What does the player need to know?
- Nothing -- you will continue to get gifts from sacrificing corpses on altars, and at mostly the same rate.

What does this accomplish?
- I can add new low-power artifacts that would be kinda crappy to get as a god gift.
- Players are less screwed over by getting bad gifts, because they'll get more gifts.

Questions/concerns/hatemail? Ping me on ##nethack-variants.