### PR TITLE
Astaroth's Assembly protection timeout

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -2115,10 +2115,21 @@ spiriteffects(power, atme)
 						break;//break loop
 					}
 				}
-				pline("Leftover electrical potential produces a field around you.");
-				u.uspellprot = max(5 - (range+1),u.uspellprot);
-				u.usptime = 5;
-				u.uspmtime = 5;
+				/* Grant protection based on the distance Astaroth's Assembly traveled.
+				* Only grant if the player does not already have better protection.
+				*If protection is granted, it decays every 5 turns */
+				if ( 5 - ( range + 1 ) > u.uspellprot )
+				{
+					pline("Leftover electrical potential produces a field around you.");
+					u.uspellprot = 5 - (range+1);
+					u.usptime = 5;
+					u.uspmtime = 5;
+				}
+				/* player would have received protection, but was already better protected */
+				else if ( 5 - ( range + 1 ) > 0 )
+				{
+					pline("Static electricity crackles around you.");
+				}
 			}
 		}break;
 		case PWR_ASTAROTH_S_SHARDS:


### PR DESCRIPTION
Changes:
Astaroth's Assembly only grants protection if it would give more than the player already has.
AA does not change protection timeout unless it grants protection.
New message for cases where the player would have received protection from AA, but already had equal or better protection from another sourse (most likely spell of protection).