### PR TITLE
Fix impossible() on failed teleport of eels

### DIFF
--- a/src/teleport.c
+++ b/src/teleport.c
@@ -71,7 +71,7 @@ unsigned gpflags;
 						Swimming || Amphibious);
 			else	return (mon_resistance(mtmp,FLYING) || breathless_mon(mtmp) || mon_resistance(mtmp,SWIMMING) ||
 								is_clinger(mdat) || amphibious_mon(mtmp));
-	    } else if (mdat->mlet == S_EEL && !ignorewater) {
+	    } else if (mdat->mlet == S_EEL && !ignorewater && rn2(13)) {
 			if (is_pool(x, y, TRUE))
 				return (mdat->msize == MZ_TINY);
 			return FALSE;


### PR DESCRIPTION
Copy the vanilla nethack solution: eels may (1/13 chance) consider land to be an acceptable place to teleport to. Fixes #615 