### PR TITLE
Bandaid-fix artifacts in monster inventories being destroyable

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -5133,7 +5133,9 @@ int osym, dmgtyp;
 	vis = canseemon(mtmp);
 	for(obj = mtmp->minvent; obj; obj = obj2) {
 	    obj2 = obj->nobj;
-	    if(obj->oclass != osym) continue; /* test only objs of type osym */
+		if (obj->oclass != osym) continue; /* test only objs of type osym */
+		if (obj->oartifact) continue; /* don't destroy artifacts */
+		if (obj->in_use && obj->quan == 1) continue; /* not available */
 	    skip = 0;
 	    quan = 0L;
 	    dindx = 0;


### PR DESCRIPTION
Real solution is to deprecate destroy_item() and destroy_mitem() and only use xhity's version, but so close to jnh I'll stick with the bandaid to avoid adding new bugs.