### PR TITLE
Fix killer when you die to a disease spell

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -2719,7 +2719,7 @@ int tary;
 				if (!Sick_res(mdef) && !umechanoid) {
 					You("are afflicted with disease!");
 					make_sick(Sick ? Sick / 3L + 1L : (long)rn1(ACURR(A_CON), 20),
-						(char *)0, TRUE, SICK_NONVOMITABLE);
+						magr->data->mname, TRUE, SICK_NONVOMITABLE);
 				}
 				else {
 					You_feel("slightly infectious.");
@@ -2835,7 +2835,7 @@ int tary;
 			/* apply sickness to defender (player-only) */
 			if (youdef) {
 				if (!Sick && !umechanoid) make_sick((long)rn1(ACURR(A_CON), 20), /* Don't make the PC more sick */
-					(char *)0, TRUE, SICK_NONVOMITABLE);
+					magr->data->mname, TRUE, SICK_NONVOMITABLE);
 			}
 			else if (!Sick_res(mdef)) {
 				/* 1/10 chance of instakill */

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2475,7 +2475,7 @@ boolean init;
 			if (otmp->otyp == CORPSE) {
 				obj_stop_timers(otmp);
 				/* if the monster was cancelled, don't self-revive */
-				if (mtmp->mcan && !is_rider(ptr))
+				if (mtmp && mtmp->mcan && !is_rider(ptr))
 					otmp->norevive = 1;
 				start_corpse_timeout(otmp);
 			}


### PR DESCRIPTION
(dependent on #950)

No sickness causer was giving `poisoned by an` for the death msg.
