### PR TITLE
kusanagi can be picked up safely

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1347,7 +1347,7 @@ touch_artifact(obj, mon, hypothetical)
 				&& oart->race == NON_PM
 			) badclass = TRUE;
 			
-			if(oart == &artilist[ART_KUSANAGI_NO_TSURUGI] && !(u.ulevel >= 30 || u.uhave.amulet)){
+			if(oart == &artilist[ART_KUSANAGI_NO_TSURUGI] && !(u.ulevel >= 22 || u.uhave.amulet)){
 				badclass = TRUE;
 				badalign = TRUE;
 			}

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -657,6 +657,10 @@ const char *name;
 	    if (obj == uswapwep) untwoweapon();
 	    /* activate warning if you've just named your weapon "Sting" */
 	    if (obj == uwep) set_artifact_intrinsic(obj, TRUE, W_WEP);
+	    if (obj == uwep && obj->oartifact == ART_KUSANAGI_NO_TSURUGI){
+	    	setuwep((struct obj *) 0);
+	    	pline("You are not yet worthy of wielding this sword, but you may bear it until you are ready.");
+	    }
 		if (carried(obj)) {
 			/*
 			 * We may need to do extra adjustments for the hero if we're

--- a/src/wield.c
+++ b/src/wield.c
@@ -163,7 +163,10 @@ boolean quietly;	/* hide the basic message saying what you are now wielding */
 		    wep->otyp == BATTLE_AXE ? "axe" : "weapon");
 	else if (wep->otyp == ARM_BLASTER && uarmg && is_metal(uarmg))
 		You("cannot fit the bracer over such bulky, rigid gloves.");
-	else if (wep->oartifact && !touch_artifact(wep, &youmonst, FALSE)) {
+	else if (wep->oartifact && wep->oartifact == ART_KUSANAGI_NO_TSURUGI && !(u.ulevel >= 30 || u.uhave.amulet)) {
+	    pline("Only a Shogun, or a bearer of the Amulet of Yendor, is truly worthy of wielding this sword.");
+	    res++;	/* takes a turn even though it doesn't get wielded */
+	} else if (wep->oartifact && !touch_artifact(wep, &youmonst, FALSE)) {
 	    res++;	/* takes a turn even though it doesn't get wielded */
 	} else {
 	    /* Weapon WILL be wielded after this point */

--- a/src/wield.c
+++ b/src/wield.c
@@ -163,7 +163,7 @@ boolean quietly;	/* hide the basic message saying what you are now wielding */
 		    wep->otyp == BATTLE_AXE ? "axe" : "weapon");
 	else if (wep->otyp == ARM_BLASTER && uarmg && is_metal(uarmg))
 		You("cannot fit the bracer over such bulky, rigid gloves.");
-	else if (wep->oartifact && wep->oartifact == ART_KUSANAGI_NO_TSURUGI && !(u.ulevel >= 30 || u.uhave.amulet)) {
+	else if (wep->oartifact == ART_KUSANAGI_NO_TSURUGI && !(u.ulevel >= 30 || u.uhave.amulet)) {
 	    pline("Only a Shogun, or a bearer of the Amulet of Yendor, is truly worthy of wielding this sword.");
 	    res++;	/* takes a turn even though it doesn't get wielded */
 	} else if (wep->oartifact && !touch_artifact(wep, &youmonst, FALSE)) {


### PR DESCRIPTION
Previous behavior: if you named the sword then dropped it, it got to sit on the floor forever, since it wouldn't let you pick it up.
Now, if you're capable of naming the sword, it won't evade your grasp. If you're not capable of naming it, it will still blast and evade.

It specifically won't let you wield it unless you fulfill the criteria. If you get drained while wielding it, you'll be fine, you just can't re-wield it until you cure your levels. This won't work well if there's any other way to wield a weapon that bypasses ready_weapon in wield.c