### PR TITLE
Hit passthru displacement with shining weapons

### DIFF
--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1601,7 +1601,7 @@ struct obj *obj;
 			Sprintf(buf, "almost hits the %s", ceiling(u.ux, u.uy));
 		}
 	}
-	if (!hits_insubstantial((struct monst *)0, &youmonst, (struct attack *)0, obj)) {
+	if (insubstantial(youracedata) && !hits_insubstantial((struct monst *)0, &youmonst, (struct attack *)0, obj)) {
 		pline("%s %s, then falls back down through you.", Doname2(obj), buf);
 		hitfloor2(&youmonst, obj, (struct obj *)0, FALSE, FALSE, &wepgone);
 	}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3584,7 +3584,7 @@ boolean ranged;
 		miss = TRUE;
 	}
 	/* insubstantial (shade-type) immunity to being hit */
-	if (!miss && !hits_insubstantial(magr, mdef, attk, weapon)) {
+	if (!miss && insubstantial(pd) && !hits_insubstantial(magr, mdef, attk, weapon)) {
 		/* Print message */
 		if (vis&VIS_MAGR) {
 			Sprintf(buf, "%s", ((!weapon || valid_weapon(weapon)) ? "attack" : cxname(weapon)));
@@ -11779,8 +11779,10 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	}
 	/* weapons/armor */
 	else if (otmp &&
-		(otmp == weapon ||							// if using a weapon, only check that weapon (probably moot)
-		hits_insubstantial(magr, mdef, attk, otmp))	// if armor harmlessly passes through mdef, skin/rings have an effect
+		// if using a weapon, only check that weapon (probably moot)
+		(otmp == weapon ||
+		// if armor harmlessly passes through mdef, skin/rings have an effect
+		!insubstantial(pd) || hits_insubstantial(magr, mdef, attk, otmp))
 		) {
 		if (otmp->oartifact == ART_GLAMDRING &&
 			(is_orc(pd) || is_demon(pd)))
@@ -11903,7 +11905,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 		}
 	}
 
-	if (poisonedobj && hits_insubstantial(magr, mdef, attk, poisonedobj))
+	if (poisonedobj && (!insubstantial(pd) || hits_insubstantial(magr, mdef, attk, poisonedobj)))
 	{
 		int poisons = poisonedobj->opoisoned;
 		int artipoisons = 0;
@@ -13006,7 +13008,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 		subtotl = (real_attack ? 1 : 0);
 
 	/* some attacks only deal searing damage to insubstantial creatures */
-	if (hits_insubstantial(magr, mdef, attk, weapon) == 1) {
+	if (insubstantial(pd) && hits_insubstantial(magr, mdef, attk, weapon) == 1) {
 		subtotl = 0;
 	}
 	/* some creatures resist weapon attacks to the extreme */

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3563,7 +3563,9 @@ boolean ranged;
 		mon_resistance(mdef, DISPLACED) &&
 		!(youagr && u.ustuck && u.ustuck == mdef) &&
 		!(youagr && u.uswallow) &&
-		rn2(2)) {
+		!(has_passthrough_displacement(pd) && hits_insubstantial(magr, mdef, attk, weapon)) &&
+		rn2(2)
+		) {
 		if (has_passthrough_displacement(pd)){
 			if (vis&VIS_MAGR) {
 				pline("%s attack passes harmlessly through %s!",

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1475,6 +1475,10 @@ struct obj * otmp;
 
 /* hits_insubstantial()
  * 
+ * Caller is responsible for checking insubstantial(mdef->data) first
+ * so that this function can also be used for other cases that can cause a creature
+ * to be insubstantial.
+ *
  * returns non-zero if [magr] attacking [mdef] with [attk] hits,
  * specifically in the case of [mdef] being insubstantial (as a shade)
  * 
@@ -1495,10 +1499,6 @@ struct obj * weapon;
 	boolean youdef = (mdef == &youmonst);
 	struct permonst * pa = (magr ? (youagr ? youracedata : magr->data) : (struct permonst *)0);
 	struct permonst * pd = youdef ? youracedata : mdef->data;
-
-	/* if the defender isn't insubstantial, full damage */
-	if (!insubstantial(pd))
-		return 2;
 
 	/* Chupoclops makes all your attacks ethereal */
 	if (youagr && u.sealsActive&SEAL_CHUPOCLOPS)


### PR DESCRIPTION
Wraithworms don't hate any kinds of objects, but if they did, those would also always hit.
If that isn't wanted (only weapons that would deal their full damage should hit passthru displacement), put an `==2` after hits_insubstantial().

Fixes #687