### PR TITLE
Don't add extra cap to yuki-onna's str/con carry amount

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2650,7 +2650,7 @@ weight_cap()
 	}
 	/* consistent with can_carry() in mon.c */
 	if (mdat->mlet == S_NYMPH)
-		carrcap = MAX_CARR_CAP;
+		carrcap = max(carrcap, MAX_CARR_CAP);
 	else if (!mdat->cwt)
 		carrcap = (carrcap * (long)mdat->msize) / MZ_HUMAN;
 	else if (!strongmonst(mdat)


### PR DESCRIPTION
Nymphs are supposed to be able to carry lots, so they get the default MAX_CARRY_CAP, 1000.
When the player has +maxcarrycap, they can get a maxcarrycap > 1000.
Don't limit the player's carrycap to 1000 prematurely.

Fixes #785