### PR TITLE
Artifact potions aren't flagged in_use

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -406,6 +406,9 @@ dodrink()
 	}
 	
 	otmp->in_use = TRUE;		/* you've opened the stopper */
+	if (otmp->oartifact)
+		otmp->in_use = FALSE;
+	
 
 #define POTION_OCCUPANT_CHANCE(n) (13 + 2*(n))	/* also in muse.c */
 
@@ -435,6 +438,9 @@ register struct obj *otmp;
 	int retval;
 
 	otmp->in_use = TRUE;
+	if (otmp->oartifact)
+		otmp->in_use = FALSE;
+	
 	nothing = unkn = 0;
 	if((retval = peffects(otmp)) >= 0) return(retval);
 
@@ -2593,6 +2599,9 @@ dodip()
 	  obj = otmp;
 	}
 	potion->in_use = TRUE;		/* assume it will be used up */
+	if (potion->oartifact)
+		potion->in_use = FALSE;
+	
 	if(potion->otyp == POT_WATER) {
 		boolean useeit = !Blind;
 		if (useeit) (void) Shk_Your(Your_buf, obj);


### PR DESCRIPTION
Otherwise, saving & loading will finish off the potion. This is in a separate if because it may require exemptions for specific intentionally consumable artifacts. 