### PR TITLE
makemon() should always place monsters safely

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1490,6 +1490,7 @@ E void FDECL(insight_vanish,(struct monst *));
 
 E void NDECL(id_permonst);
 E void FDECL(set_mon_data, (struct monst *,int));
+E void FDECL(set_mon_data_core, (struct monst *, struct permonst *));
 E void FDECL(set_faction, (struct monst *, int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(attacktype, (struct permonst *,int));

--- a/include/hack.h
+++ b/include/hack.h
@@ -205,7 +205,6 @@ NEARDATA extern coord bhitpos;	/* place where throw or zap hits or stops */
 #define MM_IGNOREWATER	  0x80	/* ignore water when positioning */
 #define MM_ADJACENTOK	  0x100 /* it is acceptable to use adjacent coordinates */
 #define MM_ADJACENTSTRICT 0x200 /* ...but only ONE removed.*/
-#define MM_CHECK_GOODPOS  0x400 /* Don't create a monster where it shouldn't be.*/
 
 /* special mhpmax value when loading bones monster to flag as extinct or genocided */
 #define DEFUNCT_MONSTER	(-100)

--- a/src/mon.c
+++ b/src/mon.c
@@ -2152,7 +2152,7 @@ movemon()
 			struct monst *sprout = (struct monst *) 0;
 			int newx = (mtmp->mx-1)+rn2(3), newy = (mtmp->my-1)+rn2(3);
 			if(isok(newx,newy)){
-				sprout = makemon(mtmp->data, newx, newy, MM_CHECK_GOODPOS|MM_NOCOUNTBIRTH|NO_MINVENT);
+				sprout = makemon(mtmp->data, newx, newy, MM_NOCOUNTBIRTH|NO_MINVENT);
 				if(sprout) sprout->mhp = In_hell(&u.uz) ? sprout->mhp*3/4 : sprout->mhp/2;
 			}
 		}

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -23,17 +23,15 @@ id_permonst()
 	return;
 }
 
-/*
- * safely sets mon->data
+/* 
+ * safely sets mon->data from an mtyp
  */
 void
 set_mon_data(mon, mtyp)
 struct monst *mon;
 int mtyp;
 {
-	int i;
 	struct permonst * ptr;
-
 	/* players in their base form are a special case */
 	if (mon == &youmonst && (mtyp == u.umonster)) {
 		mon->data = ptr = &upermonst;
@@ -41,8 +39,23 @@ int mtyp;
 	else {
 		mon->data = ptr = permonst_of(mtyp, mon->mfaction);
 	}
+	set_mon_data_core(mon, ptr);
+	return;
+}
 
-	mon->mtyp = mtyp;
+/*
+ * safely sets mon->data from an existing data pointer
+ */
+void
+set_mon_data_core(mon, ptr)
+struct monst *mon;
+struct permonst * ptr;
+{
+	int i;
+
+	/* data and type */
+	mon->data = ptr;
+	mon->mtyp = ptr->mtyp;
 
 	/* resistances */
 	mon->mintrinsics[0] = (ptr->mresists & MR_MASK);

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -120,7 +120,7 @@ struct permonst *mdat;
 	/* default to player's original monster type */
 	mdat = &mons[u.umonster];
     }
-    fakemon.data = mdat;	/* set up for goodpos */
+    set_mon_data_core(&fakemon, mdat);	/* set up for goodpos */
     good_ptr = good;
     range = 3;
     /*
@@ -195,7 +195,7 @@ struct permonst *mdat;
 	/* default to player's original monster type */
 	mdat = &mons[u.umonster];
     }
-    fakemon.data = mdat;	/* set up for goodpos */
+	set_mon_data_core(&fakemon, mdat);	/* set up for goodpos */
 	for(j = 0; j < 8; j++){
 		x = xx;
 		y = yy;
@@ -265,7 +265,7 @@ unsigned entflags;
 	/* default to player's original monster type */
 	mdat = &mons[u.umonster];
     }
-    fakemon.data = mdat;	/* set up for goodpos */
+	set_mon_data_core(&fakemon, mdat);
     good_ptr = good;
     range = 1;
     /*


### PR DESCRIPTION
No matter what combination of whether or not ptr is given or whether or not coords are given, makemon() should check that a monster will be okay for its location.
This removes the need for the MM_CHECK_GOODPOS flag.

This also unearthed a bug -- directly setting fakemon.data is not sufficient, because many aspects of monsters are now governed by their properties (most noticably, phasing) which was causing monsters to not get placed in spots where they should have been able to go.
This commit fixes said bug. Xorns are once again able to spawn in solid rock!