### PR TITLE
Fix minor bug in faction attack changes

### DIFF
--- a/src/mondata.c
+++ b/src/mondata.c
@@ -376,7 +376,7 @@ int faction;
 						&& !(attk->aatyp == AT_BREA && ptr->mlet == S_DRAGON)) || attk->aatyp == AT_NONE)) \
 					&& (insert = TRUE))
 #define end_insert_okay (!special && (is_null_attk(attk) || attk->aatyp == AT_NONE) && (insert = TRUE))
-#define maybe_insert() if(insert) {for(j=NATTK-i-1;j>0;j--)attk[j]=attk[j-1];*attk=noattack;}
+#define maybe_insert() if(insert) {for(j=NATTK-i-1;j>0;j--)attk[j]=attk[j-1];*attk=noattack;i++;}
 		/* zombies/skeletons get a melee attack if they don't have any (likely due to disallowed aatyp) */
 		if ((faction == ZOMBIFIED || faction == SKELIFIED) && (
 			i == 0 && (!nolimbs(ptr) || has_head(ptr)) && (


### PR DESCRIPTION
Was causing the 1st attack of a tomb herd to get boosted twice.

Also it auto-fixed some line endings. yay.