### PR TITLE
Block chaos_quest option from taking effect most of the time

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1001,6 +1001,7 @@ E char *FDECL(yymmdd, (time_t));
 E long FDECL(yyyymmdd, (time_t));
 E int NDECL(phase_of_the_moon);
 E boolean NDECL(friday_13th);
+E boolean NDECL(is_june);
 E int NDECL(night);
 E int NDECL(midnight);
 E unsigned long int FDECL(hash, (unsigned long int));

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -769,7 +769,7 @@ init_dungeons()		/* initialize the "dungeon" structs */
 	struct version_info vers_info;
 	int dungeonversion;
 	
-	if(flags.chaosvar){
+	if(flags.chaosvar && (wizard || is_june())) {
 		//chaosvar is incremented by 1 so that all variants are nonzero
 		dungeonversion = flags.chaosvar-1;
 	} else {

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -616,6 +616,14 @@ phase_of_the_moon()		/* 0-7, with 0: new, 4: full */
 }
 
 boolean
+is_june()
+{
+	register int month = getlt()->tm_mon;
+
+	return((boolean)(month == 5)); // 0 is Jan, 11 is Dec
+}
+
+boolean
 friday_13th()
 {
 	register struct tm *lt = getlt();


### PR DESCRIPTION
It will still take effect in June or in wizard mode (game start time), but is ignored otherwise.