### PR TITLE
The Fluorite Octet can be thrown up to all 8 at once

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -1398,23 +1398,6 @@ register const char *let,*word;
 		    }
 		    /* they typed a letter (not a space) at the prompt */
 		}
-		if(allowcnt == 2 && !strcmp(word,"throw")) {
-		    /* permit counts for throwing gold, but don't accept
-		     * counts for other things since the throw code will
-		     * split off a single item anyway */
-#ifdef GOLDOBJ
-		    if (ilet != def_oc_syms[COIN_CLASS])
-#endif
-			allowcnt = 1;
-		    if(cnt == 0 && prezero) return((struct obj *)0);
-		    if(cnt > 1) {
-			You("can only throw one item at a time.");
-			continue;
-		    }
-		}
-#ifdef GOLDOBJ
-		flags.botl = 1; /* May have changed the amount of money */
-#endif
 #ifdef REDO
 		savech(ilet);
 #endif
@@ -1425,6 +1408,16 @@ register const char *let,*word;
 #ifdef REDO
 			if (in_doagain) return((struct obj *) 0);
 #endif
+			continue;
+		} else if (allowcnt == 2 && !strcmp(word,"throw") && cnt > 1 && !(
+#ifdef GOLDOBJ
+			(ilet == def_oc_syms[COIN_CLASS]) ||
+#endif
+			(otmp->oartifact == ART_FLUORITE_OCTAHEDRON)
+			)) {
+			You("can only throw one item at a time.");
+			allowcnt = 1;
+			if (cnt == 0 && prezero) return((struct obj *)0);
 			continue;
 		} else if (cnt < 0 || otmp->quan < cnt) {
 			You("don't have that many!  You have only %ld.",

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1761,6 +1761,10 @@ int shotlimit;
 		/* else it is auto == no change */
 	}
 
+	/* The Fluorite Octet can be thrown (by hand) as many as wanted at once */
+	if (ammo->oartifact == ART_FLUORITE_OCTAHEDRON && !launcher)
+		multishot = shotlimit ? shotlimit : 8;
+
 	/* For most things, limit multishot to ammo supply */
 	if ((long)multishot > ammo->quan && !(
 		ammo->oartifact == ART_WINDRIDER ||
@@ -1929,6 +1933,7 @@ dothrow()
 
 	/* kludge to work around parse()'s pre-decrement of 'multi' */
 	shotlimit = (multi || save_cm) ? multi + 1 : 0;
+	multi = 0;		/* reset; it's been used up */
 
 	/* try to find a wielded launcher */
 	if (ammo != uwep && ammo != uswapwep &&


### PR DESCRIPTION
Fixes #818

Also, let the player do `t``6` to throw 6 octahedra, as well as still allowing `n``6``t`.

Fix bug not of reseting multi after `n``6``t`.