### PR TITLE
Cancelled monsters don't rise from the dead on their own

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2468,6 +2468,9 @@ boolean init;
 			//Between molding and all the special effects, would be best to just reset timers for everything.
 			if (otmp->otyp == CORPSE) {
 				obj_stop_timers(otmp);
+				/* if the monster was cancelled, don't self-revive */
+				if (mtmp->mcan && !is_rider(ptr))
+					otmp->norevive = 1;
 				start_corpse_timeout(otmp);
 			}
 	    }


### PR DESCRIPTION
Affects trolls, zombies, fungi, Dread Seraph floors, etc.

Does not affect Riders.