### PR TITLE
Add `\r` to the list of skipped characters when parsing some things

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -1742,7 +1742,7 @@ get_uchars(fp, buf, bufp, list, modlist, size, name)
     while (1) {
 	switch(*bufp) {
 	    case ' ':  case '\0':
-	    case '\t': case '\n':
+		case '\t': case '\n': case '\r':
 		if (havenum) {
 		    /* if modifying in place, don't insert zeros */
 		    if (num || !modlist) list[count] = num;
@@ -1810,7 +1810,7 @@ get_longs(fp, buf, bufp, list, modlist, size, name)
     while (1) {
 	switch(*bufp) {
 	    case ' ':  case '\0':
-	    case '\t': case '\n':
+		case '\t': case '\n': case '\r':
 		if (havenum) {
 		    num = parse_codepoint(tmpnum);
 		    /* if modifying in place, don't insert zeros */


### PR DESCRIPTION
My rcfile options started working again when I did this.

If this somehow breaks someone's rcfile, I'll... scream at the sky or something? Before this change, the parser would say "I don't like that character" and error out, so it shouldn't affect anyone adversely...