### PR TITLE
Glass chests shatter like other glass objects -- drop their contents.

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -816,6 +816,25 @@ boolean from_invent;
 			dowebgush(x,y, obj->ovar1 ? obj->ovar1 : 2);
 		break;
 	}
+
+	/* dump all contents on floor */
+	if (Has_contents(obj)) {
+		struct obj * otmp;
+		while ((otmp = obj->cobj) != 0) {
+			obj_extract_self(otmp);
+			if (obj->otyp == ICE_BOX && otmp->otyp == CORPSE) {
+				otmp->age = monstermoves - otmp->age; /* actual age */
+				start_corpse_timeout(otmp);
+			}
+			/* possibly 'donate' it to a shop */
+			if (hero_caused && *u.ushops)
+				check_shop_obj(otmp, x, y, FALSE);
+			place_object(otmp, x, y);
+			stackobj(otmp);
+		}
+		newsym(x, y);
+	}
+
 	if (hero_caused) {
 	    if (from_invent) {
 		if (*u.ushops)

--- a/src/shk.c
+++ b/src/shk.c
@@ -3142,8 +3142,7 @@ xchar x, y;
 
 		if(container) {
 			dropped_container(obj, shkp, FALSE);
-			if(!obj->unpaid && !saleitem)
-			    obj->no_charge = 1;
+			obj->no_charge = (!obj->unpaid && !saleitem);
 			if(obj->unpaid || count_unpaid(obj->cobj))
 			    subfrombill(obj, shkp);
 		} else obj->no_charge = 1;
@@ -3203,7 +3202,7 @@ xchar x, y;
 		    if(!isgold) {
 			if (container)
 			    dropped_container(obj, shkp, FALSE);
-			if (!obj->unpaid && !saleitem) obj->no_charge = 1;
+			obj->no_charge = (!obj->unpaid && !saleitem);
 			subfrombill(obj, shkp);
 		    }
 		    return;
@@ -3266,7 +3265,7 @@ move_on:
 		    if (c == 'q') sell_response = 'n';
 		    if (container)
 			dropped_container(obj, shkp, FALSE);
-		    if (!obj->unpaid) obj->no_charge = 1;
+		    obj->no_charge = (!obj->unpaid);
 		    subfrombill(obj, shkp);
 		}
 	} else {
@@ -3299,13 +3298,13 @@ move_on:
 		 case 'q':  sell_response = 'n';
 		 case 'n':  if (container)
 				dropped_container(obj, shkp, FALSE);
-			    if (!obj->unpaid) obj->no_charge = 1;
+			    obj->no_charge = (!obj->unpaid);
 			    subfrombill(obj, shkp);
 			    break;
 		 case 'a':  sell_response = 'y';
 		 case 'y':  if (container)
 				dropped_container(obj, shkp, TRUE);
-			    if (!obj->unpaid && !saleitem) obj->no_charge = 1;
+			    obj->no_charge = (!obj->unpaid && !saleitem);
 			    subfrombill(obj, shkp);
 			    pay(-offer, shkp);
 				obj->ostolen = FALSE;


### PR DESCRIPTION
This revealed a bug in shk code: it was selling items that had the no_charge flag already set on them, and failing to remove the no_charge flag. This would let the player pick the object up again without paying, and mark it as stolen.

Closes #750.