### PR TITLE
Buff shotguns vs zombies

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1175,6 +1175,10 @@ int spec;
 		tmp *= 2;
 		tmp += rnd(20);
 	}
+	/* shotguns are great at putting down zombies */
+	if (otmp->otyp == SHOTGUN_SHELL && mon->mfaction == ZOMBIFIED)
+		tmp += d(2, 6);
+
 	/* Eve slays plants too */
 	if(u.sealsActive&SEAL_EVE && !youdefend && ptr->mlet == S_PLANT)
 		tmp *= 2;


### PR DESCRIPTION
+2d6 damage to zombies. Specifically shotgun shells vs zombies. Awesome.