### PR TITLE
Mirrorblades also add enchantment of weapon they are mirroring

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -956,6 +956,7 @@ int spec;
 			mir += weapon_dmg_roll(&(mirdice.oc), youdefend);
 			mir += weapon_dmg_roll(&(mirdice.bon), youdefend);
 			mir += mirdice.flat;
+			mir += otmp2->spe;	/* also adds enchantment of the copied weapon */
 
 			/* use the better */
 			tmp += max(hyp, mir);


### PR DESCRIPTION
A mirrorblade's dice will use the better of:
 1) A roll of its own dice
 2) A roll of the defender's weapon's dice + 1x enchantment of defender's weapon
It will then add the mirrorblade's own enchantment, to whichever of the above was higher.

There is an exception if the defender is also using a mirrorblade. Then, it will be all of:
 a) Twice as many dice
 b) Exploding dice
 c) When dice explode, have a flat damage increase of avg of both mirrorblades' enchantments
As before, it then adds the attacker's mirrorblade's own enchantment.

Closes #835 