### PR TITLE
Add artifact_descriptors flag to show artifact details even when ID'd 

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -332,6 +332,7 @@ struct instance_flags {
     boolean role_obj_names;
     boolean obscure_role_obj_names;
     boolean dnethack_start_text;
+    boolean artifact_descriptors;
     boolean dnethack_dungeon_colors;
 
 	int pokedex;	/* default monster stats to show in the pokedex */

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1988,8 +1988,8 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		mdef->movement -= 3;
 	}
 	if (pen->ovar1&SEAL_AMON) {
-	    if (vis){ 
-			Sprintf(buf, "fiery");
+	    if (vis){
+			Sprintf(buf, "fiery"); // profane
 			and = TRUE;
 		}
 	    if (!rn2(4)) (void) destroy_item(mdef, POTION_CLASS, AD_FIRE);
@@ -1997,6 +1997,7 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 	    if (!rn2(7)) (void) destroy_item(mdef, SPBOOK_CLASS, AD_FIRE);
 	    if (youdefend && Slimed) burn_away_slime();
 	    if (youdefend && FrozenAir) melt_frozen_air();
+	    // if(youdef ? (hates_unholy(youracedata)) : (hates_unholy_mon(mdef))){
 		if(youdefend ? !Fire_resistance : !resists_fire(mdef)){
 			*dmgptr += d(dnum,4);
 		}

--- a/src/invent.c
+++ b/src/invent.c
@@ -2851,13 +2851,17 @@ winid *datawin;
 			//int artipoisons = 0;
 			if (arti_poisoned(obj))
 				poisons |= OPOISON_BASIC;
+			if (arti_silvered(obj))
+				poisons |= OPOISON_SILVER;
 			if (oartifact == ART_WEBWEAVER_S_CROOK)
 				poisons |= (OPOISON_SLEEP | OPOISON_BLIND | OPOISON_PARAL);
 			if (oartifact == ART_SUNBEAM)
 				poisons |= OPOISON_FILTH;
 			if (oartifact == ART_MOONBEAM)
 				poisons |= OPOISON_SLEEP;
-
+			
+			
+			
 			if (poisons) {
 				/* special cases */
 				if (poisons == OPOISON_BASIC) {

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -860,6 +860,156 @@ boolean dofull;
 }
 
 static void
+add_voidpen_words(obj, buf)
+struct obj *obj;
+char *buf;
+{
+	if (obj->oartifact != ART_PEN_OF_THE_VOID)
+		return;
+	
+	if(u.voidChime){
+		Strcat(buf, "ringing ");
+		return;
+	}
+
+	if (obj->ovar1&SEAL_AHAZU){
+		Strcat(buf, "hungry ");
+	}
+
+	if (obj->ovar1&SEAL_AMON){
+		if (obj->ovar1&SEAL_ENKI)
+			Strcat(buf, "steaming ");
+		else if (obj->ovar1&SEAL_BERITH)
+			Strcat(buf, "blood-crusted ");
+		else
+			Strcat(buf, "fiery ");
+	}
+
+	if (obj->ovar1&SEAL_ANDREALPHUS){
+		Strcat(buf, "curved ");
+	}
+
+	if (obj->ovar1&SEAL_ANDROMALIUS){
+		Strcat(buf, "mischievous ");
+	}
+
+	if (obj->ovar1&SEAL_ASTAROTH){
+		Strcat(buf, "crackling ");
+	}
+
+	if (obj->ovar1&SEAL_BALAM){
+		Strcat(buf, "freezing ");
+	}
+
+	if (obj->ovar1&SEAL_BERITH){
+		if (obj->ovar1&SEAL_ENKI)
+			Strcat(buf, "blood-dripping ");
+		else if (!(obj->ovar1&SEAL_AMON))
+			Strcat(buf, "blood-soaked ");
+	}
+
+	if (obj->ovar1&SEAL_BUER){
+		Strcat(buf, "lively ");
+	}
+
+	if (obj->ovar1&SEAL_CHUPOCLOPS){
+		Strcat(buf, "webbed ");
+	}
+
+	if (obj->ovar1&SEAL_DANTALION){
+		Strcat(buf, "jeweled ");
+	}
+
+	if (obj->ovar1&SEAL_ECHIDNA){
+		Strcat(buf, "caustic ");
+	}
+
+	if (obj->ovar1&SEAL_EDEN){
+		// covered in poisoned words
+	}
+
+	if (obj->ovar1&SEAL_ENKI){
+		if (obj->ovar1&SEAL_IRIS)
+			Strcat(buf, "dehydrated ");
+		else if (!(obj->ovar1&SEAL_AMON) && !(obj->ovar1&SEAL_BERITH))
+			Strcat(buf, "dripping ");
+	}
+
+	if (obj->ovar1&SEAL_EURYNOME){
+		Strcat(buf, "vengeful ");
+	}
+
+	if (obj->ovar1&SEAL_EVE){
+		Strcat(buf, "vine-wrapped ");
+	}
+
+	if (obj->ovar1&SEAL_FAFNIR){
+		Strcat(buf, "ruinous ");
+	}
+
+	if (obj->ovar1&SEAL_HUGINN_MUNINN){
+		Strcat(buf, "talon-shaped ");
+	}
+
+	if (obj->ovar1&SEAL_IRIS){
+		Strcat(buf, "rainbow ");
+	}
+
+	if (obj->ovar1&SEAL_JACK){
+		Strcat(buf, "glowing ");
+	}
+
+	if (obj->ovar1&SEAL_MALPHAS){
+		Strcat(buf, "crow-embossed ");
+	}
+
+	if (obj->ovar1&SEAL_MARIONETTE){
+		Strcat(buf, "wire-wrapped ");
+	}
+
+	if (obj->ovar1&SEAL_MOTHER){
+		Strcat(buf, "eye-marked ");
+	}
+
+	if (obj->ovar1&SEAL_NABERIUS){
+		Strcat(buf, "fanged ");
+	}
+
+	if (obj->ovar1&SEAL_ORTHOS){
+		Strcat(buf, "whistling ");
+	}
+
+	if (obj->ovar1&SEAL_OSE){
+		Strcat(buf, "murmuring ");
+	}
+
+	if (obj->ovar1&SEAL_OTIAX){
+		Strcat(buf, "mist-wreathed ");
+	}
+
+	if (obj->ovar1&SEAL_PAIMON){
+		Strcat(buf, "ink-stained ");
+	}
+
+	if (obj->ovar1&SEAL_SHIRO){
+		Strcat(buf, "distinctive ");
+	}
+
+	if (obj->ovar1&SEAL_SIMURGH){
+		Strcat(buf, "feathered ");
+	}
+
+	if (obj->ovar1&SEAL_TENEBROUS){
+		Strcat(buf, "shadowed ");
+	}
+
+	if (obj->ovar1&SEAL_YMIR){
+		// covered in poisoned words
+	}
+
+}
+
+static void
 add_enchantment_number(obj, buf)
 struct obj *obj;
 char *buf;
@@ -884,6 +1034,14 @@ char *buf;
 	 * which is handled elsewhere */
 	if (obj->otyp == find_signet_ring())
 		return;
+	
+	if (arti_poisoned(obj) && obj->oartifact != ART_WEBWEAVER_S_CROOK &&
+			(undiscovered_artifact(obj->oartifact) || obj->oartifact == ART_PEN_OF_THE_VOID))
+		Strcat(buf, "poisoned ");
+	
+	if (arti_silvered(obj) && (undiscovered_artifact(obj->oartifact) || obj->oartifact == ART_PEN_OF_THE_VOID))
+		Strcat(buf, "silvered ");
+	
 	if (obj->opoisoned){
 		if (obj->opoisoned & OPOISON_BASIC) Strcat(buf, "poisoned ");
 		if (obj->opoisoned & OPOISON_FILTH) Strcat(buf, "filth-crusted ");
@@ -1262,6 +1420,7 @@ boolean with_price;
 		if (dofull) add_grease_words(obj, buf);
 		if (dofull) add_enchantment_number(obj, buf);
 		add_properties_words(obj, buf, dofull);	// Note: more verbose for artifacts if dofull is true
+		add_voidpen_words(obj, buf);
 		add_poison_words(obj, buf);
 		add_insight_words(obj, buf);
 		add_colours_words(obj, buf);

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1039,9 +1039,7 @@ char *buf;
 	if (obj->otyp == find_signet_ring())
 		return;
 	
-	boolean show_poison = iflags.artifact_descriptors ||
-							undiscovered_artifact(obj->oartifact) ||
-							obj->oartifact == ART_PEN_OF_THE_VOID;
+	boolean show_poison = iflags.artifact_descriptors || undiscovered_artifact(obj->oartifact);
 	if (show_poison){
 		if (arti_poisoned(obj) && obj->oartifact != ART_WEBWEAVER_S_CROOK)
 			Strcat(buf, "poisoned ");

--- a/src/options.c
+++ b/src/options.c
@@ -138,6 +138,7 @@ static struct Bool_Opt
 	{"hilite_hidden_stairs",    &iflags.hilite_hidden_stairs, TRUE, SET_IN_GAME},	/*WC*/
 	{"hilite_obj_piles",    &iflags.hilite_obj_piles, FALSE, SET_IN_GAME},	/*WC*/
 	{"dnethack_start_text",    &iflags.dnethack_start_text, TRUE, DISP_IN_GAME},
+	{"artifact_descriptors",    &iflags.artifact_descriptors, FALSE, SET_IN_GAME},
 	{"role_obj_names",    &iflags.role_obj_names, TRUE, SET_IN_GAME},
 	{"obscure_role_obj_names",    &iflags.obscure_role_obj_names, FALSE, SET_IN_GAME},
 	{"dnethack_dungeon_colors",    &iflags.dnethack_dungeon_colors, TRUE, SET_IN_GAME},

--- a/src/potion.c
+++ b/src/potion.c
@@ -2845,7 +2845,8 @@ dodip()
 	if(is_poisonable(obj)) {
 	    if( (potion->otyp == POT_SICKNESS || 
 				(potion->otyp == POT_BLOOD && poisonous(&mons[potion->corpsenm]))) 
-			&& (!(obj->opoisoned & OPOISON_BASIC) || obj->otyp == VIPERWHIP)
+			&& (!(obj->opoisoned & OPOISON_BASIC || arti_poisoned(obj))
+	    		|| obj->otyp == VIPERWHIP)
 		){
 			char buf[BUFSZ];
 			if (potion->quan > 1L)
@@ -2918,7 +2919,8 @@ dodip()
 			obj->opoisoned = OPOISON_PARAL;
 			goto poof;
 	    } else if(potion->otyp == POT_STARLIGHT && obj->obj_material != SILVER &&
-	    		(!(obj->opoisoned & OPOISON_SILVER) || obj->otyp == VIPERWHIP)
+	    		(!(obj->opoisoned & OPOISON_SILVER || arti_silvered(obj))
+	    		|| obj->otyp == VIPERWHIP)
 	    	) {
 			char buf[BUFSZ];
 			if (potion->quan > 1L)

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -4690,7 +4690,7 @@ int tx,ty;
 					u.sealTimeout[SIMURGH-FIRST_SEAL] = moves + bindingPeriod;
 				}
 				else{
-					pline("It leaves");
+					pline("It leaves.");
 					// u.sealTimeout[SIMURGH-FIRST_SEAL] = moves + bindingPeriod/10;
 				}
 			} else{

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -3912,6 +3912,8 @@ int tx,ty;
 						u.spiritTineB = SEAL_EDEN;
 						u.spiritTineTB= moves + bindingPeriod;
 					}
+					if (uwep->opoisoned & OPOISON_SILVER)
+						uwep->opoisoned &= ~OPOISON_SILVER;
 					u.sealTimeout[EDEN-FIRST_SEAL] = moves + bindingPeriod;
 				}
 				else{
@@ -4794,6 +4796,8 @@ int tx,ty;
 						u.spiritTineB = SEAL_YMIR;
 						u.spiritTineTB= moves + bindingPeriod;
 					}
+					if (uwep->opoisoned & OPOISON_BASIC)
+						uwep->opoisoned &= ~OPOISON_BASIC;
 					u.sealTimeout[YMIR-FIRST_SEAL] = moves + bindingPeriod;
 				} else {
 					if(!Blind) pline("The eye closes.");


### PR DESCRIPTION
When on, shows details about artifacts that are otherwise hidden:
* Materials: artifacts with a default material that isn't the base type's default material show when unidentified by default, or always with `artifact_descriptors` on.
* Poisons: artifacts show their default poisons (ARTA_POISON / ARTA_SILVER) when unidentified by default, or even when identified with `artifact_descriptors` on.
* Size: artifacts with funky sizes show size when unidentified by default, or even when identified with `artifact_descriptors` on.
* PotV: shows spirit specific labels in inventory with `artifact_descriptors` on. See the first commit message for more info on that. 

Example: Lolth's Fang shows as `a poisoned silvered droven short sword named Lolth's Fang` when unidentified. When identified it shows as `the uncursed +0 Lolth's Fang`, or `the uncursed +0 poisoned silvered Lolth's Fang` with `artifact_descriptors` on.

Example 2: `a large poisoned flail named The Sting of the Poison Queen` -> `the uncursed +0 Sting of the Poison Queen` or `the uncursed large +0 poisoned Sting of the Poison Queen`

Example 3: `the holy rustproof +5 sizzling crow-embossed wire-wrapped lethe-rusted Pen of the Void` with the flag on, `the holy rustproof +5 sizzling lethe-rusted Pen of the Void` with the flag off.