### PR TITLE
Initialize vis=0

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -66,7 +66,7 @@ int tary;
 {
 	boolean youagr = (magr == &youmonst);
 	boolean youdef = (mdef == &youmonst);
-	int vis;
+	int vis = 0;
 	
 	if (!tarx && !tary) {
 		tarx = x(mdef);


### PR DESCRIPTION
This only affected cases where you could only see part of the action. You might have gotten messages with more information than you should have been able to see. For example, you can only see magr, but you might get a message about mdef's state.