### PR TITLE
Missed projectiles need to call wakeup2() to aggro mdef

### DIFF
--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1367,7 +1367,7 @@ boolean * wepgone;				/* pointer to: TRUE if projectile has been destroyed */
 			}
 		}
 		/* possibly wake defender */
-		if (!rn2(3))
+		if (youdef || (!mdef->msleeping && mdef->mcanmove))
 		{
 			wakeup2(mdef, youagr);
 		}


### PR DESCRIPTION
But don't call wakeup on a miss if the defender is asleep.