### PR TITLE
Add give_intrinsic function to unify things

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -734,6 +734,7 @@ E int FDECL(eaten_stat, (int,struct obj *));
 E void FDECL(food_disappears, (struct obj *));
 E void FDECL(food_substitution, (struct obj *,struct obj *));
 E boolean FDECL(bite_monster, (struct monst *));
+E void FDECL(give_intrinsic, (int, long));
 E void NDECL(fix_petrification);
 E void FDECL(consume_oeaten, (struct obj *,int));
 E boolean FDECL(maybe_finished_meal, (BOOLEAN_P));

--- a/src/apply.c
+++ b/src/apply.c
@@ -4305,14 +4305,7 @@ use_doll(obj)
 		case DOLL_OF_JUMPING:
 			if (jump(4)){
 				res = 1;
-				if((HJumping&TIMEOUT) + 100L < TIMEOUT){
-					long timer = (HJumping&TIMEOUT) + 100L;
-					HJumping &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-					HJumping |= timer; //set new timer
-				}
-				else{
-					HJumping |= TIMEOUT; //set timer to max value
-				}
+				give_intrinsic(JUMPING, 100L);
 				if(!Blind)
 					pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 				else pline("The little doll vanishes.");
@@ -4356,14 +4349,7 @@ use_doll(obj)
 		case DOLL_OF_CHASTITY:
 			res = 1;
 			pline("You feel chaste.");
-			if((HChastity&TIMEOUT) + 100L < TIMEOUT){
-				long timer = (HChastity&TIMEOUT) + 100L;
-				HChastity &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HChastity |= timer; //set new timer
-			}
-			else{
-				HChastity |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(CHASTITY, 100L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4373,15 +4359,7 @@ use_doll(obj)
 			res = 1;
 			if(!Blind)
 				pline("The doll swings its %s in wide arcs.", rn2(2) ? "greatsword" : "greataxe");
-			if((HCleaving&TIMEOUT) + 100L < TIMEOUT){
-				long timer = (HCleaving&TIMEOUT) + 100L;
-				HCleaving &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HCleaving |= timer; //set new timer
-				pline("You feel ready to cleave through foes left and right!");
-			}
-			else{
-				HCleaving |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(CLEAVING, 100L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4406,14 +4384,7 @@ use_doll(obj)
 			if (Golded) fix_petrification();
 			res = 1;
 			pline("You feel very healthy.");
-			if((HGoodHealth&TIMEOUT) + 100L < TIMEOUT){
-				long timer = (HGoodHealth&TIMEOUT) + 100L;
-				HGoodHealth &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HGoodHealth |= timer; //set new timer
-			}
-			else{
-				HGoodHealth |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(GOOD_HEALTH, 100L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4425,14 +4396,7 @@ use_doll(obj)
 				(Upolyd && u.mh < u.mhmax)
 			)
 				pline("Your wounds begin rapidly knitting shut.");
-			if((RapidHealing&TIMEOUT) + 5L < TIMEOUT){
-				long timer = (RapidHealing&TIMEOUT) + 5L;
-				RapidHealing &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				RapidHealing |= timer; //set new timer
-			}
-			else{
-				RapidHealing |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(RAPID_HEALING, 5L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4442,16 +4406,7 @@ use_doll(obj)
 			res = 1;
 			if(!Blind)
 				pline("The many-armed doll begins dancing!");
-			if((HDestruction&TIMEOUT) + 8L < TIMEOUT){
-				long timer = (HDestruction&TIMEOUT) + 8L;
-				if(!Destruction)
-					You("begin radiating waves of destruction!");
-				HDestruction &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HDestruction |= timer; //set new timer
-			}
-			else{
-				HDestruction |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(DESTRUCTION, 8L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4479,14 +4434,7 @@ use_doll(obj)
 			res = 1;
 			if(!Blind)
 				pline("The doll opens its umbrella, and a rubbery film forms around your body!");
-			if((HPreservation&TIMEOUT) + 1000L < TIMEOUT){
-				long timer = (HPreservation&TIMEOUT) + 1000L;
-				HPreservation &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HPreservation |= timer; //set new timer
-			}
-			else{
-				HPreservation |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(PRESERVATION, 1000L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4496,14 +4444,7 @@ use_doll(obj)
 			res = 1;
 			if(!Blind)
 				pline("The doll draws a wand with blinding speed!");
-			if((HQuickDraw&TIMEOUT) + 100L < TIMEOUT){
-				long timer = (HQuickDraw&TIMEOUT) + 100L;
-				HQuickDraw &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HQuickDraw |= timer; //set new timer
-			}
-			else{
-				HQuickDraw |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(QUICK_DRAW, 100L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4605,14 +4546,7 @@ use_doll(obj)
 		case DOLL_OF_CLEAR_THINKING:
 			res = 1;
 			pline("The doll takes up your mental burdens!");
-			if((HClearThoughts&TIMEOUT) + 100L < TIMEOUT){
-				long timer = (HClearThoughts&TIMEOUT) + 100L;
-				HClearThoughts &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HClearThoughts |= timer; //set new timer
-			}
-			else{
-				HClearThoughts |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(CLEAR_THOUGHTS, 100L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");
@@ -4620,16 +4554,7 @@ use_doll(obj)
 		break;
 		case DOLL_OF_MIND_BLASTING:
 			res = 1;
-			if((HMindblasting&TIMEOUT) + 8L < TIMEOUT){
-				long timer = (HMindblasting&TIMEOUT) + 8L;
-				if(!Mindblasting)
-					You("begin radiating waves of mental energy!");
-				HMindblasting &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HMindblasting |= timer; //set new timer
-			}
-			else{
-				HMindblasting |= TIMEOUT; //set timer to max value
-			}
+			give_intrinsic(MIND_BLASTS, 8L);
 			if(!Blind)
 				pline("The %s vanishes in a flash of moonlight.", OBJ_DESCR(objects[obj->otyp]));
 			else pline("The little doll vanishes.");

--- a/src/eat.c
+++ b/src/eat.c
@@ -7,12 +7,8 @@
 #include "artifact.h"
 /* #define DEBUG */	/* uncomment to enable new eat code debugging */
 
-#ifdef DEBUG
 # ifdef WIZARD
 #define debugpline	if (wizard) pline
-# else
-#define debugpline	pline
-# endif
 #endif
 
 STATIC_PTR int NDECL(eatmdone);
@@ -466,15 +462,11 @@ recalc_wt()
 {
 	struct obj *piece = victual.piece;
 
-#ifdef DEBUG
-	debugpline("Old weight = %d", piece->owt);
-	debugpline("Used time = %d, Req'd time = %d",
-		victual.usedtime, victual.reqtime);
-#endif
+	//debugpline("Old weight = %d", piece->owt);
+	//debugpline("Used time = %d, Req'd time = %d",
+	//	victual.usedtime, victual.reqtime);
 	piece->owt = weight(piece);
-#ifdef DEBUG
-	debugpline("New weight = %d", piece->owt);
-#endif
+	//debugpline("New weight = %d", piece->owt);
 }
 
 void
@@ -484,9 +476,7 @@ reset_eat()		/* called when eating interrupted by an event */
      * the round is spent eating.
      */
 	if(victual.eating && !victual.doreset) {
-#ifdef DEBUG
-	    debugpline("reset_eat...");
-#endif
+	    //debugpline("reset_eat...");
 	    victual.doreset = TRUE;
 	}
 	return;
@@ -502,9 +492,7 @@ register struct obj *otmp;
 		(void) splitobj(otmp, otmp->quan - 1L);
 	    else
 		otmp = splitobj(otmp, 1L);
-#ifdef DEBUG
-	    debugpline("split object,");
-#endif
+	    //debugpline("split object,");
 	}
 
 	if (!otmp->oeaten) {
@@ -594,9 +582,7 @@ struct obj *old_obj, *new_obj;
 STATIC_OVL void
 do_reset_eat()
 {
-#ifdef DEBUG
-	debugpline("do_reset_eat...");
-#endif
+	//debugpline("do_reset_eat...");
 	if (victual.piece) {
 		victual.piece = touchfood(victual.piece);
 		recalc_wt();
@@ -868,109 +854,93 @@ register struct permonst *ptr;
 {
 	switch (type) {
 	    case FIRE_RES:
-#ifdef DEBUG
-		if (ptr->mconveys & MR_FIRE) {
-			debugpline("can get fire resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_FIRE);
-#endif
+			if (ptr->mconveys & MR_FIRE) {
+				//debugpline("can get fire resistance");
+				return(TRUE);
+			} else  return(FALSE);
 	    case SLEEP_RES:
-#ifdef DEBUG
-		if (ptr->mconveys & MR_SLEEP) {
-			debugpline("can get sleep resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_SLEEP);
-#endif
+			if (ptr->mconveys & MR_SLEEP) {
+				debugpline("can get sleep resistance");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case COLD_RES:
-#ifdef DEBUG
-		if (ptr->mconveys & MR_COLD) {
-			debugpline("can get cold resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_COLD);
-#endif
+			if (ptr->mconveys & MR_COLD) {
+				debugpline("can get cold resistance");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case ACID_RES:
-#ifdef DEBUG
-		if (ptr->mconveys & MR_ACID) {
-			debugpline("can get acid resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_ACID);
-#endif
+			if (ptr->mconveys & MR_ACID) {
+				debugpline("can get acid resistance");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case DISINT_RES:
-#ifdef DEBUG
-		if (ptr->mconveys & MR_DISINT) {
-			debugpline("can get disintegration resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_DISINT);
-#endif
+			if (ptr->mconveys & MR_DISINT) {
+				debugpline("can get disintegration resistance");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case SHOCK_RES:	/* shock (electricity) resistance */
-#ifdef DEBUG
-		if (ptr->mconveys & MR_ELEC) {
-			debugpline("can get shock resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_ELEC);
-#endif
+			if (ptr->mconveys & MR_ELEC) {
+				debugpline("can get shock resistance");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case POISON_RES:
-#ifdef DEBUG
-		if (ptr->mconveys & MR_POISON) {
-			debugpline("can get poison resistance");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(ptr->mconveys & MR_POISON);
-#endif
+			if (ptr->mconveys & MR_POISON) {
+				debugpline("can get poison resistance");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case TELEPORT:
-#ifdef DEBUG
-		if (species_teleports(ptr)) {
-			debugpline("can get teleport");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(species_teleports(ptr));
-#endif
+			if (species_teleports(ptr)) {
+				debugpline("can get teleport");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case DISPLACED:
-#ifdef DEBUG
-		if (species_displaces(ptr)) {
-			debugpline("can displacement");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(species_displaces(ptr));
-#endif
+			if (species_displaces(ptr)) {
+				debugpline("can displacement");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case TELEPORT_CONTROL:
-#ifdef DEBUG
-		if (species_controls_teleports(ptr)) {
-			debugpline("can get teleport control");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(species_controls_teleports(ptr));
-#endif
+			if (species_controls_teleports(ptr)) {
+				debugpline("can get teleport control");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    case TELEPAT:
-#ifdef DEBUG
-		if (species_is_telepathic(ptr)) {
-			debugpline("can get telepathy");
-			return(TRUE);
-		} else  return(FALSE);
-#else
-		return(species_is_telepathic(ptr));
-#endif
+			if (species_is_telepathic(ptr)) {
+				debugpline("can get telepathy");
+				return(TRUE);
+			} else
+				return(FALSE);
 	    default:
-		return(FALSE);
+			return(FALSE);
 	}
-	/*NOTREACHED*/
 }
+
+void
+give_intrinsic(int type, long duration){
+	boolean permanent = (duration == -1);
+	boolean nullify = (duration == -2);
+	
+	if (permanent){
+		u.uprops[type].intrinsic |= FROMOUTSIDE;
+		return;
+	}
+	
+	if (nullify){
+		u.uprops[type].intrinsic &= ~TIMEOUT;
+	}
+	
+	incr_itimeout(&u.uprops[type].intrinsic, duration);
+	
+}
+
 
 /* givit() tries to give you an intrinsic based on the monster's level
  * and what type of intrinsic it is trying to give you.
@@ -1038,198 +1008,97 @@ boolean drained;
 	else multiplier = 20;
 	if(ptr->geno & G_UNIQ) multiplier = 20;
 	if(ptr->geno & G_UNIQ && ptr->mlevel > 14) permanent = 1;
+
+	long duration = nutval * multiplier;
+	if (permanent)
+		duration = -1;
+	
 	switch (type) {
 	    case FIRE_RES:
-#ifdef DEBUG
-		debugpline("Trying to give fire resistance");
-#endif
-		if( !(HFire_resistance) ) {
-			You(Hallucination ? "be chillin'." :
-			    "feel a momentary chill.");
-		}
-		if( (HFire_resistance & TIMEOUT) + (long)(nutval*multiplier) < TIMEOUT) {
-			// long timer = max((HFire_resistance & TIMEOUT), (long)(nutval*multiplier));
-			long timer = (HFire_resistance & TIMEOUT) + (long)(nutval*multiplier);
-			HFire_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HFire_resistance |= timer; //set new timer
-		}
-		else{
-			HFire_resistance |= TIMEOUT; //set timer to max value
-		}
-		if(permanent){
-			HFire_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give fire resistance");
+			if (!(HFire_resistance)) 
+				You(Hallucination ? "be chillin'." :"feel a momentary chill.");
+			give_intrinsic(FIRE_RES, duration);
 		break;
 	    case SLEEP_RES:
-#ifdef DEBUG
-		debugpline("Trying to give sleep resistance");
-#endif
-		if( !(HSleep_resistance) ) {
-			You_feel("wide awake.");
-		}
-		if( (HSleep_resistance & TIMEOUT) + (long)(nutval*multiplier) < TIMEOUT) {
-			// long timer = max((HSleep_resistance & TIMEOUT), (long)(nutval*multiplier));
-			long timer = (HSleep_resistance & TIMEOUT) + (long)(nutval*multiplier);
-			HSleep_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HSleep_resistance |= timer; //set new timer
-		}
-		else{
-			HSleep_resistance |= TIMEOUT; //set timer to max value
-		}
-		if(permanent){
-			HSleep_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give sleep resistance");
+			if (!(HSleep_resistance))
+				You_feel("wide awake.");
+			give_intrinsic(SLEEP_RES, duration);
 		break;
 	    case COLD_RES:
-#ifdef DEBUG
-		debugpline("Trying to give cold resistance");
-#endif
-		if( !(HCold_resistance) ) {
-			You_feel("full of hot air.");
-		}
-		if( (HCold_resistance & TIMEOUT) + (long)(nutval*multiplier) < TIMEOUT) {
-			// long timer = max((HCold_resistance & TIMEOUT), (long)(nutval*multiplier));
-			long timer = (HCold_resistance & TIMEOUT) + (long)(nutval*multiplier);
-			HCold_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HCold_resistance |= timer; //set new timer
-		}
-		else{
-			HCold_resistance |= TIMEOUT; //set timer to max value
-		}
-		if(permanent){
-			HCold_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give cold resistance");
+			if(!(HCold_resistance))
+				You_feel("full of hot air.");
+			give_intrinsic(COLD_RES, duration);
 		break;
 	    case DISINT_RES:
-#ifdef DEBUG
-		debugpline("Trying to give disintegration resistance");
-#endif
-		if(!(HDisint_resistance & FROMOUTSIDE)) {
-			You_feel(Hallucination ?
-			    "totally together, man." :
-			    "very firm.");
-			HDisint_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give disintegration resistance");
+			if (!(HDisint_resistance & FROMOUTSIDE)) {
+				You_feel(Hallucination ? "totally together, man." : "very firm.");
+				give_intrinsic(DISINT_RES, -1);
+			}
 		break;
 	    case SHOCK_RES:	/* shock (electricity) resistance */
-#ifdef DEBUG
-		debugpline("Trying to give shock resistance");
-#endif
-		if( !(HShock_resistance) ) {
-			if (Hallucination)
-				rn2(2) ? You_feel("grounded in reality.") : Your("health currently feels amplified!");
-			else
-				You_feel("well grounded.");
-		}
-		if( (HShock_resistance & TIMEOUT) + (long)(nutval*multiplier) < TIMEOUT) {
-			// long timer = max((HShock_resistance & TIMEOUT), (long)(nutval*multiplier));
-			long timer = (HShock_resistance & TIMEOUT) + (long)(nutval*multiplier);
-			HShock_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HShock_resistance |= timer; //set new timer
-		}
-		else{
-			HShock_resistance |= TIMEOUT; //set timer to max value
-		}
-		if(permanent){
-			HShock_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give shock resistance");
+			if (!(HShock_resistance)) {
+				if (Hallucination)
+					rn2(2) ? You_feel("grounded in reality.") : Your("health currently feels amplified!");
+				else You_feel("well grounded.");
+			}
+			give_intrinsic(SHOCK_RES, duration);
 		break;
 	    case ACID_RES:	/* acid resistance */
-#ifdef DEBUG
-		debugpline("Trying to give acid resistance");
-#endif
-		if( !(HAcid_resistance) ) {
-			if (Hallucination)
-				rn2(2) ? You_feel("like you've really gotten back to basics!") : You_feel("insoluble.");
-			else
-				Your("skin feels leathery.");
-		}
-		if( (HAcid_resistance & TIMEOUT) + (long)(nutval*multiplier) < TIMEOUT) {
-			// long timer = max((HAcid_resistance & TIMEOUT), (long)(nutval*multiplier));
-			long timer = (HAcid_resistance & TIMEOUT) + (long)(nutval*multiplier);
-			HAcid_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HAcid_resistance |= timer; //set new timer
-		}
-		else{
-			HAcid_resistance |= TIMEOUT; //set timer to max value
-		}
-		if(permanent){
-			HAcid_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give acid resistance");
+			if (!(HAcid_resistance)) {
+				if (Hallucination)
+					rn2(2) ? You_feel("like you've really gotten back to basics!") : You_feel("insoluble.");
+				else Your("skin feels leathery.");
+			}
+			give_intrinsic(ACID_RES, duration);
 		break;
 	    case POISON_RES:
-#ifdef DEBUG
-		debugpline("Trying to give poison resistance");
-#endif
-		if(!(HPoison_resistance & FROMOUTSIDE)) {
-			You_feel(Poison_resistance ?
-				 "especially healthy." : "healthy.");
-			HPoison_resistance |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give poison resistance");
+			if (!(HPoison_resistance & FROMOUTSIDE)) {
+				You_feel(Poison_resistance ? "especially healthy." : "healthy.");
+				give_intrinsic(POISON_RES, -1);
+			}
 		break;
 	    case DISPLACED:	/* displacement resistance */
 		//Note that intrinsic displacemnt disregards the timeout multiplier and permanence setting.
-#ifdef DEBUG
-		debugpline("Trying to give intrinsic displacement");
-#endif
-		if( !(HDisplaced) ) {
-			if (Hallucination)
-				You_feel("quite beside yourself!");
-			else
-				Your("outline shimmers and shifts.");
-		}
-		if( (HDisplaced & TIMEOUT) + (long)(nutval) < TIMEOUT) {
-			long timer = (HDisplaced & TIMEOUT) + (long)(nutval);
-			HDisplaced &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HDisplaced |= timer; //set new timer
-		}
-		else{
-			HDisplaced |= TIMEOUT; //set timer to max value
-		}
-		// if(permanent){
-			// HDisplaced |= FROMOUTSIDE;
-		// }
+			debugpline("Trying to give intrinsic displacement");
+			if (!(HDisplaced)) {
+				if (Hallucination) You_feel("quite beside yourself!");
+				else Your("outline shimmers and shifts.");
+			}
+			give_intrinsic(DISPLACED, duration);
 		break;
 	    case TELEPORT:
-#ifdef DEBUG
-		debugpline("Trying to give teleport");
-#endif
-		if(!(HTeleportation & FROMOUTSIDE)) {
-			You_feel(Hallucination ? "diffuse." :
-			    "very jumpy.");
-			HTeleportation |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give teleport");
+			if(!(HTeleportation & FROMOUTSIDE)) {
+				You_feel(Hallucination ? "diffuse." : "very jumpy.");
+				give_intrinsic(TELEPORT, -1);
+			}
 		break;
 	    case TELEPORT_CONTROL:
-#ifdef DEBUG
-		debugpline("Trying to give teleport control");
-#endif
-		if(!(HTeleport_control & FROMOUTSIDE)) {
-			You_feel(Hallucination ?
-			    "centered in your personal space." :
-			    "in control of yourself.");
-			HTeleport_control |= FROMOUTSIDE;
-		}
+			debugpline("Trying to give teleport control");
+			if(!(HTeleport_control & FROMOUTSIDE)) {
+				You_feel(Hallucination ? "centered in your personal space." : "in control of yourself.");
+				give_intrinsic(TELEPORT_CONTROL, -1);
+			}
 		break;
 	    case TELEPAT:
-#ifdef DEBUG
-		debugpline("Trying to give telepathy");
-#endif
-		if(!(HTelepat & FROMOUTSIDE)) {
-			You_feel(Hallucination ?
-			    "in touch with the cosmos." :
-			    "a strange mental acuity.");
-			HTelepat |= FROMOUTSIDE;
-			if(Hallucination)
-				change_uinsight(1);
-			/* If blind, make sure monsters show up. */
-			if (Blind) see_monsters();
-		}
+			debugpline("Trying to give telepathy");
+			if(!(HTelepat & FROMOUTSIDE)) {
+				You_feel(Hallucination ? "in touch with the cosmos." : "a strange mental acuity.");
+				give_intrinsic(TELEPAT, -1);
+				if(Hallucination) change_uinsight(1);
+				/* If blind, make sure monsters show up. */
+				if (Blind) see_monsters();
+			}
 		break;
 	    default:
-#ifdef DEBUG
-		debugpline("Tried to give an impossible intrinsic");
-#endif
+			debugpline("Tried to give an impossible intrinsic");
 		break;
 	}
 }
@@ -2142,13 +2011,11 @@ STATIC_OVL void
 start_eating(otmp)		/* called as you start to eat */
 	register struct obj *otmp;
 {
-#ifdef DEBUG
-	debugpline("start_eating: %lx (victual = %lx)", otmp, victual.piece);
+	/*debugpline("start_eating: %lx (victual = %lx)", otmp, victual.piece);
 	debugpline("reqtime = %d", victual.reqtime);
 	debugpline("(original reqtime = %d)", objects[otmp->otyp].oc_delay);
 	debugpline("nmod = %d", victual.nmod);
-	debugpline("oeaten = %d", otmp->oeaten);
-#endif
+	debugpline("oeaten = %d", otmp->oeaten);*/
 	victual.fullwarn = victual.doreset = FALSE;
 	victual.eating = TRUE;
 
@@ -2415,21 +2282,11 @@ struct obj *otmp;
 		}
 		break;
 	    case AMULET_OF_DRAIN_RESISTANCE:
-#ifdef DEBUG
 			debugpline("Trying to give drain resistance");
-#endif
-			if( !(HDrain_resistance) ) {
-				You(Hallucination ? "are bouncing off the walls!" :
-					"feel especially energetic.");
-			}
-			if( (HDrain_resistance & TIMEOUT) + 1000 < TIMEOUT) {
-				long timer = (HDrain_resistance & TIMEOUT)+1000;
-				HDrain_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-				HDrain_resistance |= timer; //set new timer
-			}
-			else{
-				HDrain_resistance |= TIMEOUT; //set timer to max value
-			}
+			if (!(HDrain_resistance))
+				You(Hallucination ? "are bouncing off the walls!" : "feel especially energetic.");
+			
+			give_intrinsic(DRAIN_RES, 1000L);
 		break;
 	    case RIN_SUSTAIN_ABILITY:
 	    case AMULET_OF_LIFE_SAVING:
@@ -3863,17 +3720,13 @@ doeat()		/* generic "eat" command funtion (see cmd.c) */
 	    basenutrit -= drainlevel(otmp);
 	}
 
-#ifdef DEBUG
-	debugpline("before rounddiv: victual.reqtime == %d", victual.reqtime);
+	/*debugpline("before rounddiv: victual.reqtime == %d", victual.reqtime);
 	debugpline("oeaten == %d, basenutrit == %d", otmp->oeaten, basenutrit);
-	debugpline("nutrit == %d, cnutrit == %d", nutrit, otmp->otyp == CORPSE ?
-	  mons[otmp->corpsenm].cnutrit : objects[otmp->otyp].oc_nutrition);
-#endif
+	debugpline("nutrit == %d, cnutrit == %d", nutrit, otmp->otyp == CORPSE ?*
+	  mons[otmp->corpsenm].cnutrit : objects[otmp->otyp].oc_nutrition);*/
 	victual.reqtime = (basenutrit == 0 ? 0 : (u.sealsActive&SEAL_AHAZU) ? 1 : 
 		rounddiv(victual.reqtime * (long)nutrit, basenutrit));
-#ifdef DEBUG
-	debugpline("after rounddiv: victual.reqtime == %d", victual.reqtime);
-#endif
+	//debugpline("after rounddiv: victual.reqtime == %d", victual.reqtime);
 	/* calculate the modulo value (nutrit. units per round eating)
 	 * [ALI] Note: although this is not exact, the remainder is
 	 *       now dealt with in done_eating().
@@ -4041,9 +3894,7 @@ register int num;
 {
 	/* See comments in newuhs() for discussion on force_save_hs */
 	boolean iseating = (occupation == eatfood) || force_save_hs;
-#ifdef DEBUG
-	debugpline("lesshungry(%d)", num);
-#endif
+ 	//debugpline("lesshungry(%d)", num);
 	if(Race_if(PM_INCANTIFIER)) u.uen += num;
 	else u.uhunger += num;
 	if(((Race_if(PM_INCANTIFIER) && u.uen > u.uenmax) ||

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -471,7 +471,7 @@ int what;		/* should be a long */
 	 * Start the actual pickup process.  This is split into two main
 	 * sections, the newer menu and the older "traditional" methods.
 	 * Automatic pickup has been split into its own menu-style routine
-	 * to make things less confusin
+	 * to make things less confusing.
 	 */
 	if (autopickup) {
 	    n = autopick(objchain, traverse_how, &pick_list);
@@ -1715,7 +1715,7 @@ lootcont:
 					}
 					if (cobj->otyp == BAG_OF_TRICKS) {
 						int tmp;
-						You("carefully open the ba..");
+						You("carefully open the bag...");
 						pline("It develops a huge set of teeth and bites you!");
 						tmp = rnd(10);
 						if (Half_physical_damage) tmp = (tmp+1) / 2;

--- a/src/potion.c
+++ b/src/potion.c
@@ -1132,24 +1132,11 @@ as_extra_healing:
 				}
 			}
 		}
-		if((HSlow_digestion&TIMEOUT) + 5000L < TIMEOUT){
-			long timer = (HSlow_digestion&TIMEOUT) + 5000L;
-			HSlow_digestion &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HSlow_digestion |= timer; //set new timer
-		}
-		else{
-			HSlow_digestion |= TIMEOUT; //set timer to max value
-		}
+		give_intrinsic(SLOW_DIGESTION, 5000L);
 		if(!Breathless)
 			You("no longer feel the need to breathe!");
-		if((HMagical_breathing&TIMEOUT) + 5000L < TIMEOUT){
-			long timer = (HMagical_breathing&TIMEOUT) + 5000L;
-			HMagical_breathing &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HMagical_breathing |= timer; //set new timer
-		}
-		else{
-			HMagical_breathing |= TIMEOUT; //set timer to max value
-		}
+		give_intrinsic(MAGICAL_BREATHING, 5000L);
+		
 		break;
 	case POT_LEVITATION:
 	case SPE_LEVITATION:

--- a/src/pray.c
+++ b/src/pray.c
@@ -3964,20 +3964,29 @@ aligntyp alignment;
 					if (++i >= A_MAX) i = 0;
 				}
 				
-				i = rn2(A_MAX);
-				for (ii = A_MAX; ii > 0; ii--) {
-					if (adjattrib(i, 1, (ii == 1) ? 0 : -1))
-						break;
-					i = (i+1)%6;
+				if (ii == A_MAX){
+					i = rn2(A_MAX);
+					for (ii = A_MAX; ii > 0; ii--) {
+						if (adjattrib(i, 1, (ii == 1) ? 0 : -1))
+							break;
+						i = (i+1)%6;
+					}
 				}
 				flags.botl = 1;
 				break;
 			case 1: // increase weapon enchantment
 				if (uwep && uwep->spe < 7 && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)))
 					uwep->spe++;
-				else if(uswapwep && uswapwep->spe < 7 && (uswapwep->oclass == WEAPON_CLASS || is_weptool(uswapwep)))
+				else if (uswapwep && uswapwep->spe < 7 && (uswapwep->oclass == WEAPON_CLASS || is_weptool(uswapwep)))
 					uswapwep->spe++;
-				
+				else if (u.umartial && uarmg && (uarmg->oartifact || !uwep) && uarmg->spe < 5)
+					uarmg->spe++;
+				else if (u.umartial && uarmf && (uarmf->oartifact || !uwep) && uarmf->spe < 5)
+					uarmf->spe++;
+				else if (uleft && objects[uleft->otyp].oc_charged && uleft->spe < 5)
+					uleft->spe++;
+				else if (uright && objects[uright->otyp].oc_charged && uright->spe < 5)
+					uright->spe++;
 				break;
 			case 2: // identify an item
 				if (uwep && not_fully_identified(uwep)) identify(uwep);
@@ -3994,7 +4003,10 @@ aligntyp alignment;
 				else if (uarms && not_fully_identified(uarms)) identify(uarms);
 				else {
 					for(otmp=invent; otmp; otmp=otmp->nobj)
-					if (not_fully_identified(otmp)) identify(otmp);
+					if (not_fully_identified(otmp)){
+						identify(otmp);
+						break;
+					}
 				}
 				break;
 			case 3: // give an intrinsic for 500-1500 turns, first of pois/slee/fire/cold/shock
@@ -4064,71 +4076,115 @@ aligntyp alignment;
 				break;
 			case 4: // repair an item
 				for (i = 3; i >= 0; i--){
-					if (uwep && uwep->oeroded == i && (i > 0 || !uwep->oerodeproof)){
-						if (i == 0)
-							uwep->oerodeproof = TRUE;
-						else
-							uwep->oeroded = 0;
-						
+					if (uwep && (uwep->oeroded == i || uwep->oeroded2 == i)){
 						uwep->rknown = TRUE;
-						break;
-					} else if (uswapwep && uswapwep->oeroded == i && (i > 0 || !uswapwep->oerodeproof)){
-						if (i == 0)
-							uswapwep->oerodeproof = TRUE;
-						else
-							uswapwep->oeroded = 0;
-						
+						if (uwep->oeroded == i && i > 0){
+							uwep->oeroded--;
+							break;
+						} else if (uwep->oeroded2 == i && i > 0){
+							uwep->oeroded2--;
+							break;
+						} else if (uwep->oeroded == i && uwep->oeroded2 == i && !(uwep->oerodeproof)){
+							uwep->oerodeproof = TRUE;
+							break;
+						}
+					} if (uswapwep && (uswapwep->oeroded == i || uswapwep->oeroded2 == i)){
 						uswapwep->rknown = TRUE;
-						break;
-					} else if (uarmc && uarmc->oeroded == i && (i > 0 || !uarmc->oerodeproof)){
-						if (i == 0)
-							uarmc->oerodeproof = TRUE;
-						else
-							uarmc->oeroded = 0;
-						
+						if (uswapwep->oeroded == i && i > 0){
+							uswapwep->oeroded--;
+							break;
+						} else if (uswapwep->oeroded2 == i && i > 0){
+							uswapwep->oeroded2--;
+							break;
+						} else if (uswapwep->oeroded == i && uswapwep->oeroded2 == i && !(uswapwep->oerodeproof)){
+							uswapwep->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarmc && (uarmc->oeroded == i || uarmc->oeroded2 == i)){
 						uarmc->rknown = TRUE;
-						break;
-					} else if (uarm && uarm->oeroded == i && (i > 0 || !uarm->oerodeproof)){
-						if (i == 0)
-							uarm->oerodeproof = TRUE;
-						else
-							uarm->oeroded = 0;
-						
+						if (uarmc->oeroded == i && i > 0){
+							uarmc->oeroded--;
+							break;
+						} else if (uarmc->oeroded2 == i && i > 0){
+							uarmc->oeroded2--;
+							break;
+						} else if (uarmc->oeroded == i && uarmc->oeroded2 == i && !(uarmc->oerodeproof)){
+							uarmc->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarm && (uarm->oeroded == i || uarm->oeroded2 == i)){
 						uarm->rknown = TRUE;
-						break;
-					} else if (uarmu && uarmu->oeroded == i && (i > 0 || !uarmu->oerodeproof)){
-						if (i == 0)
-							uarmu->oerodeproof = TRUE;
-						else
-							uarmu->oeroded = 0;
-						
+						if (uarm->oeroded == i && i > 0){
+							uarm->oeroded--;
+							break;
+						} else if (uarm->oeroded2 == i && i > 0){
+							uarm->oeroded2--;
+							break;
+						} else if (uarm->oeroded == i && uarm->oeroded2 == i && !(uarm->oerodeproof)){
+							uarm->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarmu && (uarmu->oeroded == i || uarmu->oeroded2 == i)){
 						uarmu->rknown = TRUE;
-						break;
-					} else if (uarmh && uarmh->oeroded == i && (i > 0 || !uarmh->oerodeproof)){
-						if (i == 0)
-							uarmh->oerodeproof = TRUE;
-						else
-							uarmh->oeroded = 0;
-						
+						if (uarmu->oeroded == i && i > 0){
+							uarmu->oeroded--;
+							break;
+						} else if (uarmu->oeroded2 == i && i > 0){
+							uarmu->oeroded2--;
+							break;
+						} else if (uarmu->oeroded == i && uarmu->oeroded2 == i && !(uarmu->oerodeproof)){
+							uarmu->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarmh && (uarmh->oeroded == i || uarmh->oeroded2 == i)){
 						uarmh->rknown = TRUE;
-						break;
-					} else if (uarmg && uarmg->oeroded == i && (i > 0 || !uarmg->oerodeproof)){
-						if (i == 0)
-							uarmg->oerodeproof = TRUE;
-						else
-							uarmg->oeroded = 0;
-						
+						if (uarmh->oeroded == i && i > 0){
+							uarmh->oeroded--;
+							break;
+						} else if (uarmh->oeroded2 == i && i > 0){
+							uarmh->oeroded2--;
+							break;
+						} else if (uarmh->oeroded == i && uarmh->oeroded2 == i && !(uarmh->oerodeproof)){
+							uarmh->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarmg && (uarmg->oeroded == i || uarmg->oeroded2 == i)){
 						uarmg->rknown = TRUE;
-						break;
-					} else if (uarmf && uarmf->oeroded == i && (i > 0 || !uarmf->oerodeproof)){
-						if (i == 0)
-							uarmf->oerodeproof = TRUE;
-						else
-							uarmf->oeroded = 0;
-						
+						if (uarmg->oeroded == i && i > 0){
+							uarmg->oeroded--;
+							break;
+						} else if (uarmg->oeroded2 == i && i > 0){
+							uarmg->oeroded2--;
+							break;
+						} else if (uarmg->oeroded == i && uarmg->oeroded2 == i && !(uarmg->oerodeproof)){
+							uarmg->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarmf && (uarmf->oeroded == i || uarmf->oeroded2 == i)){
 						uarmf->rknown = TRUE;
-						break;
-					} 
+						if (uarmf->oeroded == i && i > 0){
+							uarmf->oeroded--;
+							break;
+						} else if (uarmf->oeroded2 == i && i > 0){
+							uarmf->oeroded2--;
+							break;
+						} else if (uarmf->oeroded == i && uarmf->oeroded2 == i && !(uarmf->oerodeproof)){
+							uarmf->oerodeproof = TRUE;
+							break;
+						}
+					} if (uarms && (uarms->oeroded == i || uarms->oeroded2 == i)){
+						uarms->rknown = TRUE;
+						if (uarms->oeroded == i && i > 0){
+							uarms->oeroded--;
+							break;
+						} else if (uarms->oeroded2 == i && i > 0){
+							uarms->oeroded2--;
+							break;
+						} else if (uarms->oeroded == i && uarms->oeroded2 == i && !(uarms->oerodeproof)){
+							uarms->oerodeproof = TRUE;
+							break;
+						}
+					}
 				}
 				break;
 			case 5: // bless/curse an item
@@ -4158,8 +4214,10 @@ aligntyp alignment;
 					if (wrongbuc(otmp)) break;
 					return;
 				}
-				if (hates_unholy(youracedata) && hates_holy(youracedata))
-					otmp->cursed = otmp->blessed = 0;
+				if (hates_unholy(youracedata) && hates_holy(youracedata)){
+					uncurse(otmp);
+					unbless(otmp);
+				}
 				else if (hates_holy(youracedata))
 					curse(otmp);
 				else if (hates_unholy(youracedata))
@@ -4172,9 +4230,9 @@ aligntyp alignment;
 					Your("%s %s.", what ? what : (const char *) aobjnam(otmp, "softly glow"), 
 								hcolor(otmp->blessed ? NH_LIGHT_BLUE : \
 								(otmp->cursed ? NH_BLACK : NH_AMBER)));
+#undef wrongbuc
 				break;
 			default: impossible("bad god_gives_benefit benefit?");
-				
 		}
 	}
 }

--- a/src/pray.c
+++ b/src/pray.c
@@ -4020,58 +4020,25 @@ aligntyp alignment;
 				
 				if(!(HSleep_resistance)) {
 					You_feel("wide awake.");				
-					if((HSleep_resistance & timeout) < TIMEOUT) {
-						long timer = (HSleep_resistance & TIMEOUT) + timeout;
-						HSleep_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-						HSleep_resistance |= timer; //set new timer
-						break;
-					} else {
-						HSleep_resistance |= timeout;
-						break;
-					}
+					give_intrinsic(SLEEP_RES, timeout);
 				}
 				
 				if(!(HFire_resistance)) {
 					You(Hallucination ? "be chillin'." : "feel a momentary chill.");				
-					if((HFire_resistance & timeout) < TIMEOUT) {
-						long timer = (HFire_resistance & TIMEOUT) + timeout;
-						HFire_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-						HFire_resistance |= timer; //set new timer
-						break;
-					} else {
-						HFire_resistance |= timeout;
-						break;
-					}
+					give_intrinsic(FIRE_RES, timeout);
 				}
 
 				if(!(HCold_resistance)) {
 					You_feel("full of hot air.");
-					if((HCold_resistance & timeout) < TIMEOUT) {
-						long timer = (HFire_resistance & TIMEOUT) + timeout;
-						HCold_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-						HCold_resistance |= timer; //set new timer
-						break;
-					} else {
-						HCold_resistance |= timeout;
-						break;
-					}
+					give_intrinsic(COLD_RES, timeout);
 				}
 						
 				if(!(HShock_resistance)) {
 					if (Hallucination)
 						rn2(2) ? You_feel("grounded in reality.") : Your("health currently feels amplified!");
-					else
-						You_feel("well grounded.");
-				
-					if((HShock_resistance & timeout) < TIMEOUT) {
-						long timer = (HFire_resistance & TIMEOUT) + timeout;
-						HShock_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-						HShock_resistance |= timer; //set new timer
-						break;
-					} else {
-						HShock_resistance |= timeout;
-						break;
-					}
+					else You_feel("well grounded.");
+					
+					give_intrinsic(SHOCK_RES, timeout);
 				}
 				break;
 			case 4: // repair an item

--- a/src/pray.c
+++ b/src/pray.c
@@ -4444,23 +4444,26 @@ boolean yourinvent;
 	    /* The player can gain an artifact */
 	    /* The chance goes down as the number of artifacts goes up */
 		/* Priests now only count gifts in this calculation, found artifacts are excluded */
-	    if(u.ulevel > 2 && u.uluck >= 0 
-		    && (!flags.made_know || 
-			 (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || uwep->oartifact) && !(uwep->oproperties&OPROP_ACIDW))
-		    )
-			&& maybe_god_gives_gift()
-		){
-			if(uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || uwep->oartifact) && !(uwep->oproperties&OPROP_ACIDW)){
-				if(!Blind) pline("Acid drips from your weapon!");
-				uwep->oproperties |= OPROP_ACIDW;
-				uwep->oeroded = 0;
-				uwep->oeroded2 = 0;
-				uwep->oerodeproof = 1;
+		struct obj *otmp = (struct obj *)0;
+		if (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || uwep->oartifact) && !(uwep->oproperties&OPROP_ACIDW))
+			otmp = uwep;
+		else if (uarmg && u.umartial && uarmg->oartifact && !(uarmg->oproperties&OPROP_ACIDW))
+			otmp = uarmg;
+		else if (uarmf && u.umartial && uarmf->oartifact && !(uarmf->oproperties&OPROP_ACIDW))
+			otmp = uarmf;
+			
+	    if(u.ulevel > 2 && u.uluck >= 0 && (!flags.made_know || otmp) && maybe_god_gives_gift()){
+			if(otmp){
+				if(!Blind) pline("Acid drips from your %s!", 
+					(otmp == uwep) ? "weapon" : ((otmp == uarmg) ? "gloves" : "boots"));
+				otmp->oproperties |= OPROP_ACIDW;
+				otmp->oeroded = 0;
+				otmp->oeroded2 = 0;
+				otmp->oerodeproof = 1;
 				u.ugifts++;
 				u.uartisval += TIER_S;
 			}
 			else if(!flags.made_know){
-				struct obj *otmp;
 				otmp = mksobj(WORD_OF_KNOWLEDGE, FALSE, FALSE);
 				dropy(otmp);
 				at_your_feet("An object");

--- a/src/pray.c
+++ b/src/pray.c
@@ -3946,66 +3946,235 @@ aligntyp alignment;
 {
 	register struct obj *otmp;
 	const char *what = (const char *)0;
+	int i, ii, lim, timeout;
 	
 	if (rnl((30 + u.ulevel)*10) < 10) god_gives_pet(align_gname_full(alignment),alignment);
 	else {
-		switch (rnl(5)) {
-			case 0: /* randomly charge an object */
-			case 1: /* increase weapon bonus */
-				if(uwep && uwep->spe < 7 && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep))){
-					uwep->spe++;
+		switch (rn2(6)) {
+			case 0: // randomly increment an ability score
+				i = rn2(A_MAX);
+				for (ii = 0; ii < A_MAX; ii++) {
+					lim = AMAX(i);
+					if (i == A_STR && u.uhs >= 3) --lim;
+					if (ABASE(i) < lim) {
+						ABASE(i) = lim;
+						pline("Wow! You feel good!");
+						break;
+					}
+					if (++i >= A_MAX) i = 0;
 				}
-			case 2: /* randomly identify items in the backpack */
-			case 3: /* do magic mapping */
-			case 4: /* give some food */
-			case 5: /* randomly bless items */
-		    /* weapon takes precedence if it interferes
-		       with taking off a ring or shield */
+				
+				i = rn2(A_MAX);
+				for (ii = A_MAX; ii > 0; ii--) {
+					if (adjattrib(i, 1, (ii == 1) ? 0 : -1))
+						break;
+					i = (i+1)%6;
+				}
+				flags.botl = 1;
+				break;
+			case 1: // increase weapon enchantment
+				if (uwep && uwep->spe < 7 && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)))
+					uwep->spe++;
+				else if(uswapwep && uswapwep->spe < 7 && (uswapwep->oclass == WEAPON_CLASS || is_weptool(uswapwep)))
+					uswapwep->spe++;
+				
+				break;
+			case 2: // identify an item
+				if (uwep && not_fully_identified(uwep)) identify(uwep);
+				else if (uswapwep && not_fully_identified(uswapwep)) identify(uswapwep);
+				else if (uamul && not_fully_identified(uamul)) identify(uamul);
+				else if (uleft && not_fully_identified(uleft)) identify(uleft);
+				else if (uright && not_fully_identified(uright)) identify(uright);
+				else if (uarmc && not_fully_identified(uarmc)) identify(uarmc);
+				else if (uarm && not_fully_identified(uarm)) identify(uarm);
+				else if (uarmu && not_fully_identified(uarmu)) identify(uarmu);
+				else if (uarmh && not_fully_identified(uarmh)) identify(uarmh);
+				else if (uarmg && not_fully_identified(uarmg)) identify(uarmf);
+				else if (uarmf && not_fully_identified(uarmf)) identify(uarmf);
+				else if (uarms && not_fully_identified(uarms)) identify(uarms);
+				else {
+					for(otmp=invent; otmp; otmp=otmp->nobj)
+					if (not_fully_identified(otmp)) identify(otmp);
+				}
+				break;
+			case 3: // give an intrinsic for 500-1500 turns, first of pois/slee/fire/cold/shock
+				timeout = rn1(1000, 500);
 
-		    if (uwep && !uwep->blessed) /* weapon */
-			    otmp = uwep;
-		    else if (uswapwep && !uswapwep->blessed) /* secondary weapon */
-			    otmp = uswapwep;
-		    /* gloves come next, due to rings */
-		    else if (uarmg && !uarmg->blessed)    /* gloves */
-			    otmp = uarmg;
-		    /* then shield due to two handed weapons and spells */
-		    else if (uarms && !uarms->blessed)    /* shield */
-			    otmp = uarms;
-		    /* then cloak due to body armor */
-		    else if (uarmc && !uarmc->blessed)    /* cloak */
-			    otmp = uarmc;
-		    else if (uarm && !uarm->blessed)      /* armor */
-			    otmp = uarm;
-		    else if (uarmh && !uarmh->blessed)    /* helmet */
-			    otmp = uarmh;
-		    else if (uarmf && !uarmf->blessed)    /* boots */
-			    otmp = uarmf;
-//ifdef TOURIST
-		    else if (uarmu && !uarmu->blessed)    /* shirt */
-			    otmp = uarmu;
-//endif
-		    /* (perhaps amulet should take precedence over rings?) */
-		    else if (uleft && !uleft->blessed)
-			    otmp = uleft;
-		    else if (uright && !uright->blessed)
-			    otmp = uright;
-		    else if (uamul && !uamul->blessed) /* amulet */
-			    otmp = uamul;
-		    else {
-			    for(otmp=invent; otmp; otmp=otmp->nobj)
-				if (!otmp->blessed)
+				if(!(HPoison_resistance & FROMOUTSIDE)) {
+					You_feel(Poison_resistance ? "especially healthy." : "healthy.");
+					HPoison_resistance |= FROMOUTSIDE;
 					break;
-			    return; /* Nothing to do! */
-		    }
-		    bless(otmp);
-		    otmp->bknown = TRUE;
-		    if (!Blind)
-			    Your("%s %s.",
-				 what ? what :
-				 (const char *)aobjnam (otmp, "softly glow"),
-				 hcolor(NH_AMBER));
-			break;
+				}
+				
+				if(!(HSleep_resistance)) {
+					You_feel("wide awake.");				
+					if((HSleep_resistance & timeout) < TIMEOUT) {
+						long timer = (HSleep_resistance & TIMEOUT) + timeout;
+						HSleep_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
+						HSleep_resistance |= timer; //set new timer
+						break;
+					} else {
+						HSleep_resistance |= timeout;
+						break;
+					}
+				}
+				
+				if(!(HFire_resistance)) {
+					You(Hallucination ? "be chillin'." : "feel a momentary chill.");				
+					if((HFire_resistance & timeout) < TIMEOUT) {
+						long timer = (HFire_resistance & TIMEOUT) + timeout;
+						HFire_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
+						HFire_resistance |= timer; //set new timer
+						break;
+					} else {
+						HFire_resistance |= timeout;
+						break;
+					}
+				}
+
+				if(!(HCold_resistance)) {
+					You_feel("full of hot air.");
+					if((HCold_resistance & timeout) < TIMEOUT) {
+						long timer = (HFire_resistance & TIMEOUT) + timeout;
+						HCold_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
+						HCold_resistance |= timer; //set new timer
+						break;
+					} else {
+						HCold_resistance |= timeout;
+						break;
+					}
+				}
+						
+				if(!(HShock_resistance)) {
+					if (Hallucination)
+						rn2(2) ? You_feel("grounded in reality.") : Your("health currently feels amplified!");
+					else
+						You_feel("well grounded.");
+				
+					if((HShock_resistance & timeout) < TIMEOUT) {
+						long timer = (HFire_resistance & TIMEOUT) + timeout;
+						HShock_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
+						HShock_resistance |= timer; //set new timer
+						break;
+					} else {
+						HShock_resistance |= timeout;
+						break;
+					}
+				}
+				break;
+			case 4: // repair an item
+				for (i = 3; i >= 0; i--){
+					if (uwep && uwep->oeroded == i && (i > 0 || !uwep->oerodeproof)){
+						if (i == 0)
+							uwep->oerodeproof = TRUE;
+						else
+							uwep->oeroded = 0;
+						
+						uwep->rknown = TRUE;
+						break;
+					} else if (uswapwep && uswapwep->oeroded == i && (i > 0 || !uswapwep->oerodeproof)){
+						if (i == 0)
+							uswapwep->oerodeproof = TRUE;
+						else
+							uswapwep->oeroded = 0;
+						
+						uswapwep->rknown = TRUE;
+						break;
+					} else if (uarmc && uarmc->oeroded == i && (i > 0 || !uarmc->oerodeproof)){
+						if (i == 0)
+							uarmc->oerodeproof = TRUE;
+						else
+							uarmc->oeroded = 0;
+						
+						uarmc->rknown = TRUE;
+						break;
+					} else if (uarm && uarm->oeroded == i && (i > 0 || !uarm->oerodeproof)){
+						if (i == 0)
+							uarm->oerodeproof = TRUE;
+						else
+							uarm->oeroded = 0;
+						
+						uarm->rknown = TRUE;
+						break;
+					} else if (uarmu && uarmu->oeroded == i && (i > 0 || !uarmu->oerodeproof)){
+						if (i == 0)
+							uarmu->oerodeproof = TRUE;
+						else
+							uarmu->oeroded = 0;
+						
+						uarmu->rknown = TRUE;
+						break;
+					} else if (uarmh && uarmh->oeroded == i && (i > 0 || !uarmh->oerodeproof)){
+						if (i == 0)
+							uarmh->oerodeproof = TRUE;
+						else
+							uarmh->oeroded = 0;
+						
+						uarmh->rknown = TRUE;
+						break;
+					} else if (uarmg && uarmg->oeroded == i && (i > 0 || !uarmg->oerodeproof)){
+						if (i == 0)
+							uarmg->oerodeproof = TRUE;
+						else
+							uarmg->oeroded = 0;
+						
+						uarmg->rknown = TRUE;
+						break;
+					} else if (uarmf && uarmf->oeroded == i && (i > 0 || !uarmf->oerodeproof)){
+						if (i == 0)
+							uarmf->oerodeproof = TRUE;
+						else
+							uarmf->oeroded = 0;
+						
+						uarmf->rknown = TRUE;
+						break;
+					} 
+				}
+				break;
+			case 5: // bless/curse an item
+#define wrongbuc(obj) ((hates_unholy(youracedata) && hates_holy(youracedata)) ? \
+						(obj->blessed || obj->cursed) : \
+						(hates_unholy(youracedata) ? !obj->blessed : \
+						(hates_holy(youracedata) ? !obj->cursed : !obj->blessed)))
+
+				/* weapon takes precedence if it interferes with taking off a ring or shield */				
+				if (uwep && wrongbuc(uwep)) otmp = uwep;
+				else if (uswapwep && wrongbuc(uswapwep)) otmp = uswapwep;
+				/* gloves come next, due to rings */
+				else if (uarmg && wrongbuc(uarmg)) otmp = uarmg;
+				/* then shield due to two handed weapons and spells */
+				else if (uarms && wrongbuc(uarms)) otmp = uarms;
+				/* then cloak due to body armor */
+				else if (uarmc && wrongbuc(uarmc)) otmp = uarmc;
+				else if (uarm && wrongbuc(uarm)) otmp = uarm;
+				else if (uarmh && wrongbuc(uarmh)) otmp = uarmh;
+				else if (uarmf && wrongbuc(uarmf)) otmp = uarmf;
+				else if (uarmu && wrongbuc(uarmu)) otmp = uarmu;
+				else if (uamul && wrongbuc(uamul)) otmp = uamul;
+				else if (uleft && wrongbuc(uleft))  otmp = uleft;
+				else if (uright && wrongbuc(uright)) otmp = uright;
+				else {
+					for(otmp=invent; otmp; otmp=otmp->nobj)
+					if (wrongbuc(otmp)) break;
+					return;
+				}
+				if (hates_unholy(youracedata) && hates_holy(youracedata))
+					otmp->cursed = otmp->blessed = 0;
+				else if (hates_holy(youracedata))
+					curse(otmp);
+				else if (hates_unholy(youracedata))
+					bless(otmp);
+				else
+					bless(otmp);
+			
+				otmp->bknown = TRUE;
+				if (!Blind)
+					Your("%s %s.", what ? what : (const char *) aobjnam(otmp, "softly glow"), 
+								hcolor(otmp->blessed ? NH_LIGHT_BLUE : \
+								(otmp->cursed ? NH_BLACK : NH_AMBER)));
+				break;
+			default: impossible("bad god_gives_benefit benefit?");
+				
 		}
 	}
 }
@@ -4061,10 +4230,11 @@ goat_gives_benefit()
 				uncurse(optr);
 			}
 			if(Punished) unpunish();
-		break;
+			break;
 		case 2:
+			You_feel("very lucky.");
 			change_luck(2*LUCKMAX);
-		break;
+			break;
 		case 3:
 			if(uwep && !uwep->oartifact && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && !(uwep->oproperties&OPROP_ACIDW)){
 				if(!Blind) pline("Acid drips from your weapon!");
@@ -4073,13 +4243,13 @@ goat_gives_benefit()
 				uwep->oeroded2 = 0;
 				uwep->oerodeproof = 1;
 			}
-		break;
+			break;
 		case 4:
 			if(HSterile){
 				You_feel("fertile.");
 				HSterile = 0L;
 			}
-		break;
+			break;
 		case 5:
 		case 6:
 		case 7:
@@ -4087,8 +4257,8 @@ goat_gives_benefit()
 			optr->quan = rnd(8);
 			optr->owt = weight(optr);
 			dropy(optr);
-			optr->quan > 1 ? at_your_feet("Some objects") : at_your_feet("An object");
-		break;
+			optr->quan > 1 ? at_your_feet("Some potions") : at_your_feet("A potion");
+			break;
 	}
 	return;
 }
@@ -4276,11 +4446,11 @@ boolean yourinvent;
 		/* Priests now only count gifts in this calculation, found artifacts are excluded */
 	    if(u.ulevel > 2 && u.uluck >= 0 
 		    && (!flags.made_know || 
-			 (uwep && (uwep->oartifact || uwep->oproperties || spec_prop_otyp(uwep)) && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && !(uwep->oproperties&OPROP_ACIDW))
+			 (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || uwep->oartifact) && !(uwep->oproperties&OPROP_ACIDW))
 		    )
 			&& maybe_god_gives_gift()
 		){
-			if(uwep && (uwep->oartifact || uwep->oproperties || spec_prop_otyp(uwep)) && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && !(uwep->oproperties&OPROP_ACIDW)){
+			if(uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || uwep->oartifact) && !(uwep->oproperties&OPROP_ACIDW)){
 				if(!Blind) pline("Acid drips from your weapon!");
 				uwep->oproperties |= OPROP_ACIDW;
 				uwep->oeroded = 0;

--- a/src/read.c
+++ b/src/read.c
@@ -2541,23 +2541,17 @@ struct obj	*sobj;
 		}
 		if(confused){
 			//Confused: Remove magic shield
-			if(HNullmagic && ( HNullmagic & ~TIMEOUT) == 0L)
+			if(HNullmagic && (HNullmagic & ~TIMEOUT) == 0L)
 				pline("The shimmering film around you pops!");
 			else pline("Nothing happens.");
-			HNullmagic &= ~TIMEOUT;
+			give_intrinsic(NULLMAGIC, -2);
 	break;
 		}
 		if(!Nullmagic) pline("A shimmering film surrounds you!");
 		else pline("The shimmering film grows brighter!");
-		if ((HNullmagic & TIMEOUT) + amt < TIMEOUT) {
-			long timer = (HNullmagic & TIMEOUT) + amt;
-			HNullmagic &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HNullmagic |= timer; //set new timer
-		}
-		else{
-			HNullmagic |= TIMEOUT; //set timer to max value
-		}
-	}break;
+		give_intrinsic(NULLMAGIC, amt);
+	}
+	break;
 	case SCR_RESISTANCE:{
 		if(confused){
 			int damlevel = max(3, u.ulevel), sx = u.ux, sy = u.uy;
@@ -2605,74 +2599,38 @@ struct obj	*sobj;
 	break;
 		}
 		long rturns = sobj->blessed ? 5000L : sobj->cursed ? 5L : 250L;
-		if( !(HFire_resistance) ) {
-			You(Hallucination ? "be chillin'." :
-			    "feel a momentary chill.");
-		}
-		if( (HFire_resistance & TIMEOUT) + rturns < TIMEOUT) {
-			long timer = (HFire_resistance & TIMEOUT) + rturns;
-			HFire_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HFire_resistance |= timer; //set new timer
-		}
-		else{
-			HFire_resistance |= TIMEOUT; //set timer to max value
-		}
 		
-		if( !(HSleep_resistance) ) {
+		if (!(HFire_resistance))
+			You(Hallucination ? "be chillin'." : "feel a momentary chill.");
+		give_intrinsic(FIRE_RES, rturns);
+		
+		if (!(HSleep_resistance))
 			You_feel("wide awake.");
-		}
-		if( (HSleep_resistance & TIMEOUT) + rturns < TIMEOUT) {
-			long timer = (HSleep_resistance & TIMEOUT) + rturns;
-			HSleep_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HSleep_resistance |= timer; //set new timer
-		}
-		else{
-			HSleep_resistance |= TIMEOUT; //set timer to max value
-		}
+		give_intrinsic(SLEEP_RES, rturns);
 		
-		if( !(HCold_resistance) ) {
+		if (!(HCold_resistance))
 			You_feel("full of hot air.");
-		}
-		if( (HCold_resistance & TIMEOUT) + rturns < TIMEOUT) {
-			long timer = (HCold_resistance & TIMEOUT) + rturns;
-			HCold_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HCold_resistance |= timer; //set new timer
-		}
-		else{
-			HCold_resistance |= TIMEOUT; //set timer to max value
-		}
+		give_intrinsic(COLD_RES, rturns);
 		
-		if( !(HShock_resistance) ) {
+		
+		if (!(HShock_resistance)) {
 			if (Hallucination)
 				rn2(2) ? You_feel("grounded in reality.") : Your("health currently feels amplified!");
 			else
 				You_feel("well grounded.");
 		}
-		if( (HShock_resistance & TIMEOUT) + rturns < TIMEOUT) {
-			long timer = (HShock_resistance & TIMEOUT) + rturns;
-			HShock_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HShock_resistance |= timer; //set new timer
-		}
-		else{
-			HShock_resistance |= TIMEOUT; //set timer to max value
-		}
+		give_intrinsic(SHOCK_RES, rturns);
 		
-		if( !(HAcid_resistance) ) {
+		if (!(HAcid_resistance)) {
 			if (Hallucination)
 				rn2(2) ? You_feel("like you've really gotten back to basics!") : You_feel("insoluble.");
 			else
 				Your("skin feels leathery.");
 		}
-		if( (HAcid_resistance & TIMEOUT) + rturns < TIMEOUT) {
-			// long timer = max((HAcid_resistance & TIMEOUT), (long)(nutval*multiplier));
-			long timer = (HAcid_resistance & TIMEOUT) + rturns;
-			HAcid_resistance &= ~TIMEOUT; //wipe old timer, leaving higher bits in place
-			HAcid_resistance |= timer; //set new timer
-		}
-		else{
-			HAcid_resistance |= TIMEOUT; //set timer to max value
-		}
-	}break;
+		give_intrinsic(ACID_RES, rturns);
+		
+	}
+	break;
 	case SCR_CONSECRATION:
 	if(In_endgame(&u.uz)){
 		if(Is_astralevel(&u.uz)) pline("This place is already pretty consecrated.");


### PR DESCRIPTION
(This needs to be merged AFTER the god_gives_benefit changes)

Unifies all of the copy-paste for giving the player a temporary intrinsic into one function. `give_intrinsic` takes 2 arguments - the property (FIRE_RES/etc.) and a long for the duration. If the duration is -1, it's permanent, and if the duration is -2 then that intrinsic is removed.

Calls incr_itimeout. It's possible that the incr_itimeout function should be consolidated and parts of them merged, but I don't know why they were separate in the first place, so they're left alone for now.
