### PR TITLE
Improve monster ranged AI

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1655,7 +1655,6 @@ E int FDECL(set_destroy_thrown, (int));
 E struct monst *FDECL(mfind_target, (struct monst *, int));
 E boolean FDECL(linedup, (XCHAR_P,XCHAR_P,XCHAR_P,XCHAR_P));
 E boolean FDECL(lined_up, (struct monst *));
-E boolean FDECL(mlined_up, (struct monst *,struct monst *,BOOLEAN_P));
 E struct obj *FDECL(m_carrying, (struct monst *,int));
 E struct obj *FDECL(m_carrying_charged, (struct monst *,int));
 E void FDECL(m_useup, (struct monst *,struct obj *));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1655,6 +1655,7 @@ E int FDECL(set_destroy_thrown, (int));
 E struct monst *FDECL(mfind_target, (struct monst *, int));
 E boolean FDECL(linedup, (XCHAR_P,XCHAR_P,XCHAR_P,XCHAR_P));
 E boolean FDECL(lined_up, (struct monst *));
+E int FDECL(m_pole_range, (struct monst *));
 E struct obj *FDECL(m_carrying, (struct monst *,int));
 E struct obj *FDECL(m_carrying_charged, (struct monst *,int));
 E void FDECL(m_useup, (struct monst *,struct obj *));

--- a/include/monattk.h
+++ b/include/monattk.h
@@ -217,6 +217,8 @@
 #define AD_CURS		AD_CLRC+6	/* random curse (ex. gremlin) */
 #define AD_SQUE		AD_CLRC+7	/* hits, may steal Quest Art or Amulet (Nemeses) */
 
+#define real_spell_adtyp(adtyp) \
+	((adtyp) == AD_SPEL || (adtyp) == AD_CLRC || (adtyp) == AD_PSON)
 
 /*
  *  Monster to monster attacks.  When a monster attacks another (mattackm),

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1635,83 +1635,25 @@ register struct monst *mtmp;
 	}
 toofar:
 
-	/* If monster is nearby you, and has to wield a weapon, do so.   This
-	 * costs the monster a move, of course.
-	 */
-	if((!mtmp->mpeaceful || Conflict) && inrange &&
-	   dist2(mtmp->mx, mtmp->my, mtmp->mux, mtmp->muy) <= 8
-	   && !no_upos(mtmp)
-	   && attacktype(mdat, AT_WEAP)) {
-	    struct obj *mw_tmp;
+	if (TRUE); /* stupid to make the label not label a declaration */
 
-	    /* The scared check is necessary.  Otherwise a monster that is
-	     * one square near the player but fleeing into a wall would keep	
-	     * switching between pick-axe and weapon.  If monster is stuck
-	     * in a trap, prefer ranged weapon (wielding is done in thrwmu).
-	     * This may cost the monster an attack, but keeps the monster
-	     * from switching back and forth if carrying both.
-	     */
-	    mw_tmp = MON_WEP(mtmp);
-	    if (!(scared && mw_tmp && is_pick(mw_tmp)) &&
-		mtmp->weapon_check == NEED_WEAPON &&
-		!(mtmp->mtrapped && !nearby && select_rwep(mtmp))) {
-			mtmp->combat_mode = HNDHND_MODE;
-			mtmp->weapon_check = NEED_HTH_WEAPON;
-			if (mon_wield_item(mtmp) != 0) return(0);
-	    }
-	}
-/*      Look for other monsters to fight (at a distance) */
-	if ((
-	      (attacktype(mtmp->data, AT_GAZE) && !mtmp->mcan) ||
-	      attacktype(mtmp->data, AT_ARRW) ||
-	      attacktype(mtmp->data, AT_LNCK) ||
-	      attacktype(mtmp->data, AT_LRCH) ||
-	      attacktype(mtmp->data, AT_5SQR) ||
-	      attacktype(mtmp->data, AT_5SBT) ||
-	      (!mtmp->mspec_used && 
-			(attacktype(mtmp->data, AT_SPIT) ||
-			 attacktype(mtmp->data, AT_TNKR) ||
-			 attacktype(mtmp->data, AT_BEAM) ||
-			 (attacktype(mtmp->data, AT_BREA) && !mtmp->mcan)
-			)
-		  )||
-	     (attacktype(mtmp->data, AT_MMGC) && !mtmp->mcan &&
-			(((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp
-	         <= AD_SPC2))
-	      ) ||
-	     (attacktype(mtmp->data, AT_MAGC) && !mtmp->mcan &&
-	      (((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp
-	         <= AD_SPC2))
-	      ) ||
-	     (attacktype(mtmp->data, AT_MAGC) && !mtmp->mcan &&
-	      (((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp
-	         == AD_RBRE))
-	      ) ||
-	     (attacktype(mtmp->data, AT_MAGC) && !mtmp->mcan &&
-	      (((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp
-	         == AD_OONA))
-	      ) ||
-	     (attacktype(mtmp->data, AT_WEAP) &&
-	      (select_rwep(mtmp) != 0)) ||
-	      find_offensive(mtmp)) && 
-	    mtmp->mlstmv != monstermoves)
-	{
-	    register struct monst *mtmp2 = mfind_target(mtmp, FALSE);
-	    if (mtmp2 && 
-	        (mtmp2 != &youmonst || 
-				dist2(mtmp->mx, mtmp->my, mtmp->mux, mtmp->muy) > 2) &&
-			(mtmp2 != mtmp)
-		){
-	        int res;
-			mon_ranged_gazeonly = 1;//State variable
-			res = (mtmp2 == &youmonst) ? mattacku(mtmp)
-		                           : mattackm(mtmp, mtmp2);
-			/* note: mattacku and mattackm have different returns */
-			if (res & MM_AGR_DIED) return 1; /* Oops. */
+	/* Look for other monsters to fight (at a distance) */
+	struct monst *mtmp2 = mfind_target(mtmp, FALSE);
+	if (mtmp2 && 
+	    (mtmp2 != &youmonst || 
+			dist2(mtmp->mx, mtmp->my, mtmp->mux, mtmp->muy) > 2) &&
+		(mtmp2 != mtmp)
+	){
+	    int res;
+		mon_ranged_gazeonly = 1;//State variable
+		res = (mtmp2 == &youmonst) ? mattacku(mtmp)
+		                        : mattackm(mtmp, mtmp2);
 
-			if(!(mon_ranged_gazeonly))
-				return 0; /* that was our move for the round */
-	    }
+		if (res & MM_AGR_DIED)
+			return 1; /* Oops. */
+
+		if(!(mon_ranged_gazeonly) && (res & MM_HIT))
+			return 0; /* that was our move for the round */
 	}
 
 /*	Now the actual movement phase	*/

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -205,12 +205,16 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 				(attacktype(magr->data, AT_BEAM))
 			))
 			||
-			/* attacks in a square range of 2 -- includes polearms */
-			(distmin(magr->mx, magr->my, tarx, tary) <= 2 && (
-				(attacktype(magr->data, AT_LRCH)) ||
-				(attacktype(magr->data, AT_LNCK)) ||
+			/* attacks in polearm range */
+			(dist2(magr->mx, magr->my, tarx, tary) <= m_pole_range(magr) && (
 				(attacktype(magr->data, AT_WEAP) && mrwep && is_pole(mrwep)) ||
 				(attacktype(magr->data, AT_DEVA) && mrwep && is_pole(mrwep))
+			))
+			||
+			/* attacks in a square range of 2 */
+			(distmin(magr->mx, magr->my, tarx, tary) <= 2 && (
+				(attacktype(magr->data, AT_LRCH)) ||
+				(attacktype(magr->data, AT_LNCK))
 			))
 			||
 			/* attacks in a square range of 5 */
@@ -289,6 +293,47 @@ lined_up(mtmp)		/* is mtmp in position to use ranged attack? */
 {
 	return(linedup(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my));
 }
+
+
+/* returns the max euclidean distance magr can use a polearm at */
+/* Ranges:
+ * 
+ * ESBSE
+ * S...S
+ * B.@.B
+ * S...S
+ * ESBSE
+ *  
+ */
+int
+m_pole_range(magr)
+struct monst * magr;
+{
+	if (magr == &youmonst) {
+		impossible("calculating player's polearm range with m_pole_range?");
+		return 8;
+	}
+
+	int skill_equiv = P_BASIC;
+
+	if (magr->data->mlevel >= 6)
+		skill_equiv++;
+	if (magr->data->mlevel >= 12)
+		skill_equiv++;
+	if (is_prince(magr->data))
+		skill_equiv++;
+
+	/* cap at expert */
+	if (skill_equiv > P_EXPERT)
+		skill_equiv = P_EXPERT;
+
+	switch (skill_equiv) {
+	case P_BASIC:	return 4;
+	case P_SKILLED:	return 5;
+	case P_EXPERT:	return 8;
+	}
+}
+
 
 #endif /* OVL1 */
 #ifdef OVL0

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -93,7 +93,29 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 	
 	struct obj *mrwep = select_rwep(magr);
 	
-	if (is_derived_undead_mon(magr)) return 0;
+	if (is_derived_undead_mon(magr))
+		return (struct monst *)0;
+
+	/* Check that magr can make any ranged attacks at all */
+	if (!force_linedup &&
+		!(
+		(attacktype(magr->data, AT_WEAP) && mrwep) ||
+		(attacktype(magr->data, AT_DEVA) && mrwep) ||
+		(attacktype(magr->data, AT_BREA) && !magr->mcan) ||
+		(attacktype(magr->data, AT_MAGC) && !magr->mcan) ||
+		(attacktype(magr->data, AT_MMGC) && !magr->mcan) ||
+		(attacktype(magr->data, AT_GAZE) && !magr->mcan) ||
+		(attacktype(magr->data, AT_SPIT)) ||
+		(attacktype(magr->data, AT_ARRW)) ||
+		(attacktype(magr->data, AT_TNKR)) ||
+		(attacktype(magr->data, AT_BEAM)) ||
+		(attacktype(magr->data, AT_LRCH)) ||
+		(attacktype(magr->data, AT_LNCK)) ||
+		(attacktype(magr->data, AT_5SQR)) ||
+		(attacktype(magr->data, AT_5SBT)) ||
+		(is_commander(magr->data))
+		))
+		return (struct monst *)0;
 
 	/* priority of targets:
 	 * covetous item holder
@@ -130,6 +152,10 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 		if (mdef == &youmonst) {
 			tarx = magr->mux;
 			tary = magr->muy;
+
+			/* don't attempt to attack self if displacement made magr think player is on top of magr */
+			if (tarx == magr->mx && tary == magr->my)
+				continue;
 		}
 		else {
 			tarx = mdef->mx;

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -70,298 +70,172 @@ struct obj *obj;
 extern int monstr[];
 
 /* Find a target for a ranged attack. */
+/* needs to set tbx, tby */
 struct monst *
-mfind_target(mtmp, force_linedup)
-struct monst *mtmp;
+mfind_target(magr, force_linedup)
+struct monst *magr;
 int force_linedup;	/* if TRUE, we have some offensive item ready that will work if we are lined up */
 {
-    int dir, origdir = -1;
-    int x, y, dx, dy;
+	struct monst * mdef = (struct monst *)0;
+	struct monst * best_target = (struct monst *)0;
+	int target_val = 0;
+	int best_val = 0;
+	int tarx;
+	int tary;
+	boolean coveted = FALSE;	/* mdef was found via covetousness (used to prioritize this mdef in targeting loop) */
+	boolean tried_you = FALSE;	/* you have been attempted as mdef (used to prioritize you in targeting loop)*/
 
-    int i;
+	boolean conflicted = Conflict && couldsee(magr->mx, magr->my) &&
+		(distu(magr->mx, magr->my) <= BOLT_LIM*BOLT_LIM) &&
+		!resist(magr, RING_CLASS, 0, 0);
 
-    struct monst *mat, *mret = (struct monst *)0, *oldmret = (struct monst *)0;
-	struct monst *mtmp2;
+	boolean dogbesafe = (magr->mtame && !magr->mconf && !conflicted);
 	
-    boolean conflicted = Conflict && couldsee(mtmp->mx,mtmp->my) && 
-						(distu(mtmp->mx,mtmp->my) <= BOLT_LIM*BOLT_LIM) &&
-						!resist(mtmp, RING_CLASS, 0, 0);
+	struct obj *mrwep = select_rwep(magr);
 	
-	struct obj *mrwep = select_rwep(mtmp);
-	
-	if(is_derived_undead_mon(mtmp)) return 0;
-	
-	
-    if (is_covetous(mtmp->data) && !mtmp->mtame)
-    {
-        /* find our mark and let him have it, if possible! */
-        register int gx = STRAT_GOALX(mtmp->mstrategy),
-                     gy = STRAT_GOALY(mtmp->mstrategy);
-        mtmp2 = m_at(gx, gy);
-	if (mtmp2 && (!force_linedup || lined_up(mtmp)) && (
-			   (attacktype(mtmp->data, AT_BREA) && !mtmp->mcan && mlined_up(mtmp, mtmp2, FALSE))
-			|| (force_linedup && mlined_up(mtmp, mtmp2, FALSE))
-			|| (attacktype(mtmp->data, AT_SPIT) && mlined_up(mtmp, mtmp2, FALSE))
-			|| (attacktype(mtmp->data, AT_TNKR) && mlined_up(mtmp, mtmp2, FALSE))
-			|| (attacktype(mtmp->data, AT_ARRW) && mlined_up(mtmp, mtmp2, FALSE))
-			|| (attacktype(mtmp->data, AT_BEAM) && mlined_up(mtmp, mtmp2, FALSE))
-			|| (attacktype(mtmp->data, AT_MAGC) && !mtmp->mcan && (
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp <= AD_SPC2) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp == AD_RBRE) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp == AD_OONA) )
-				&& mlined_up(mtmp, mtmp2, FALSE)
-			  )
-			|| (attacktype(mtmp->data, AT_MMGC) && !mtmp->mcan && (
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp <= AD_SPC2) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp == AD_RBRE) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp == AD_OONA) )
-				&& mlined_up(mtmp, mtmp2, FALSE)
-			  )
-			|| (is_commander(mtmp->data) && distmin(mtmp2->mx, mtmp2->my, mtmp->mx, mtmp->my) < BOLT_LIM)
-			|| (attacktype(mtmp->data, AT_LRCH) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_LNCK) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_5SQR) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_5SBT) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_GAZE) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_WEAP, AD_PHYS) && mrwep && (
-				(!is_pole(mrwep) && mlined_up(mtmp, mtmp2, FALSE)) ||
-				( is_pole(mrwep) && mlined_up(mtmp, mtmp2, FALSE) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 2 && (mtmp2->mx == mtmp->mx || mtmp2->my == mtmp->my))
-			   ))
-		)
-	){
-	    if(!(mtmp->mtyp == PM_OONA && resists_oona(mtmp2)) && mm_aggression(mtmp, mtmp2)) return mtmp2;
+	if (is_derived_undead_mon(magr)) return 0;
+
+	/* priority of targets:
+	 * covetous item holder
+	 * player
+	 * others
+	 */
+	/* maybe have a prefered mdef */
+	if (is_covetous(magr->data) && !magr->mtame) {
+		tarx = STRAT_GOALX(magr->mstrategy);
+		tary = STRAT_GOALY(magr->mstrategy);
+		if ((mdef = m_at(tarx, tary)))
+			coveted = TRUE;
 	}
 	
-#if 0
-	if (!is_mplayer(mtmp->data)/* || !(mtmp->mstrategy & STRAT_NONE)*/)
-	{
-		return 0;
+	/* target-finding loop */
+	do {
+		/* get next target */
+		if (coveted)
+			coveted = FALSE;
+		else if (!tried_you) {
+			mdef = &youmonst;
+			tried_you = TRUE;
+		}
+		else if (mdef == &youmonst)
+			mdef = fmon;
+		else
+			mdef = mdef->nmon;
+
+		/* validate */
+		if (!mdef)
+			continue;
+
+		/* get location of next target */
+		if (mdef == &youmonst) {
+			tarx = magr->mux;
+			tary = magr->muy;
+		}
+		else {
+			tarx = mdef->mx;
+			tary = mdef->my;
+		}
+
+		/* is mdef an acceptable target? */
+		if (!clear_path(magr->mx, magr->my, tarx, tary))
+			continue;
+		if (dogbesafe && (mdef == &youmonst))
+			continue;
+		if (mdef != &youmonst && !(mm_aggression(magr, mdef) & ALLOW_M) && !conflicted)
+			continue;
+
+		/* don't make ranged attacks at melee distance */
+		if (distmin(magr->mx, magr->my, tarx, tary) < 2)
+			continue;
+
+		/* horrible kludge: Oona doesn't target those resistant to her at range */
+		if (mdef == &youmonst ? Oona_resistance : resists_oona(mdef))
+			continue;
+
+		/* are any of our attacks good? */
+		if (/* force_linedup means we only check m_online -- we have a specific attack in mind to use that needs to be on a line */
+			(force_linedup) ? m_online(magr, mdef, tarx, tary, dogbesafe, TRUE) : (
+
+			/* OTHERWISE... (!force_linedup) */
+
+			/* attacks that are on a line that do NOT stop on hit */
+			(m_online(magr, mdef, tarx, tary, dogbesafe, FALSE) && (
+				(attacktype(magr->data, AT_BREA) && !magr->mcan) ||
+				(attacktype(magr->data, AT_MAGC) && !magr->mcan && !real_spell_adtyp((attacktype_fordmg(magr->data, AT_MAGC, AD_ANY))->adtyp)) ||
+				(attacktype(magr->data, AT_MMGC) && !magr->mcan && !real_spell_adtyp((attacktype_fordmg(magr->data, AT_MMGC, AD_ANY))->adtyp))
+			))
+			||
+			/* attacks that are on a line that DO stop on hit */
+			(m_online(magr, mdef, tarx, tary, dogbesafe, TRUE) && (
+				(attacktype(magr->data, AT_SPIT)) ||
+				(attacktype(magr->data, AT_ARRW)) ||
+				(attacktype(magr->data, AT_WEAP) && mrwep && !is_pole(mrwep)) ||
+				(attacktype(magr->data, AT_DEVA) && mrwep && !is_pole(mrwep))
+			))
+			||
+			/* attacks that are on a line that are ALWAYS SAFE */
+			(m_online(magr, mdef, tarx, tary, FALSE, FALSE) && (
+				(attacktype(magr->data, AT_TNKR)) ||
+				(attacktype(magr->data, AT_BEAM))
+			))
+			||
+			/* attacks in a square range of 2 -- includes polearms */
+			(distmin(magr->mx, magr->my, tarx, tary) <= 2 && (
+				(attacktype(magr->data, AT_LRCH)) ||
+				(attacktype(magr->data, AT_LNCK)) ||
+				(attacktype(magr->data, AT_WEAP) && mrwep && is_pole(mrwep)) ||
+				(attacktype(magr->data, AT_DEVA) && mrwep && is_pole(mrwep))
+			))
+			||
+			/* attacks in a square range of 5 */
+			(distmin(magr->mx, magr->my, tarx, tary) <= 5 && (
+				(attacktype(magr->data, AT_5SQR)) ||
+				(attacktype(magr->data, AT_5SBT))
+			))
+			||
+			/* attacks in a square range of 8 */
+			(distmin(magr->mx, magr->my, tarx, tary) <= 8 && (
+				(is_commander(magr->data) && !rn2(4)) ||	/* !rn2(4) -> reduce command frequency */
+				(attacktype(magr->data, AT_GAZE) && !magr->mcan) ||
+				(attacktype(magr->data, AT_MAGC) && !magr->mcan && real_spell_adtyp((attacktype_fordmg(magr->data, AT_MAGC, AD_ANY))->adtyp)) ||
+				(attacktype(magr->data, AT_MMGC) && !magr->mcan && real_spell_adtyp((attacktype_fordmg(magr->data, AT_MMGC, AD_ANY))->adtyp))
+			))
+			))
+		{
+			/* mdef can be targeted by one of our attacks */
+			/* calculate value of target */
+			if (is_covetous(magr->data) && !magr->mtame &&
+				mdef == m_at(STRAT_GOALX(magr->mstrategy), STRAT_GOALY(magr->mstrategy))) {
+				/* prefer item-holder */
+				target_val = 999;
+			}
+			else if (mdef == &youmonst) {
+				/* prefer player */
+				target_val = 999;
+			}
+			else {
+				/* value is mdef's difficulty, but adjusted to prefer closer targets */
+				target_val = monstr[mdef->mtyp] + BOLT_LIM - distmin(magr->mx, magr->my, tarx, tary);
+			}
+			/* maybe we have a new target */
+			if (target_val > best_val) {
+				best_target = mdef;
+				best_val = target_val;
+			}
+			/* if we found a prefered target (best_val == 999), end target-finding loop early */
+		}
+	} while (mdef && best_val < 999);
+
+	/* we have a target */
+
+	/* set tbx, tby */
+	/* caller has to know to reject tbx==0, tby==0 if called with force_linedup */
+	if (!linedup(tarx, tary, magr->mx, magr->my)) {
+		tbx = tby = 0;
 	}
-#endif
-    	if (!mtmp->mpeaceful && !conflicted &&
-			((mtmp->mstrategy & STRAT_STRATMASK) == STRAT_NONE) && (
-			   (attacktype(mtmp->data, AT_BREA) && !mtmp->mcan && lined_up(mtmp))
-			|| (force_linedup && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_SPIT) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_TNKR) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_ARRW) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_BEAM) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_MAGC) && !mtmp->mcan && (
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp <= AD_SPC2) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp == AD_RBRE) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp == AD_OONA) )
-				&& lined_up(mtmp)
-			  )
-			|| (attacktype(mtmp->data, AT_MMGC) && !mtmp->mcan && (
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp <= AD_SPC2) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp == AD_RBRE) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp == AD_OONA) )
-				&& lined_up(mtmp)
-			  )
-			|| (is_commander(mtmp->data) && distmin(mtmp->mux, mtmp->muy, mtmp->mx, mtmp->my) < BOLT_LIM)
-			|| (attacktype(mtmp->data, AT_LRCH) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_LNCK) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_5SQR) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_5SBT) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_GAZE) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_WEAP, AD_PHYS) && mrwep && (
-				(!is_pole(mrwep) && lined_up(mtmp)) ||
-				( is_pole(mrwep) && lined_up(mtmp) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2 && (mtmp->mux == mtmp->mx || mtmp->muy == mtmp->my))
-			   ))
-		)) {
-        	if(!(mtmp->mtyp == PM_OONA && Oona_resistance)) return &youmonst;  /* kludge - attack the player first
-				      if possible */
-		}
-		if(gx != 0 || gy != 0){
-			for (dir = 0; dir < 8; dir++)
-				if (dirx[dir] == sgn(gx-mtmp->mx) &&
-					diry[dir] == sgn(gy-mtmp->my))
-						break;
 
-			if (dir == 8) {
-				tbx = tby = 0;
-				return 0;
-			}
-		} else {
-			dir = rn2(8);
-		}
-
-		origdir = -1;
-    } else {
-		int i, j;
-		struct monst *tmpm;
-    	dir = rn2(8);
-		origdir = -1;
-
-		//Don't make ranged attacks if in melee
-		for(i=-1;i<2;i++){
-			for(j=-1;j<2;j++){
-				if(!i && !j)
-					continue;
-				if(isok(mtmp->mx+i, mtmp->my+j)){
-					tmpm = m_at(mtmp->mx+i, mtmp->my+j);
-					if(tmpm && mm_aggression(mtmp, tmpm)){
-						return (struct monst *) 0;
-					}
-				}
-			}
-		}
-	
-		if (!mtmp->mpeaceful && (!force_linedup || lined_up(mtmp)) && !conflicted && (
-			   (attacktype(mtmp->data, AT_BREA) && !mtmp->mcan && lined_up(mtmp))
-			|| (force_linedup && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_SPIT) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_TNKR) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_ARRW) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_BEAM) && lined_up(mtmp))
-			|| (attacktype(mtmp->data, AT_MAGC) && !mtmp->mcan && (
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp <= AD_SPC2) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp == AD_RBRE) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MAGC, AD_ANY))->adtyp == AD_OONA) )
-				&& lined_up(mtmp)
-			  )
-			|| (attacktype(mtmp->data, AT_MMGC) && !mtmp->mcan && (
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp <= AD_SPC2) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp == AD_RBRE) ||
-			  ((attacktype_fordmg(mtmp->data, AT_MMGC, AD_ANY))->adtyp == AD_OONA) )
-				&& lined_up(mtmp)
-			  )
-			|| (is_commander(mtmp->data) && distmin(mtmp->mux, mtmp->muy, mtmp->mx, mtmp->my) < BOLT_LIM)
-			|| (attacktype(mtmp->data, AT_LRCH) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_LNCK) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_5SQR) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_5SBT) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_GAZE) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_WEAP, AD_PHYS) && mrwep && (
-				(!is_pole(mrwep) && lined_up(mtmp)) ||
-				( is_pole(mrwep) && lined_up(mtmp) && distmin(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my) <= 2 && (mtmp->mux == mtmp->mx || mtmp->muy == mtmp->my))
-			   ))
-		)) {
-        	if(!(mtmp->mtyp == PM_OONA && Oona_resistance)) return &youmonst;  /* kludge - attack the player first
-				      if possible */
-		}
-    }
-
-    for (; dir != origdir; dir = ((dir + 1) % 8))
-    {
-        if (origdir < 0) origdir = dir;
-
-	mret = (struct monst *)0;
-
-	x = mtmp->mx;
-	y = mtmp->my;
-	dx = dirx[dir];
-	dy = diry[dir];
-	for(i = 0; i < BOLT_LIM; i++)
-	{
-	    x += dx;
-	    y += dy;
-
-	    if (!isok(x, y) || !ZAP_POS(levl[x][y].typ) || closed_door(x, y))
-	        break; /* off the map or otherwise bad */
-
-	    if (!conflicted &&
-	        ((mtmp->mpeaceful && (x == mtmp->mux && y == mtmp->muy)) ||
-	        (mtmp->mtame && x == u.ux && y == u.uy)))
-	    {
-	        mret = oldmret;
-	        break; /* don't attack you if peaceful */
-	    }
-
-	    if ((mat = m_at(x, y)))
-	    {
-	        /* i > 0 ensures this is not a close range attack */
-	        if (mtmp->mtame && !mat->mtame && i > 0) {
-				if (((!oldmret) ||
-					(monstr[monsndx(mat->data)] >
-					monstr[monsndx(oldmret->data)])
-					) && !(mtmp->mtyp == PM_OONA && resists_oona(mat))
-					 && mm_aggression(mtmp, mat)
-				) mret = mat;
-			}
-			else if ((mm_aggression(mtmp, mat) & ALLOW_M)
-				|| conflicted)
-			{
-				if (mtmp->mtame && !conflicted){
-					mret = oldmret;
-					break; /* not willing to attack in that direction */
-				}
-
-				/* Can't make some pairs work together
-				   if they hate each other on principle. */
-				if ((conflicted ||
-					(!(mtmp->mtame && mat->mtame) || !rn2(5))) &&
-				i > 0) {
-					if (((!oldmret) ||
-						(monstr[monsndx(mat->data)] >
-						monstr[monsndx(oldmret->data)])
-						) && !(mtmp->mtyp == PM_OONA && resists_oona(mat))
-						 && mm_aggression(mtmp, mat)
-					)
-						mret = mat;
-				}
-			}
-			if (mtmp->mtame && mat->mtame)
-			{
-				mret = oldmret;
-				break;  /* Not going to hit friendlies unless they
-						   already hate them, as above. */
-			}
-		}
-	}
-	oldmret = mret;
-    }
-	
-	if(!mret && !force_linedup) for(mtmp2 = fmon; mtmp2; mtmp2 = mtmp2->nmon){
-		if(mtmp == mtmp2) continue;
-    	if ((!!mtmp->mtame != !!mtmp2->mtame || conflicted || (mm_aggression(mtmp, mtmp2) & ALLOW_M)) &&
-			!mlined_up(mtmp, mtmp2, FALSE) && //Note: must be something we don't want to hit in the way.
-			(
-			   (is_commander(mtmp->data) && distmin(mtmp2->mx, mtmp2->my, mtmp->mx, mtmp->my) < BOLT_LIM)
-			|| (attacktype(mtmp->data, AT_LRCH) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_LNCK) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 2)
-			|| (attacktype(mtmp->data, AT_5SQR) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_5SBT) && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) <= 5)
-			|| (attacktype(mtmp->data, AT_GAZE) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MAGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_SPEL) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-			|| (attacktype_fordmg(mtmp->data, AT_MMGC, AD_CLRC) && !mtmp->mcan && distmin(mtmp2->mx,mtmp2->my,mtmp->mx,mtmp->my) < BOLT_LIM)
-		)) {
-			if (((!mret) ||
-				(monstr[monsndx(mtmp2->data)] >
-				monstr[monsndx(mret->data)])
-				) && !(mtmp->mtyp == PM_OONA && resists_oona(mtmp2))
-				 && mm_aggression(mtmp, mtmp2)
-			){
-				mret = mtmp2;
-			}
-		}
-	}
-	
-    if (mret != (struct monst *)0) {
-		if(!mlined_up(mtmp, mret, FALSE)){
-			tbx = tby = 0;
-		}
-        return mret; /* should be the strongest monster that's not behind
-	                a friendly */
-    }
-
-    /* Nothing lined up? */
-    tbx = tby = 0;
-    return (struct monst *)0;
+	/* return the best target we found */
+	return best_target;
 }
 
 boolean
@@ -388,49 +262,6 @@ lined_up(mtmp)		/* is mtmp in position to use ranged attack? */
 	register struct monst *mtmp;
 {
 	return(linedup(mtmp->mux,mtmp->muy,mtmp->mx,mtmp->my));
-}
-
-boolean
-mlined_up(mtmp, mdef, breath)	/* is mtmp in position to use ranged attack? */
-	register struct monst *mtmp;
-	register struct monst *mdef;
-	register boolean breath;
-{
-	struct monst *mat;
-
-        boolean lined_up = linedup(mdef->mx,mdef->my,mtmp->mx,mtmp->my);
-
-	int dx = sgn(mdef->mx - mtmp->mx),
-	    dy = sgn(mdef->my - mtmp->my);
-
-	int x = mtmp->mx, y = mtmp->my;
-
-	int i = 10; /* arbitrary */
-
-        /* No special checks if confused - can't tell friend from foe */
-	if (!lined_up || mtmp->mconf || !mtmp->mtame) return lined_up;
-
-        /* Check for friendlies in the line of fire. */
-	for (; !breath || i > 0; --i)
-	{
-	    x += dx;
-	    y += dy;
-	    if (!isok(x, y)) break;
-		
-            if (x == u.ux && y == u.uy) 
-	        return FALSE;
-
-	    mat = m_at(x, y);
-	    if (mat)
-	    {
-	        if (!breath && mat == mdef) return lined_up;
-
-		/* Don't hit friendlies: */
-		if (mat->mtame) return FALSE;
-	    }
-	}
-
-	return lined_up;
 }
 
 #endif /* OVL1 */

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -609,22 +609,31 @@ int tary;
 				(aatyp == AT_WEAP || aatyp == AT_DEVA) &&				// using a primary weapon attack
 				(magr->weapon_check == NEED_WEAPON || !MON_WEP(magr))	// needs a weapon
 				){
+				/* what ranged weapon options do we have? */
+				otmp = select_rwep(magr);
+
 				/* pick appropriate weapon based on range to target */
 				if (dist2(x(magr), y(magr), tarx, tary) <= 
-					(MON_WEP(magr) && is_pole(MON_WEP(magr))) ? 2 : 8)	// if a polearm is wielded, continue using it 2 < x <= 8
+					((otmp && is_pole(otmp)) ? 2 : 8))		// if we have a polearm, use it longer range
 				{
-					/* melee or polearm range */
+					/* melee range */
 					magr->combat_mode = HNDHND_MODE;
 					magr->weapon_check = NEED_HTH_WEAPON;
 				}
 				else {
-					/* long range */
+					/* long or polearm range */
 					magr->combat_mode = RANGED_MODE;
 					magr->weapon_check = NEED_RANGED_WEAPON;
 				}
 				if (mon_wield_item(magr) != 0)				// and try to wield something (did it take time?)
 				{
-					continue;								// it took time, don't attack using this action
+					if (MON_WEP(magr) && is_pole(MON_WEP(magr))) {
+						/* you can wield a polearm and attack in the same action */
+					}
+					else {
+						allres |= MM_HIT;					// this xattacky() call took time
+						continue;							// it took time, don't attack using this action
+					}
 				}
 			}
 			/* 2: Offhand attack when not allowed */

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -610,7 +610,9 @@ int tary;
 				(magr->weapon_check == NEED_WEAPON || !MON_WEP(magr))	// needs a weapon
 				){
 				/* pick appropriate weapon based on range to target */
-				if (dist2(x(magr), y(magr), tarx, tary) <= 8) {
+				if (dist2(x(magr), y(magr), tarx, tary) <= 
+					(MON_WEP(magr) && is_pole(MON_WEP(magr))) ? 2 : 8)	// if a polearm is wielded, continue using it 2 < x <= 8
+				{
 					/* melee or polearm range */
 					magr->combat_mode = HNDHND_MODE;
 					magr->weapon_check = NEED_HTH_WEAPON;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -613,8 +613,8 @@ int tary;
 				otmp = select_rwep(magr);
 
 				/* pick appropriate weapon based on range to target */
-				if (dist2(x(magr), y(magr), tarx, tary) <= 
-					((otmp && is_pole(otmp)) ? 2 : 8))		// if we have a polearm, use it longer range
+				if (dist2(x(magr), y(magr), tarx, tary) <
+					((otmp && is_pole(otmp)) ? 3 : m_pole_range(magr)))	// if we have a polearm, use it longer range
 				{
 					/* melee range */
 					magr->combat_mode = HNDHND_MODE;
@@ -702,7 +702,7 @@ int tary;
 			/* make the attack */
 			/* melee -- if attacking an adjacent square or thrusting a polearm */
 			if (!ranged ||
-				(otmp && is_pole(otmp) && dist2(x(magr), y(magr), tarx, tary) < 8)) {
+				(otmp && is_pole(otmp) && dist2(x(magr), y(magr), tarx, tary) <= m_pole_range(magr))) {
 				int devai = 0;
 				/* they did do an attack */
 				mon_ranged_gazeonly = FALSE;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -631,6 +631,7 @@ int tary;
 						/* you can wield a polearm and attack in the same action */
 					}
 					else {
+						mon_ranged_gazeonly = FALSE;
 						allres |= MM_HIT;					// this xattacky() call took time
 						continue;							// it took time, don't attack using this action
 					}


### PR DESCRIPTION
If monster is in polearm range of you, it can and will wield a polearm and attack you with it in a single action (like you do `a`pplying a polearm to pound).

If you step closer to the monster, it will prefer other melee weapons, using a weapon attack action to swap weapons. For monsters like trolls, who get a weapon attack and then claw attacks, it will use its weapon attack to swap but still claw you.

Fixes bugs with monster ranged AI that were caused by `mfind_target()` being unreadable and therefore not maintained.