### PR TITLE
Reading the Blinding Glyph should grant Intrinsic Flight

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -135,7 +135,7 @@ Boots_on()
 			incr_itimeout(&HFumbling, rnd(20));
 		break;
 	case FLYING_BOOTS:
-		if (!oldprop && !(mon_resistance(&youmonst,FLYING) || (u.usteed && mon_resistance(u.usteed,FLYING))) && !HLevitation) {
+		if (!oldprop && !(species_flies(youracedata) || (u.usteed && mon_resistance(u.usteed,FLYING))) && !HLevitation) {
 			makeknown(uarmf->otyp);
 			float_up();
 			spoteffects(FALSE);
@@ -189,7 +189,7 @@ Boots_off()
 			HFumbling = EFumbling = 0;
 		break;
 	case FLYING_BOOTS:
-		if (!oldprop && !mon_resistance(&youmonst,FLYING) && !(u.usteed && mon_resistance(u.usteed,FLYING)) && !Levitation && !cancelled_don) {
+		if (!oldprop && !species_flies(youracedata) && !(u.usteed && mon_resistance(u.usteed,FLYING)) && !Levitation && !cancelled_don) {
 			(void) float_down(0L, 0L);
 			makeknown(otyp);
 		}
@@ -992,7 +992,7 @@ register struct obj *obj;
 #endif
 
 		if (Invis && !oldprop && !HSee_invisible &&
-				!mon_resistance(&youmonst,SEE_INVIS) && !Blind) {
+				!species_perceives(youracedata) && !Blind) {
 		    newsym(u.ux,u.uy);
 		    pline("Suddenly you are transparent, but there!");
 		    makeknown(RIN_SEE_INVISIBLE);

--- a/src/read.c
+++ b/src/read.c
@@ -924,6 +924,7 @@ learn_word()
 			You("learn the First Word of Creation!");
 			u.ufirst_light = TRUE;
 			u.ufirst_light_timeout = 0;
+			HFlying |= FROMOUTSIDE;
 			float_up();
 			spoteffects(FALSE);
 		break;


### PR DESCRIPTION
Fixes bad messages involving flying boots after having read the Slab.

The `u.ufirst_light` check in youprop.h should be removed with the next save-breaking patch.

Also, replace bad mon_resistance(&youmonst, ...) checks.