### PR TITLE
Fix (null)-named artifacts appearing in the end score

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -752,7 +752,6 @@ winid endwin;
     char pbuf[BUFSZ];
     struct obj *otmp;
     long value, points;
-    short dummy;	/* object type returned by artifact_name() */
 
     for (otmp = list; otmp; otmp = otmp->nobj) {
 	if (otmp->oartifact ||
@@ -769,7 +768,7 @@ winid endwin;
 		/* assumes artifacts don't have quan > 1 */
 		Sprintf(pbuf, "%s%s (worth %ld %s and %ld points)",
 			the_unique_obj(otmp) ? "The " : "",
-			otmp->oartifact ? artifact_name(xname(otmp), &dummy) :
+			otmp->oartifact ? artiname(otmp->oartifact) :
 				OBJ_NAME(objects[otmp->otyp]),
 			value, currency(value), points);
 #ifdef DUMP_LOG


### PR DESCRIPTION
Use a different artifact-naming function.