### PR TITLE
Adjust fluorite octet

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -914,7 +914,7 @@ A("Plague",				BOW,							(const char *)0,
 
 /*Needs encyc entry*/
 /* die size set to 1d8 in weapon.c */
-A("The Fluorite Octahedron",		BLUE_FLUORITE,		(const char *)0,
+A("The Fluorite Octahedron",		BLUE_FLUORITE,		"glowing cobalt eight-sided die",
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_NONE, NON_PM, NON_PM, TIER_A, NOFLAG,
 	NO_MONS(),

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2329,6 +2329,9 @@ const char *str;
 				)) ||
 				(strlen(str) >= 25 && (
 				!strncmp(str, "Candelabrum of Invocation", 25)
+				)) ||
+				(strlen(str) >= 12 && (
+				!strncmp(str, "Fluorite Oct", 12)
 				))
 				))
 				insert_the = TRUE;
@@ -2402,7 +2405,7 @@ register const char *verb;
 	 * if the result of xname(otmp) would be plural.  Don't bother
 	 * recomputing xname(otmp) at this time.
 	 */
-	if (!is_plural(otmp))
+	if (!is_plural(otmp) || (otmp->oartifact == ART_FLUORITE_OCTAHEDRON && otmp->quan == 8))
 	    return vtense((char *)0, verb);
 
 	buf = nextobuf();

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -518,7 +518,7 @@ char *buf;
 {
 	char tmpbuf[PREFIX + 1];
 
-	if (obj->quan != 1L)
+	if (obj->quan != 1L && !(obj->quan == 8 && obj->oartifact == ART_FLUORITE_OCTAHEDRON && !undiscovered_artifact(obj->oartifact)))
 	{
 		Sprintf(tmpbuf, "%ld ", obj->quan);
 		Strcat(buf, tmpbuf);

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -289,7 +289,7 @@ struct obj *otmp;
 			}
 		} break;
 		case ART_ARKENSTONE: return Hallucination ? hcolor(0) : "rainbow-glinting sparking white";
-		case ART_FLUORITE_OCTAHEDRON: return Hallucination ? hcolor(0) : "burning cerulean";
+		case ART_FLUORITE_OCTAHEDRON: return Hallucination ? hcolor(0) : "burning cobalt";
 		case ART_HEART_OF_AHRIMAN: return Hallucination ? hcolor(0) : "pulsing and shimmering ruby";
 		case ART_GLITTERSTONE: return Hallucination ? hcolor(0) : "glittering gold";
 		
@@ -518,7 +518,7 @@ char *buf;
 {
 	char tmpbuf[PREFIX + 1];
 
-	if (obj->quan != 1L && !(obj->quan == 8 && obj->oartifact == ART_FLUORITE_OCTAHEDRON))
+	if (obj->quan != 1L)
 	{
 		Sprintf(tmpbuf, "%ld ", obj->quan);
 		Strcat(buf, tmpbuf);
@@ -1281,6 +1281,7 @@ boolean with_price;
 		}
 		else {
 			Strcat(buf, oart->desc);
+			if (obj->quan != 1L) Strcpy(buf, makeplural(buf)); // makes fluorite octet display right
 		}
 	}
 	else if (!obj_is_pname(obj))
@@ -1652,7 +1653,7 @@ boolean with_price;
 #endif
 		if (obj->quan != 1L) Strcpy(buf, makeplural(buf));
 	}//endif !obj_is_pname(obj)
-
+	
 	if (!(obj->oartifact && undiscovered_artifact(obj->oartifact) && oart->desc)) {
 		if ((obj->onamelth && obj->dknown) || (obj_is_pname(obj))) {
 			if (!obj_is_pname(obj) && obj->onamelth && obj->dknown) Strcat(buf, " named ");
@@ -2822,6 +2823,12 @@ const char *oldstr;
 		Strcpy(spot-3, "dra");
 		goto bottom;
 	}
+	
+	if (len >= 4 && (!strcmp(spot-3, " die"))) {
+		Strcpy(spot-3, " dice");
+		goto bottom;
+	}
+	
 	
 	/* note: -eau/-eaux (gateau, bordeau...) */
 	/* note: ox/oxen, VAX/VAXen, goose/geese */

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2479,6 +2479,7 @@ register const char *verb;
 			(*(spot-1) != 'u' && *(spot-1) != 's') &&
 			!((spot - subj) >= 5 && !strncmp(spot-4, "Chaos", 5))
 		) ||
+		((spot - subj) >= 5 && !strncmp(spot-4, "hedra", 5)) ||
 		((spot - subj) >= 4 && !strncmp(spot-3, "eeth", 4)) ||
 		((spot - subj) >= 3 && !strncmp(spot-3, "feet", 4)) ||
 		((spot - subj) >= 2 && !strncmp(spot-1, "ia", 2)) ||

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1762,7 +1762,7 @@ int shotlimit;
 	}
 
 	/* The Fluorite Octet can be thrown (by hand) as many as wanted at once */
-	if (ammo->oartifact == ART_FLUORITE_OCTAHEDRON && !launcher)
+	if (ammo->oartifact == ART_FLUORITE_OCTAHEDRON && !launcher && !(youagr && Race_if(PM_ANDROID)))
 		multishot = shotlimit ? shotlimit : 8;
 
 	/* For most things, limit multishot to ammo supply */
@@ -2329,6 +2329,9 @@ boolean forcedestroy;
 	m_shot.s = (launcher) ? TRUE : FALSE;
 	m_shot.o = ammo->otyp;
 	m_shot.n = multishot;
+	
+	if (!shotlimit && ammo->oartifact == ART_FLUORITE_OCTAHEDRON)
+		shotlimit = m_shot.n;
 	
 	/* give a message if shooting more than one, or if player attempted to specify a count */
 	if (ammo->oartifact == ART_FLUORITE_OCTAHEDRON){


### PR DESCRIPTION
When un-id'd: "glowing cobalt eight-sided die" (that pluralizes correctly to "dice", too!)
When id'd: "fluorite octet/octahedra/octahedron"
When in a lightsaber: "burning cobalt" (instead of "burning cerulean")

Also, only throws 1 per throw when used by an android with returning.