### PR TITLE
Close loopholes for Anas to lose telepathy

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -5627,7 +5627,8 @@ cleanup:
 	  !(u.sealsActive&SEAL_MALPHAS) && (!always_hostile_mon(mtmp) && mtmp->malign <= 0) &&
 	   (mndx < PM_ARCHEOLOGIST || mndx > PM_WIZARD) &&
 	   u.ualign.type != A_CHAOTIC) {
-		HTelepat &= ~INTRINSIC;
+		if (!Role_if(PM_ANACHRONONAUT))
+			HTelepat &= ~INTRINSIC;	/* no murdering to get rid of this liability in the quest */
 		change_luck(-2);
 		You("murderer!");
 		if(u.ualign.type == A_LAWFUL){

--- a/src/sit.c
+++ b/src/sit.c
@@ -702,7 +702,7 @@ attrcurse()			/* remove a random INTRINSIC ability */
 			You_feel("a little sick!");
 			break;
 		}
-	case 4 : if (HTelepat & INTRINSIC) {
+	case 4 : if ((HTelepat & INTRINSIC) && !Role_if(PM_ANACHRONONAUT)) {
 			HTelepat &= ~INTRINSIC;
 			if (Blind && !Blind_telepat)
 			    see_monsters();	/* Can't sense mons anymore! */


### PR DESCRIPTION
Being not-telepathic makes their quest significantly easier. Anachrononauts were changed to start with telepathy for a reason.
Therefore, remove methods for losing telepathy for anachrononauts.