### PR TITLE
Fix crashing when you die

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2475,7 +2475,7 @@ boolean init;
 			if (otmp->otyp == CORPSE) {
 				obj_stop_timers(otmp);
 				/* if the monster was cancelled, don't self-revive */
-				if (mtmp->mcan && !is_rider(ptr))
+				if (mtmp && mtmp->mcan && !is_rider(ptr))
 					otmp->norevive = 1;
 				start_corpse_timeout(otmp);
 			}


### PR DESCRIPTION
Needs a mtmp check first, otherwise a player death makes the game die as well.