### PR TITLE
Add more tip interactions

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3389,20 +3389,34 @@ tipmonster:
 				}
 			}
 		} else if (mtmp->isshk){
-			if (u.ugold){
+			if (!can_respond(mtmp))
+				pline("%s doesn't react.", Monnam(mtmp));
+#ifdef GOLDOBJ
+			else if (money_cnt(invent))
+#else
+			else if (u.ugold){
+#endif
 				You("offer %s a tip for their excellent service.", Monnam(mtmp));
 				if (strcmp(shkname(mtmp), "Izchak") == 0){
 					pline("Izchak thanks you for your generous tip.");
 					domonnoise(mtmp, TRUE);
 				}
+#ifdef GOLDOBJ
+				money2mon(mtmp,1);
+#else
 				u.ugold -= 1;
 				mtmp->mgold += 1;
+#endif
 			} else
 				You("have no cash on you right now.");
 		} else if (mtmp->mtyp == PM_LEPRECHAUN){
 			if (!can_respond(mtmp))
 				pline("%s doesn't react.", Monnam(mtmp));
+#ifdef GOLDOBJ
+			else if (!money_cnt(invent))
+#else
 			else if (!u.ugold)
+#endif
 				You("have no money to bribe with!");
 			else {
 				You("offer %s some gold to leave you alone.", mon_nam(mtmp));
@@ -3410,9 +3424,14 @@ tipmonster:
 					pline("%s accepts before you can change your mind.", Monnam(mtmp));
 				else
 					pline("%s greedily accepts.", Monnam(mtmp));
+#ifdef GOLDOBJ
+				int cash = min(money_cnt(invent), rnd(10));
+				money2mon(mtmp, cash);
+#else
 				int cash = min(u.ugold, rnd(10));
 				u.ugold -= cash;
 				mtmp->mgold += cash;
+#endif
 				mtmp->mpeaceful = TRUE;
 				
 				if (!tele_restrict(mtmp)) {
@@ -3422,10 +3441,18 @@ tipmonster:
 				}
 			}
 		} else if (mtmp->mtyp == PM_MIGO_PHILOSOPHER){
+#ifdef GOLDOBJ
+			if (money_cnt(invent)){
+#else
 			if (u.ugold){
+#endif
 				You("offer %s a penny for their thoughts.", mon_nam(mtmp));
+#ifdef GOLDOBJ
+				money2mon(mtmp,1);
+#else
 				u.ugold -= 1;
 				mtmp->mgold += 1;
+#endif
 				if (can_respond(mtmp))
 					domonnoise(mtmp, TRUE);
 			}

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -35,6 +35,7 @@ STATIC_DCL long FDECL(mbag_item_gone, (int,struct obj *));
 STATIC_DCL int FDECL(menu_loot, (int, struct obj *, BOOLEAN_P));
 STATIC_DCL int FDECL(in_or_out_menu, (const char *,struct obj *, BOOLEAN_P, BOOLEAN_P));
 STATIC_DCL void FDECL(tipcontainer, (struct obj *));
+STATIC_DCL int NDECL(tiphat);
 STATIC_DCL int FDECL(container_at, (int, int, BOOLEAN_P));
 STATIC_DCL boolean FDECL(able_to_loot, (int, int, boolean));
 STATIC_DCL boolean FDECL(mon_beside, (int, int));
@@ -3207,258 +3208,260 @@ static const char tippables[] = { ALL_CLASSES, TOOL_CLASS, 0 };
 int
 dotip()
 {
-    struct obj *cobj, *nobj;
-    coord cc;
-    int boxes;
-    char c, buf[BUFSZ], qbuf[BUFSZ];
-    const char *spillage = 0;
+	struct obj *cobj, *nobj;
+	coord cc;
+	int boxes;
+	char c, buf[BUFSZ], qbuf[BUFSZ];
+	const char *spillage = 0;
 
-    /*
-     * doesn't require free hands;
-     * limbs are needed to tip floor containers
-     */
+	/*
+	 * doesn't require free hands;
+	 * limbs are needed to tip floor containers
+	 */
 
-    /* at present, can only tip things at current spot, not adjacent ones */
-    cc.x = u.ux, cc.y = u.uy;
+	/* at present, can only tip things at current spot, not adjacent ones */
+	cc.x = u.ux, cc.y = u.uy;
 
-    /* check floor container(s) first; at most one will be accessed */
-    if ((boxes = container_at(cc.x, cc.y, TRUE)) > 0) {
-        Sprintf(buf, "You can't tip %s while carrying so much.",
-                !flags.verbose ? "a container" : (boxes > 1) ? "one" : "it");
-        if (!check_capacity(buf) && able_to_loot(cc.x, cc.y, FALSE)) {
-            if (boxes > 1 && (flags.menu_style != MENU_TRADITIONAL
-                              || iflags.menu_requested)) {
-                /* use menu to pick a container to tip */
-                int n, i;
-                winid win;
-                anything any;
-                menu_item *pick_list = (menu_item *) 0;
-                struct obj dummyobj, *otmp;
+	/* check floor container(s) first; at most one will be accessed */
+	if ((boxes = container_at(cc.x, cc.y, TRUE)) > 0) {
+		Sprintf(buf, "You can't tip %s while carrying so much.",
+				!flags.verbose ? "a container" : (boxes > 1) ? "one" : "it");
+		if (!check_capacity(buf) && able_to_loot(cc.x, cc.y, FALSE)) {
+			if (boxes > 1 && (flags.menu_style != MENU_TRADITIONAL
+							  || iflags.menu_requested)) {
+				/* use menu to pick a container to tip */
+				int n, i;
+				winid win;
+				anything any;
+				menu_item *pick_list = (menu_item *) 0;
+				struct obj dummyobj, *otmp;
 
-                any = zeroany;
-                win = create_nhwindow(NHW_MENU);
-                start_menu(win);
+				any = zeroany;
+				win = create_nhwindow(NHW_MENU);
+				start_menu(win);
 
-                for (cobj = level.objects[cc.x][cc.y], i = 0; cobj;
-                     cobj = cobj->nexthere)
-                    if (Is_container(cobj)) {
-                        ++i;
-                        any.a_obj = cobj;
-                        add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
-                                 doname(cobj), MENU_UNSELECTED);
-                    }
-                if (invent) {
-                    any = zeroany;
-                    add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
-                             "", MENU_UNSELECTED);
-                    any.a_obj = &dummyobj;
-                    /* use 'i' for inventory unless there are so many
-                       containers that it's already being used */
-                    i = (i <= 'i' - 'a' && !iflags.lootabc) ? 'i' : 0;
-                    add_menu(win, NO_GLYPH, &any, i, 0, ATR_NONE,
-                             "tip something being carried", MENU_UNSELECTED);
-                }
-                end_menu(win, "Tip which container?");
-                n = select_menu(win, PICK_ONE, &pick_list);
-                destroy_nhwindow(win);
-                /*
-                 * Deal with quirk of preselected item in pick-one menu:
-                 * n ==  0 => picked preselected entry, toggling it off;
-                 * n ==  1 => accepted preselected choice via SPACE or RETURN;
-                 * n ==  2 => picked something other than preselected entry;
-                 * n == -1 => cancelled via ESC;
-                 */
-                otmp = (n <= 0) ? (struct obj *) 0 : pick_list[0].item.a_obj;
-                if (n > 1 && otmp == &dummyobj)
-                    otmp = pick_list[1].item.a_obj;
-                if (pick_list)
-                    free((genericptr_t) pick_list);
-                if (otmp && otmp != &dummyobj) {
-                    tipcontainer(otmp);
-                    return 1;
-                }
-                if (n == -1)
-                    return 0;
-                /* else pick-from-invent below */
-            } else {
-                for (cobj = level.objects[cc.x][cc.y]; cobj; cobj = nobj) {
-                    nobj = cobj->nexthere;
-                    if (!Is_container(cobj))
-                        continue;
-                    Sprintf(qbuf, "You see here %s, tip it?", safe_qbuf(qbuf, sizeof("You see here , tip it?"), doname(cobj), xname(cobj), "container"));
-                    c = ynq(qbuf);
-                    if (c == 'q')
-                        return 0;
-                    if (c == 'n')
-                        continue;
-                    tipcontainer(cobj);
-                    /* can only tip one container at a time */
-                    return 1;
-                }
-            }
-        }
-    }
+				for (cobj = level.objects[cc.x][cc.y], i = 0; cobj;
+					 cobj = cobj->nexthere)
+					if (Is_container(cobj)) {
+						++i;
+						any.a_obj = cobj;
+						add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
+								 doname(cobj), MENU_UNSELECTED);
+					}
+				if (invent) {
+					any = zeroany;
+					add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
+							 "", MENU_UNSELECTED);
+					any.a_obj = &dummyobj;
+					/* use 'i' for inventory unless there are so many
+					   containers that it's already being used */
+					i = (i <= 'i' - 'a' && !iflags.lootabc) ? 'i' : 0;
+					add_menu(win, NO_GLYPH, &any, i, 0, ATR_NONE,
+							 "tip something being carried", MENU_UNSELECTED);
+				}
+				end_menu(win, "Tip which container?");
+				n = select_menu(win, PICK_ONE, &pick_list);
+				destroy_nhwindow(win);
+				/*
+				 * Deal with quirk of preselected item in pick-one menu:
+				 * n ==  0 => picked preselected entry, toggling it off;
+				 * n ==  1 => accepted preselected choice via SPACE or RETURN;
+				 * n ==  2 => picked something other than preselected entry;
+				 * n == -1 => cancelled via ESC;
+				 */
+				otmp = (n <= 0) ? (struct obj *) 0 : pick_list[0].item.a_obj;
+				if (n > 1 && otmp == &dummyobj)
+					otmp = pick_list[1].item.a_obj;
+				if (pick_list)
+					free((genericptr_t) pick_list);
+				if (otmp && otmp != &dummyobj) {
+					tipcontainer(otmp);
+					return 1;
+				}
+				if (n == -1)
+					return 0;
+				/* else pick-from-invent below */
+			} else {
+				for (cobj = level.objects[cc.x][cc.y]; cobj; cobj = nobj) {
+					nobj = cobj->nexthere;
+					if (!Is_container(cobj))
+						continue;
+					Sprintf(qbuf, "You see here %s, tip it?", safe_qbuf(qbuf, sizeof("You see here , tip it?"), doname(cobj), xname(cobj), "container"));
+					c = ynq(qbuf);
+					if (c == 'q')
+						return 0;
+					if (c == 'n')
+						continue;
+					tipcontainer(cobj);
+					/* can only tip one container at a time */
+					return 1;
+				}
+			}
+		}
+	}
 
-    /* either no floor container(s) or couldn't tip one or didn't tip any */
-    cobj = getobj(tippables, "tip");
-    if (!cobj)
-        return 0;
+	/* either no floor container(s) or couldn't tip one or didn't tip any */
+	cobj = getobj(tippables, "tip");
+	if (!cobj)
+		return 0;
 
-    /* normal case */
-    if (Is_container(cobj) || cobj->otyp == HORN_OF_PLENTY) {
-        tipcontainer(cobj);
-        return 1;
-    }
-    /* assorted other cases */
-    if (Is_candle(cobj) && cobj->lamplit) {
-        /* note "wax" even for tallow candles to avoid giving away info */
-        spillage = "wax";
-    } else if ((cobj->otyp == POT_OIL && cobj->lamplit)
-               || (cobj->otyp == OIL_LAMP && cobj->age != 0L)
-               || (cobj->otyp == MAGIC_LAMP && cobj->spe != 0)) {
-        spillage = "oil";
-        /* todo: reduce potion's remaining burn timer or oil lamp's fuel */
-    } else if (cobj->otyp == CAN_OF_GREASE && cobj->spe > 0) {
-        /* charged consumed below */
-        spillage = "grease";
-    } else if (cobj->otyp == FOOD_RATION || cobj->otyp == CRAM_RATION
-               || cobj->otyp == LEMBAS_WAFER) {
-        spillage = "crumbs";
-    } else if (cobj->oclass == VENOM_CLASS) {
-        spillage = "venom";
-    }
-    if (spillage) {
-        buf[0] = '\0';
-        if (is_pool(u.ux, u.uy, TRUE))
-            Sprintf(buf, " and gradually %s", vtense(spillage, "dissipate"));
-        else if (is_lava(u.ux, u.uy))
-            Sprintf(buf, " and immediately %s away",
-                    vtense(spillage, "burn"));
-        pline("Some %s %s onto the %s%s.", spillage,
-              vtense(spillage, "spill"), surface(u.ux, u.uy), buf);
-        /* shop usage message comes after the spill message */
-        if (cobj->otyp == CAN_OF_GREASE && cobj->spe > 0) {
-            consume_obj_charge(cobj, TRUE);
-        }
-        /* something [useless] happened */
-        return 1;
-    }
-    /* anything not covered yet */
-    if (cobj->oclass == POTION_CLASS) /* can't pour potions... */
-        pline_The("%s %s securely sealed.", xname(cobj), otense(cobj, "are"));
-    else if (cobj->otyp == STATUE)
-        pline("Nothing interesting happens.");
-    else
-        pline1(nothing_happens);
-    return 0;
+	/* normal case */
+	if (Is_container(cobj) || cobj->otyp == HORN_OF_PLENTY) {
+		tipcontainer(cobj);
+		return 1;
+	}
+	/* assorted other cases */
+	if (Is_candle(cobj) && cobj->lamplit) {
+		/* note "wax" even for tallow candles to avoid giving away info */
+		spillage = "wax";
+	} else if ((cobj->otyp == POT_OIL && cobj->lamplit)
+			   || (cobj->otyp == OIL_LAMP && cobj->age != 0L)
+			   || (cobj->otyp == MAGIC_LAMP && cobj->spe != 0)) {
+		spillage = "oil";
+		/* todo: reduce potion's remaining burn timer or oil lamp's fuel */
+	} else if (cobj->otyp == CAN_OF_GREASE && cobj->spe > 0) {
+		/* charged consumed below */
+		spillage = "grease";
+	} else if (cobj->otyp == FOOD_RATION || cobj->otyp == CRAM_RATION
+			   || cobj->otyp == LEMBAS_WAFER) {
+		spillage = "crumbs";
+	} else if (cobj->oclass == VENOM_CLASS) {
+		spillage = "venom";
+	}
+	if (spillage) {
+		buf[0] = '\0';
+		if (is_pool(u.ux, u.uy, TRUE))
+			Sprintf(buf, " and gradually %s", vtense(spillage, "dissipate"));
+		else if (is_lava(u.ux, u.uy))
+			Sprintf(buf, " and immediately %s away",
+					vtense(spillage, "burn"));
+		pline("Some %s %s onto the %s%s.", spillage,
+			  vtense(spillage, "spill"), surface(u.ux, u.uy), buf);
+		/* shop usage message comes after the spill message */
+		if (cobj->otyp == CAN_OF_GREASE && cobj->spe > 0) {
+			consume_obj_charge(cobj, TRUE);
+		}
+		/* something [useless] happened */
+		return 1;
+	}
+	/* anything not covered yet */
+	if (cobj->oclass == POTION_CLASS) /* can't pour potions... */
+		pline_The("%s %s securely sealed.", xname(cobj), otense(cobj, "are"));
+	else if (uarmh && cobj == uarmh)
+		tiphat();
+	else if (cobj->otyp == STATUE)
+		pline("Nothing interesting happens.");
+	else
+		pline1(nothing_happens);
+	return 0;
 }
 
 static void
 tipcontainer(box)
 struct obj *box; /* or bag */
 {
-    xchar ox = u.ux, oy = u.uy; /* #tip only works at hero's location */
-    boolean empty_it = FALSE, maybeshopgoods;
+	xchar ox = u.ux, oy = u.uy; /* #tip only works at hero's location */
+	boolean empty_it = FALSE, maybeshopgoods;
 
-    /* box is either held or on floor at hero's spot; no need to check for
-       nesting; when held, we need to update its location to match hero's;
-       for floor, the coordinate updating is redundant */
-    if (get_obj_location(box, &ox, &oy, 0))
-        box->ox = ox, box->oy = oy;
+	/* box is either held or on floor at hero's spot; no need to check for
+	   nesting; when held, we need to update its location to match hero's;
+	   for floor, the coordinate updating is redundant */
+	if (get_obj_location(box, &ox, &oy, 0))
+		box->ox = ox, box->oy = oy;
 
-    /* Shop handling:  can't rely on the container's own unpaid
-       or no_charge status because contents might differ with it.
-       A carried container's contents will be flagged as unpaid
-       or not, as appropriate, and need no special handling here.
-       Items owned by the hero get sold to the shop without
-       confirmation as with other uncontrolled drops.  A floor
-       container's contents will be marked no_charge if owned by
-       hero, otherwise they're owned by the shop.  By passing
-       the contents through shop billing, they end up getting
-       treated the same as in the carried case.   We do so one
-       item at a time instead of doing whole container at once
-       to reduce the chance of exhausting shk's billing capacity. */
-    maybeshopgoods = !carried(box) && costly_spot(box->ox, box->oy);
+	/* Shop handling:  can't rely on the container's own unpaid
+	   or no_charge status because contents might differ with it.
+	   A carried container's contents will be flagged as unpaid
+	   or not, as appropriate, and need no special handling here.
+	   Items owned by the hero get sold to the shop without
+	   confirmation as with other uncontrolled drops.  A floor
+	   container's contents will be marked no_charge if owned by
+	   hero, otherwise they're owned by the shop.  By passing
+	   the contents through shop billing, they end up getting
+	   treated the same as in the carried case.   We do so one
+	   item at a time instead of doing whole container at once
+	   to reduce the chance of exhausting shk's billing capacity. */
+	maybeshopgoods = !carried(box) && costly_spot(box->ox, box->oy);
 
-    /* caveat: this assumes that cknown, lknown, olocked, and otrapped
-       fields haven't been overloaded to mean something special for the
-       non-standard "container" horn of plenty */
-    if (box->otyp == MAGIC_CHEST && box->obolted){
-    	pline("You can't tip something bolted down!");
-    	return;
-    }
-    if (box->olocked) {
-        pline("It's locked.");
-    } else if (box->otrapped) {
-        /* we're not reaching inside but we're still handling it... */
-        (void) chest_trap(box, HAND, FALSE);
-        /* even if the trap fails, you've used up this turn */
-        if (multi >= 0) { /* in case we didn't become paralyzed */
-            nomul(-1, "tipping a container");
-        }
-    } else if (box->otyp == BAG_OF_TRICKS || box->otyp == HORN_OF_PLENTY) {
-        boolean bag = box->otyp == BAG_OF_TRICKS;
-        int old_spe = box->spe, seen = 0;
+	/* caveat: this assumes that cknown, lknown, olocked, and otrapped
+	   fields haven't been overloaded to mean something special for the
+	   non-standard "container" horn of plenty */
+	if (box->otyp == MAGIC_CHEST && box->obolted){
+		pline("You can't tip something bolted down!");
+		return;
+	}
+	if (box->olocked) {
+		pline("It's locked.");
+	} else if (box->otrapped) {
+		/* we're not reaching inside but we're still handling it... */
+		(void) chest_trap(box, HAND, FALSE);
+		/* even if the trap fails, you've used up this turn */
+		if (multi >= 0) { /* in case we didn't become paralyzed */
+			nomul(-1, "tipping a container");
+		}
+	} else if (box->otyp == BAG_OF_TRICKS || box->otyp == HORN_OF_PLENTY) {
+		boolean bag = box->otyp == BAG_OF_TRICKS;
+		int old_spe = box->spe, seen = 0;
 
-        if (maybeshopgoods && !box->no_charge)
-            addtobill(box, FALSE, FALSE, TRUE);
-        /* apply this bag/horn until empty or monster/object creation fails
-           (if the latter occurs, force the former...) */
-        do {
-            if (!(bag ? bagotricks(box, TRUE, &seen) : hornoplenty(box, TRUE))) 
-                break;
-        } while (box->spe > 0);
+		if (maybeshopgoods && !box->no_charge)
+			addtobill(box, FALSE, FALSE, TRUE);
+		/* apply this bag/horn until empty or monster/object creation fails
+		   (if the latter occurs, force the former...) */
+		do {
+			if (!(bag ? bagotricks(box, TRUE, &seen) : hornoplenty(box, TRUE))) 
+				break;
+		} while (box->spe > 0);
 
-        if (box->spe < old_spe) {
-            if (bag)
-                pline((seen == 0) ? "Nothing seems to happen."
-                                  : (seen == 1) ? "A monster suddenly appears!"
-                                                : "Monsters suddenly appear!");
-            /* check_unpaid wants to see a non-zero charge count */
-            box->spe = old_spe;
-            check_unpaid_usage(box, TRUE);
-            box->spe = 0; /* empty */
-        }
-        if (maybeshopgoods && !box->no_charge)
-            subfrombill(box, shop_keeper(*in_rooms(ox, oy, SHOPBASE)));
-    } else if (box->otyp == BOX && box->spe == 1) {
-        char yourbuf[BUFSZ];
+		if (box->spe < old_spe) {
+			if (bag)
+				pline((seen == 0) ? "Nothing seems to happen."
+								  : (seen == 1) ? "A monster suddenly appears!"
+												: "Monsters suddenly appear!");
+			/* check_unpaid wants to see a non-zero charge count */
+			box->spe = old_spe;
+			check_unpaid_usage(box, TRUE);
+			box->spe = 0; /* empty */
+		}
+		if (maybeshopgoods && !box->no_charge)
+			subfrombill(box, shop_keeper(*in_rooms(ox, oy, SHOPBASE)));
+	} else if (box->otyp == BOX && box->spe == 1) {
+		char yourbuf[BUFSZ];
 
-        observe_quantum_cat(box, TRUE);
-        if (!Has_contents(box)) /* evidently a live cat came out */
-            /* container type of "large box" is inferred */
-            pline("%sbox is now empty.", Shk_Your(yourbuf, box));
-        else /* holds cat corpse */
-            empty_it = TRUE;
-    } else if (!Has_contents(box)) {
-        pline("It's empty.");
-    } else {
-        empty_it = TRUE;
-    }
+		observe_quantum_cat(box, TRUE);
+		if (!Has_contents(box)) /* evidently a live cat came out */
+			/* container type of "large box" is inferred */
+			pline("%sbox is now empty.", Shk_Your(yourbuf, box));
+		else /* holds cat corpse */
+			empty_it = TRUE;
+	} else if (!Has_contents(box)) {
+		pline("It's empty.");
+	} else {
+		empty_it = TRUE;
+	}
 
-    if (empty_it) {
-        struct obj *otmp, *nobj;
-        boolean terse, highdrop = !can_reach_floor(),
-                altarizing = IS_ALTAR(levl[ox][oy].typ),
-                cursed_mbag = (Is_mbag(box) && box->cursed);
-        int held = carried(box);
-        long loss = 0L;
+	if (empty_it) {
+		struct obj *otmp, *nobj;
+		boolean terse, highdrop = !can_reach_floor(),
+				altarizing = IS_ALTAR(levl[ox][oy].typ),
+				cursed_mbag = (Is_mbag(box) && box->cursed);
+		int held = carried(box);
+		long loss = 0L;
 
-        if (u.uswallow)
-            highdrop = altarizing = FALSE;
-        terse = !(highdrop || altarizing || costly_spot(box->ox, box->oy));
-        /* Terse formatting is
-         * "Objects spill out: obj1, obj2, obj3, ..., objN."
-         * If any other messages intervene between objects, we revert to
-         * "ObjK drops to the floor.", "ObjL drops to the floor.", &c.
-         */
-        pline("%s out%c",
-              box->cobj->nobj ? "Objects spill" : "An object spills",
-              terse ? ':' : '.');
-        for (otmp = box->cobj; otmp; otmp = nobj) {
-            nobj = otmp->nobj;
-            obj_extract_self(otmp);
-            otmp->ox = box->ox, otmp->oy = box->oy;
+		if (u.uswallow)
+			highdrop = altarizing = FALSE;
+		terse = !(highdrop || altarizing || costly_spot(box->ox, box->oy));
+		/* Terse formatting is
+		 * "Objects spill out: obj1, obj2, obj3, ..., objN."
+		 * If any other messages intervene between objects, we revert to
+		 * "ObjK drops to the floor.", "ObjL drops to the floor.", &c.
+		 */
+		pline("%s out%c",
+			  box->cobj->nobj ? "Objects spill" : "An object spills",
+			  terse ? ':' : '.');
+		for (otmp = box->cobj; otmp; otmp = nobj) {
+			nobj = otmp->nobj;
+			obj_extract_self(otmp);
+			otmp->ox = box->ox, otmp->oy = box->oy;
 
 			if (box->otyp == ICE_BOX){
 				if (!age_is_relative(otmp)) {
@@ -3467,39 +3470,143 @@ struct obj *box; /* or bag */
 						start_corpse_timeout(otmp);
 				}
 			}
-            else if (cursed_mbag && !rn2(13)) {
-                loss += mbag_item_gone(held, otmp);
-                /* abbreviated drop format is no longer appropriate */
-                terse = FALSE;
-                continue;
-            }
+			else if (cursed_mbag && !rn2(13)) {
+				loss += mbag_item_gone(held, otmp);
+				/* abbreviated drop format is no longer appropriate */
+				terse = FALSE;
+				continue;
+			}
 
-            if (highdrop) {
-                /* might break or fall down stairs; handles altars itself */
-            	boolean wepgone = FALSE;
+			if (highdrop) {
+				/* might break or fall down stairs; handles altars itself */
+				boolean wepgone = FALSE;
 				bhitpos.x = u.ux; bhitpos.y = u.uy;
 				otmp->ox = u.ux; otmp->oy = u.uy;
 				hitfloor2(&youmonst, otmp, (struct obj *)0, FALSE, FALSE, &wepgone);
-            } else {
-                if (altarizing) {
-                    doaltarobj(otmp);
-                } else if (!terse) {
-                    pline("%s %s to the %s.", Doname2(otmp),
-                          otense(otmp, "drop"), surface(ox, oy));
-                } else {
-                    pline("%s%c", doname(otmp), nobj ? ',' : '.');
-                }
-                dropy(otmp);
-            }
-        }
-        if (loss) /* magic bag lost some shop goods */
-            You("owe %ld %s for lost merchandise.", loss, currency(loss));
-        box->owt = weight(box); /* mbag_item_gone() doesn't update this */
-        if (held)
-            (void) encumber_msg();
-    }
-    if (carried(box)) /* box is now empty with cknown set */
-        update_inventory();
+			} else {
+				if (altarizing) {
+					doaltarobj(otmp);
+				} else if (!terse) {
+					pline("%s %s to the %s.", Doname2(otmp),
+						  otense(otmp, "drop"), surface(ox, oy));
+				} else {
+					pline("%s%c", doname(otmp), nobj ? ',' : '.');
+				}
+				dropy(otmp);
+			}
+		}
+		if (loss) /* magic bag lost some shop goods */
+			You("owe %ld %s for lost merchandise.", loss, currency(loss));
+		box->owt = weight(box); /* mbag_item_gone() doesn't update this */
+		if (held)
+			(void) encumber_msg();
+	}
+	if (carried(box)) /* box is now empty with cknown set */
+		update_inventory();
 }
 
-/*pickup.c*/ 
+int
+tiphat()
+{
+	struct monst *mtmp;
+	struct obj *otmp;
+	int x, y, range, glyph, vismon, unseen, statue, res;
+
+	if (!uarmh) /* can't get here from there */
+		return 0;
+
+	res = uarmh->bknown ? 0 : 1;
+	if (cursed(uarmh)) /* "You can't.  It is cursed." */
+		return res; /* if learned of curse, use a move */
+
+	/* might choose a position, but dealing with direct lines is simpler */
+	if (!getdir("At whom? (in what direction)")) /* bail on ESC */
+		return res; /* iffy; now know it's not cursed for sure (since we got
+					 * past prior test) but might have already known that */
+	res = 1; /* physical action is going to take place */
+
+	/* most helmets have a short wear/take-off delay and we could set
+	   'multi' to account for that, but we'll pretend that no extra time
+	   beyond the current move is necessary */
+	
+	char * term = (uarmh && !is_metallic(uarmh)) ? "hat" : "helm";
+	You("briefly doff your %s.", term);
+
+	if (!u.dx && !u.dy) {
+		if (u.usteed && u.dz > 0) {
+			if (!u.usteed->mcanmove || u.usteed->msleeping)
+				pline("%s doesn't notice.", Monnam(u.usteed));
+			else
+				(void) domonnoise(u.usteed, TRUE);
+		} else if (u.dz) {
+			pline("There's no one %s there.", (u.dz < 0) ? "up" : "down");
+		} else {
+			pline_The("lout here doesn't acknowledge you...");
+		}
+		return res;
+	}
+#define can_respond(mtmp) (mtmp && !(!mtmp->mcanmove || mtmp->msleeping\
+								|| !m_canseeu(mtmp) || (x != mtmp->mx || y != mtmp->my)))
+
+	mtmp = (struct monst *) 0;
+	vismon = unseen = statue = 0;
+	x = u.ux, y = u.uy;
+	for (range = 1; range <= BOLT_LIM + 1; ++range) {
+		x += u.dx, y += u.dy;
+		if (!isok(x, y) || (range > 1 && !couldsee(x, y))) {
+			/* switch back to coordinates for previous interation's 'mtmp' */
+			x -= u.dx, y -= u.dy;
+			break;
+		}
+		mtmp = m_at(x, y);
+		vismon = (mtmp && canseemon(mtmp));
+		if (vismon || (range == 1 && mtmp && can_respond(mtmp) && !is_silent(mtmp->data)))
+			break;
+	}
+	
+	// statue interactions removed, since they make no sense when the obj has a randomized
+	// glyph, and it would be annoying if a statue is between you and a target
+	
+	if (!mtmp || (mtmp && !can_respond(mtmp))) {
+		if (vismon)
+			pline("%s seems not to notice you.", Monnam(mtmp));
+		else
+			goto nada;
+	} else { // at this point, we have mtmp
+		mtmp->mstrategy &= ~STRAT_WAITMASK;
+
+		if (vismon && humanoid(mtmp->data) && mtmp->mpeaceful && !Conflict) {
+			if ((otmp = which_armor(mtmp, W_ARMH)) == 0) {
+				pline("%s waves.", Monnam(mtmp));
+			} else if (otmp->cursed && !is_weldproof_mon(mtmp)) {
+				pline("%s grasps %s %s but can't remove it.", Monnam(mtmp),
+					  mhis(mtmp), term);
+				otmp->bknown = 1;
+			} else {
+				pline("%s tips %s %s in response.", Monnam(mtmp),
+					  mhis(mtmp), term);
+			}
+		} else if (vismon && humanoid(mtmp->data)) {
+			static const char *const reaction[3] = {
+				"curses", "gestures rudely", "gestures offensively",
+			};
+			int which = rn2(3);
+			int twice = (rn2(3) || which > 0) ? 0 : rn1(2, 1);
+			pline("%s %s%s%s at you...", Monnam(mtmp), reaction[which],
+				  twice ? " and " : "", twice ? reaction[twice] : "");
+		} else if (distu(x, y) <= 2 && domonnoise(mtmp, TRUE)) {
+			if (!vismon)
+				map_invisible(x, y);
+		} else if (vismon) {
+			pline("%s doesn't respond.", Monnam(mtmp));
+		} else {
+nada:
+			pline("%s", nothing_happens);
+		}
+	}
+#undef can_respond
+	return res;
+}
+
+
+/*pickup.c*/

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3410,7 +3410,7 @@ tipmonster:
 					pline("%s accepts before you can change your mind.", Monnam(mtmp));
 				else
 					pline("%s greedily accepts.", Monnam(mtmp));
-				int cash = rnd(10);
+				int cash = min(u.ugold, rnd(10));
 				u.ugold -= cash;
 				mtmp->mgold += cash;
 				mtmp->mpeaceful = TRUE;
@@ -3642,7 +3642,7 @@ tiphat()
 		}
 		mtmp = m_at(x, y);
 		vismon = (mtmp && canseemon(mtmp));
-		if (vismon || (range == 1 && mtmp && can_respond(mtmp) && (x == mtmp->mx || y == mtmp->my) && !is_silent(mtmp->data)))
+		if (vismon || (range == 1 && mtmp && can_respond(mtmp) && x == mtmp->mx && y == mtmp->my && !is_silent(mtmp->data)))
 			break;
 	}
 	


### PR DESCRIPTION
* Can tip uarmh if it's not welded to you for a response back. Peacefuls without hats wave, peacefuls with a hat they can't tip (cursed) try and fail to tip it at you, peacefuls with a hat tip it back. Hostiles will generally curse at you, unless they're invisible, in which case they're giving their current chat msg.

* Can tip a rothe to wake it up, but knocking it over. 
* Can tip a shk to offer them gold. 
* Tip a leprechaun to bribe them to go somewhere else, pacifying them.
* Tip a migo philosopher to offer them a penny for their thoughts. 
* Tipping a mercenary will prompt to throw gold if you want to bribe.
