### PR TITLE
Show monster DR alongside monster AC

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3012,6 +3012,8 @@ E int FDECL(full_marmorac, (struct monst *));
 E int FDECL(base_nat_mdr, (struct monst *));
 E int FDECL(base_mdr, (struct monst *));
 E int FDECL(roll_mdr, (struct monst *, struct monst *));
+E int FDECL(avg_mdr, (struct monst *)); 
+E int FDECL(mdat_avg_mdr, (struct monst *));
 E void FDECL(m_dowear, (struct monst *,BOOLEAN_P));
 E boolean FDECL(mon_remove_armor, (struct monst *));
 E struct obj *FDECL(which_armor, (struct monst *,long));

--- a/src/pager.c
+++ b/src/pager.c
@@ -2083,7 +2083,8 @@ get_description_of_monster_type(struct monst * mtmp, char * description)
 			strcat(description, "Base statistics of this monster type:");
 			strcat(description, "\n");
 			int ac = 10-(ptr->nac+ptr->dac+ptr->pac);
-			sprintf(temp_buf, "Base level = %d. Difficulty = %d. AC = %d. MR = %d. Alignment %d. ", ptr->mlevel, monstr[monsndx(ptr)], ac, ptr->mr, ptr->maligntyp);
+			sprintf(temp_buf, "Base level = %d. Difficulty = %d. AC = %d. DR = %d. MR = %d. Alignment %d. ",
+				ptr->mlevel, monstr[monsndx(ptr)], ac, mdat_avg_mdr(mtmp), ptr->mr, ptr->maligntyp);
 			strcat(description, temp_buf);
 			temp_buf[0] = '\0';
 			strcat(description, get_speed_description_of_monster_type(mtmp, temp_buf));

--- a/src/pline.c
+++ b/src/pline.c
@@ -519,13 +519,14 @@ register struct monst *mtmp;
 	Strcpy(monnambuf, x_monnam(mtmp, ARTICLE_THE, (char *)0,
 	    (SUPPRESS_IT|SUPPRESS_INVISIBLE), FALSE));
 
-	pline("Status of %s (%s):  Level %d  HP %d(%d)  AC %d%s.",
+	pline("Status of %s (%s):  Level %d  HP %d(%d)  AC %d  DR %d%s.",
 		monnambuf,
 		align_str(alignment),
 		mtmp->m_lev,
 		mtmp->mhp,
 		mtmp->mhpmax,
 		full_mac(mtmp),
+		avg_mdr(mtmp),
 		info);
 }
 

--- a/src/worn.c
+++ b/src/worn.c
@@ -1144,6 +1144,57 @@ mon_lowertorso:
 	return base;
 }
 
+int
+avg_mdr(mon)
+struct monst *mon;
+{
+	/* stupid solution: take average of 200 calls of monster's rolled DR */
+	/* this function should only be called when the player inspects a creature in some way */
+	int i;
+	int sum = 0;
+
+	for (i = 0; i < 200; i++)
+		sum += roll_mdr(mon, (struct monst *)0);
+
+	return sum / 200;
+}
+
+int
+mdat_avg_mdr(mon)
+struct monst * mon;
+{
+	/* only looks at a monster's base stats with minimal adjustment (and no worn armor) */
+	/* used for pokedex entry */
+	int slots = 5;
+	int dr = 0;
+
+#define m_bdr mon->data->bdr + mon->data->spe_bdr
+#define m_ldr mon->data->ldr + mon->data->spe_ldr
+#define m_hdr mon->data->hdr + mon->data->spe_hdr
+#define m_fdr mon->data->fdr + mon->data->spe_fdr
+#define m_gdr mon->data->gdr + mon->data->spe_gdr
+
+	dr += m_bdr;
+	dr += m_ldr;
+
+	if (has_head_mon(mon))			dr += m_hdr;
+	else							dr += m_bdr;
+
+	if (can_wear_boots(mon->data))	dr += m_fdr;
+	else							dr += m_ldr;
+
+	if (can_wear_gloves(mon->data))	dr += m_gdr;
+	else							dr += m_bdr;
+	
+#undef m_bdr
+#undef m_ldr
+#undef m_hdr
+#undef m_fdr
+#undef m_gdr
+
+	return (dr / 5);
+}
+
 /* weapons are handled separately; rings and eyewear aren't used by monsters */
 
 /* Wear the best object of each type that the monster has.  During creation,


### PR DESCRIPTION
Applies to stethoscopes, probing, and the pokedex.

Does a kinda stupid method of finding average DR for stethoscopes and probing, but no one should notice in-game.

Closes #748.