### PR TITLE
Change menu type for describing spirit powers to fix TTY menu

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -4860,13 +4860,11 @@ int respect_timeout;
 				case SPELLMENU_DESCRIBE:
 					if (TRUE)
 					{
-						tmpwin = create_nhwindow(NHW_MENU);
-						start_menu(tmpwin);
+						tmpwin = create_nhwindow(NHW_TEXT);
 						Sprintf(buf, "%s %s", s_suffix(sealNames[decode_sealID(spirit_powers[p_no].owner) - FIRST_SEAL]),
 							spirit_powers[p_no].name);
 						putstr(tmpwin, 0, buf);
 						putstr(tmpwin, 0, spirit_powers[p_no].desc);
-						end_menu(tmpwin, (const char *)0);
 						display_nhwindow(tmpwin, FALSE);
 						destroy_nhwindow(tmpwin);
 					}


### PR DESCRIPTION
Previous version worked fine on Curses, but not on TTY.
Fixes #860.