### PR TITLE
Specify while-blind name of objects

### DIFF
--- a/include/objclass.h
+++ b/include/objclass.h
@@ -61,9 +61,13 @@ struct objclass {
 
 #define	UPPER_TORSO_DR 0x01 /* body armor, shirt, cloak (2x weight) */
 #define	LOWER_TORSO_DR 0x02 /* body armor, cloak (2x weight) */
-#define	HEAD_DR        0x04 /* helmet, cloak */
+#define	HEAD_DR        0x04 /* helmet */
 #define	LEG_DR         0x08 /* boots, cloak */
 #define	ARM_DR         0x10 /* gloves */
+
+#define TORSO_DR       (UPPER_TORSO_DR|LOWER_TORSO_DR)
+#define CLOAK_DR       (UPPER_TORSO_DR|LOWER_TORSO_DR|LEG_DR)
+#define ALL_DR         (UPPER_TORSO_DR|LOWER_TORSO_DR|HEAD_DR|LEG_DR|ARM_DR)
 
 	/*Bitfield(oc_subtyp,3);*/	/* Now too big for a bitfield... see below */
 

--- a/include/objclass.h
+++ b/include/objclass.h
@@ -49,7 +49,7 @@ struct objclass {
 #define oc_bulky	oc_size==MZ_HUGE	/* for armor */
 	Bitfield(oc_tough,1);	/* hard gems/rings */
 
-	Bitfield(oc_dir,4);
+	Bitfield(oc_dir,5);
 #define NODIR		1	/* for wands/spells: non-directional */
 #define IMMEDIATE	2	/*		     directional */
 #define RAY		3	/*		     zap beams */
@@ -58,6 +58,12 @@ struct objclass {
 #define PIERCE		2	/* for weapons & tools used as weapons */
 #define SLASH		4	/* (latter includes iron ball & chain) */
 #define EXPLOSION	8	/* (rockets,  grenades) */
+
+#define	UPPER_TORSO_DR 0x01 /* body armor, shirt, cloak (2x weight) */
+#define	LOWER_TORSO_DR 0x02 /* body armor, cloak (2x weight) */
+#define	HEAD_DR        0x04 /* helmet, cloak */
+#define	LEG_DR         0x08 /* boots, cloak */
+#define	ARM_DR         0x10 /* gloves */
 
 	/*Bitfield(oc_subtyp,3);*/	/* Now too big for a bitfield... see below */
 

--- a/include/objclass.h
+++ b/include/objclass.h
@@ -175,7 +175,8 @@ struct objclass {
 
 struct objdescr {
 	const char *oc_name;		/* actual name */
-	const char *oc_descr;		/* description when name unknown */
+	const char *oc_descr;		/* description when oclass name unknown */
+	const char *oc_blindname;	/* appearence when object !dknown */
 };
 
 struct colorTextClr {
@@ -265,4 +266,5 @@ struct fruit {
 
 #define OBJ_NAME(obj)  (obj_descr[(obj).oc_name_idx].oc_name)
 #define OBJ_DESCR(obj) (obj_descr[(obj).oc_descr_idx].oc_descr)
+#define OBJ_BLINDNAME(obj) (obj_descr[(obj).oc_descr_idx].oc_blindname)
 #endif /* OBJCLASS_H */

--- a/include/you.h
+++ b/include/you.h
@@ -475,11 +475,6 @@ struct you {
 	schar	uacinc;			/* bonus AC (not spell/divine) */
 	schar	uac;
 	schar	udr;
-#define	UPPER_TORSO_DR	0
-#define	LOWER_TORSO_DR	1
-#define	HEAD_DR			2
-#define	LEG_DR			3
-#define	ARM_DR			4
 	uchar	uspellprot;		/* protection by SPE_PROTECTION */
 	uchar	udrunken;		/* drunkeness level (based on total number of potions of booze drunk) */
 	uchar	usptime;		/* #moves until uspellprot-- */

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2463,18 +2463,28 @@ find_dr()
 #endif /* OVL0 */
 #ifdef OVLB
 
+/* Calculates your DR for a slot 
+ * Does not randomize values >10 (must be done elsewhere)
+ * 
+ * Includes effectiveness vs magr (optional)
+ */
 int
 slot_udr(slot, magr)
 int slot;
 struct monst *magr;
 {
-	int udr;
-	int nat_udr;
+	/* DR addition: bas + sqrt(nat^2 + arm^2) */
+	int bas_udr; /* base DR:    magical-ish   */
+	int nat_udr; /* natural DR: (poly)form    */
+	int arm_udr; /* armor DR:   worn armor    */
+
+	bas_udr = base_udr();
+	nat_udr = base_nat_udr();
+	arm_udr = 0;
+
+	/* for use vs specific magr */
 	int agralign = 0;
 	int agrmoral = 0;
-	int armdr = 0;
-	int clkdr = 0;
-	
 	if(magr){
 		agralign = (magr == &youmonst) ? sgn(u.ualign.type) : sgn(magr->data->maligntyp);
 		
@@ -2491,141 +2501,81 @@ struct monst *magr;
 		}
 	}
 	
-	udr = base_udr();
-	nat_udr = base_nat_udr();
-	
-	if (uarmc){
-		clkdr += arm_dr_bonus(uarmc);
-		if(magr) clkdr += properties_dr(uarmc, agralign, agrmoral);
-	} else if(uwep && uwep->oartifact == ART_TENSA_ZANGETSU){
-		clkdr += max( 1 + (uwep->spe+1)/2,0);
+	/* some slots may be unacceptable and must be replaced */
+	if (magr && magr->mtyp == PM_XAN)
+		slot = LEG_DR;
+	if (slot == HEAD_DR && !has_head_mon(&youmonst))
+		slot = UPPER_TORSO_DR;
+	if (slot == LEG_DR && !can_wear_boots(youracedata))
+		slot = LOWER_TORSO_DR;
+	if (slot == ARM_DR && !can_wear_gloves(youracedata))
+		slot = UPPER_TORSO_DR;
+
+	/* DR of worn armor */
+	struct obj * uarmor[] = { uarm, uarmc, uarmf, uarmh, uarmg, uarms, uarmu };
+	int i;
+	for (i = 0; i < SIZE(uarmor); i++) {
+		if (uarmor[i] && (objects[uarmor[i]->otyp].oc_dir & slot)) {
+			arm_udr += arm_dr_bonus(uarmor[i]);
+			if (magr) arm_udr += properties_dr(uarmor[i], agralign, agrmoral);
+		}
 	}
-	
-	if(uarmu && uarmu->otyp == BODYGLOVE){
-		armdr += arm_dr_bonus(uarmu);
-		if(magr) armdr += properties_dr(uarmu, agralign, agrmoral);
+	/* Tensa Zangetsu adds to worn armor */
+	if (uwep && uwep->oartifact == ART_TENSA_ZANGETSU) {
+		if (!uarmc && (slot & CLOAK_DR)) {
+			arm_udr += max(1 + (uwep->spe + 1) / 2, 0);
+		}
+		if (!uarm && (slot & TORSO_DR)) {
+			arm_udr += max(1 + (uwep->spe + 1) / 2, 0);
+		}
 	}
-	if(uarm && uarm->otyp == JUMPSUIT){
-		armdr += arm_dr_bonus(uarm);
-		if(magr) armdr += properties_dr(uarm, agralign, agrmoral);
+	/* Natural DR (overriden and ignored by base_nat_udr() for halfdragons) */
+	if (!Race_if(PM_HALF_DRAGON)) {
+		switch (slot)
+		{
+		case UPPER_TORSO_DR: nat_udr += youracedata->bdr; break;
+		case LOWER_TORSO_DR: nat_udr += youracedata->ldr; break;
+		case HEAD_DR:        nat_udr += youracedata->hdr; break;
+		case LEG_DR:         nat_udr += youracedata->fdr; break;
+		case ARM_DR:         nat_udr += youracedata->gdr; break;
+		}
 	}
-	
-	//Note: Bias this somehow?
-	if(magr && magr->mtyp == PM_XAN)
-		goto boot_hit;
-	switch(slot){
-		case UPPER_TORSO_DR:
-uppertorso:
-			//Note: upper body (shirt plus torso armor)
-			if(!Race_if(PM_HALF_DRAGON))
-				nat_udr += youracedata->bdr;
-			if (uarmu){
-				if(uarmu->otyp != BODYGLOVE){
-					armdr += arm_dr_bonus(uarmu);
-					if(magr) armdr += properties_dr(uarmu, agralign, agrmoral);
-				}
-			}
-			udr += (u.uvaul+3)/5;
-			//Note: SHOULD fall-through here to add the torso armor bonus
-		case LOWER_TORSO_DR:
-lowertorso:
-			//Note: lower body (torso armor only)
-			if (uarm){
-				if(uarm->otyp != JUMPSUIT){
-					armdr += arm_dr_bonus(uarm);
-					if(magr) armdr += properties_dr(uarm, agralign, agrmoral);
-				}
-			} else if(uwep && uwep->oartifact == ART_TENSA_ZANGETSU){
-				armdr += max( 1 + (uwep->spe+1)/2,0);
-			}
-			//Lower body SPECIFIC modifiers
-			if (slot == LOWER_TORSO_DR){
-				if(!Race_if(PM_HALF_DRAGON))
-					nat_udr += youracedata->ldr;
-				if(uarmu && (uarmu->otyp == BLACK_DRESS || uarmu->otyp == VICTORIAN_UNDERWEAR)){
-					armdr += arm_dr_bonus(uarmu);
-					if(magr) armdr += properties_dr(uarmu, agralign, agrmoral);
-				}
-				udr += (u.uvaul+1)/5;
-			}
-			armdr += clkdr;
-		break;
-		case HEAD_DR:
-			if(!has_head_mon(&youmonst)){
-				slot = UPPER_TORSO_DR;
-				goto uppertorso;
-			}
-			if(!Race_if(PM_HALF_DRAGON))
-				nat_udr += youracedata->hdr;
-			if (uarmh){
-				armdr += arm_dr_bonus(uarmh);
-				if(magr) armdr += properties_dr(uarmh, agralign, agrmoral);
-			}
-			if((uright && uright->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN) || (uleft && uleft->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN)){
-				udr += 3;
-			}
-			udr += (u.uvaul+4)/5;
-			armdr += clkdr;
-		break;
-		case LEG_DR:
-boot_hit:
-			if(!can_wear_boots(youracedata)){
-				slot = LOWER_TORSO_DR;
-				goto lowertorso;
-			}
-			if(!Race_if(PM_HALF_DRAGON))
-				nat_udr += youracedata->fdr;
-			if (uarmf){
-				armdr += arm_dr_bonus(uarmf);
-				if(magr) armdr += properties_dr(uarmf, agralign, agrmoral);
-			} else if(uwep && uwep->oartifact == ART_TENSA_ZANGETSU){
-				armdr += max( 1 + (uwep->spe+1)/2,0);
-			}
-			udr += (u.uvaul)/5;
-			armdr += clkdr;
-		break;
-		case ARM_DR:
-			if(!can_wear_gloves(youracedata)){
-				slot = UPPER_TORSO_DR;
-				goto uppertorso;
-			}
-			if(!Race_if(PM_HALF_DRAGON))
-				nat_udr += youracedata->gdr;
-			if (uarmg){
-				armdr += arm_dr_bonus(uarmg);
-				if(magr) armdr += properties_dr(uarmg, agralign, agrmoral);
-			} else if(uwep && uwep->oartifact == ART_TENSA_ZANGETSU){
-				armdr += max( 1 + (uwep->spe+1)/2,0);
-			}
-			if((uright && uright->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN) || (uleft && uleft->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN)){
-				udr += 3;
-			}
-			udr += (u.uvaul+2)/5;
-		break;
+	/* Wearing the Shard from Morgoth's Crown adds +3 magical DR to arms and head (in addition to its +3 to all slots) */
+	if (((uright && uright->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN) || (uleft && uleft->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN))
+		&& (slot & (ARM_DR | HEAD_DR))) {
+		bas_udr += 3;
 	}
-	
-	
-	// if(u.ustdy && armdr>0){
-		// armdr -= u.ustdy;
-		// if(armdr<0)
-			// armdr = 0;
-	// }
-	
-	if(armdr && nat_udr){
-		/* Assumes that dr values can't be negative */
-		udr += (int)sqrt(nat_udr*nat_udr + armdr*armdr);
-	} else if(nat_udr){
-		udr += nat_udr;
-	} else {
-		udr += armdr;
+	/* Vaul is not randomized, and contributes to magical DR */
+	if (u.uvaul) {
+		int offset;
+		switch (slot)
+		{
+		case UPPER_TORSO_DR: offset = 3; break;
+		case LOWER_TORSO_DR: offset = 1; break;
+		case HEAD_DR:        offset = 4; break;
+		case LEG_DR:         offset = 0; break;
+		case ARM_DR:         offset = 2; break;
+		}
+		bas_udr += ((u.uvaul + offset) / 5);
 	}
+	/* Having the Deep Sea glyph increase magical DR by 3 */
+	if (active_glyph(DEEP_SEA))
+		bas_udr += 3;
+
+	/* Combine into total */
+	int total_dr = bas_udr;
+	if(arm_udr >= 0 && nat_udr >= 0) {
+		total_dr += (int)sqrt(nat_udr*nat_udr + arm_udr*arm_udr);
+	}
+	else {
+		total_dr += nat_udr + arm_udr;
+	}
+
+	/* cap at 127 (u.udr is an schar) */
+	if (total_dr > 127)
+		total_dr = 127;
 	
-	if(active_glyph(DEEP_SEA))
-		udr += 3;
-	
-	if (udr > 127) udr = 127;	/* u.uac is an schar */
-	
-	return udr;
+	return total_dr;
 }
 
 int

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -511,11 +511,6 @@ register struct obj *otmp;
 #endif /* OVL1 */
 #ifdef OVLB
 
-static const char dknowns[] = {
-		WAND_CLASS, RING_CLASS, POTION_CLASS, SCROLL_CLASS,
-		GEM_CLASS, SPBOOK_CLASS, WEAPON_CLASS, TOOL_CLASS, 0
-};
-
 struct obj *
 mksobj(otyp, init, artif)
 int otyp;
@@ -535,7 +530,7 @@ boolean artif;
 	otmp->oclass = let;
 	otmp->otyp = otyp;
 	otmp->where = OBJ_FREE;
-	otmp->dknown = index(dknowns, let) ? 0 : 1;
+	otmp->dknown = 0;
 	otmp->corpsenm = 0; /* BUGFIX: Where does this get set? shouldn't it be given a default during initialization? */
 	otmp->objsize = MZ_MEDIUM;
 	otmp->bodytypeflag = MB_HUMANOID;

--- a/src/objects.c
+++ b/src/objects.c
@@ -598,13 +598,13 @@ BOW("atlatl", "notched stick",                      0, MZ_MEDIUM,  0, 12,  30,  
 		{0}, {0}, 10 - ac, can, dr, wt, c, __VA_ARGS__ )
 
 #define SUIT(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, UPPER_TORSO_DR|LOWER_TORSO_DR, ARM_SUIT, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, TORSO_DR, ARM_SUIT, metal, c, __VA_ARGS__)
 #define SHIRT(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
 	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, UPPER_TORSO_DR, ARM_SHIRT, metal, c, __VA_ARGS__)
 #define HELM(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
 	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, HEAD_DR, ARM_HELM, metal, c, __VA_ARGS__)
 #define CLOAK(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_MEDIUM, power, prob, delay, wt, cost, ac, dr, can, HEAD_DR|UPPER_TORSO_DR|LOWER_TORSO_DR|LEG_DR, ARM_CLOAK, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, MZ_MEDIUM, power, prob, delay, wt, cost, ac, dr, can, CLOAK_DR, ARM_CLOAK, metal, c, __VA_ARGS__)
 #define SHIELD(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
 	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, 0, ARM_SHIELD, metal, c, __VA_ARGS__)
 #define GLOVES(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
@@ -717,7 +717,7 @@ SUIT("elven toga", (char *)0, /*Needs encyc entry*//*Needs tile*/
 SUIT("noble's dress", "armored black dress", /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 40, 2000,  6, 4, 3, SHADOWSTEEL, CLR_BLACK),
 SHIRT("black dress", (char *)0, /*Needs encyc entry*/
-	1, 0,   MZ_HUGE, 0,	0, 5,  5,  500, 10, 0, 2, CLOTH, CLR_BLACK),
+	1, 0,   MZ_HUGE, 0,	0, 5,  5,  500, 10, 0, 2, CLOTH, CLR_BLACK, O_DRSLOT(TORSO_DR)),
 SUIT("consort's suit", "loud foppish suit", /*Needs encyc entry*//*Needs tile*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 10, 	1000, 10, 1, 1, CLOTH, CLR_BRIGHT_MAGENTA),
 SUIT("gentleman's suit", "expensive clothes", /*Needs encyc entry*/
@@ -797,12 +797,13 @@ SHIRT("striped shirt", (char *)0, /*Needs encyc entry*/
 SHIRT("ruffled shirt", (char *)0, /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 /* victorian underwear, on the other hand, inflicts a penalty to AC but grants MC 3 */
+/* needs special case to be 'bulky' */
 SHIRT("victorian underwear", "white dress",
-	0, 0, MZ_MEDIUM, 		  0,	 0, 5,	 5,   10, 10, 2, 3, CLOTH, CLR_WHITE),	/* needs special case to be 'bulky' */
+	0, 0, MZ_MEDIUM, 		  0,	 0, 5,	 5,   10, 10, 2, 3, CLOTH, CLR_WHITE,  O_DRSLOT(TORSO_DR)),
 SUIT("jumpsuit", "silvery clothes",/*Needs encyc entry*//*Needs tile*/
-	0, 0, MZ_HUGE, REFLECTING,	 0, 5,	 5, 1000, 10, 1, 3, PLASTIC, HI_SILVER),
+	0, 0, MZ_HUGE, REFLECTING,	 0, 5,	 5, 1000, 10, 1, 3, PLASTIC, HI_SILVER, O_DRSLOT(ALL_DR)),
 SHIRT("bodyglove", "tight black clothes", /*Needs encyc entry*//*Needs tile*/
-	0, 0, MZ_HUGE, SICK_RES,	 0, 5,	 5, 1000, 10, 0, 3, PLASTIC, CLR_BLACK),
+	0, 0, MZ_HUGE, SICK_RES,	 0, 5,	 5, 1000, 10, 0, 3, PLASTIC, CLR_BLACK, O_DRSLOT(ALL_DR)),
 /* cloaks */
 /*  'cope' is not a spelling mistake... leave it be */
 CLOAK("mummy wrapping", (char *)0,
@@ -814,17 +815,17 @@ CLOAK("droven cloak", "cobwebbed cloak", /*Needs encyc entry*/
 CLOAK("orcish cloak", "coarse mantelet",
 		0, 0,	0,	    8, 0, 10, 40, 10, 0, 2, CLOTH, CLR_BLACK),
 CLOAK("dwarvish cloak", "hooded cloak",
-		0, 0,	0,	    8, 0, 10, 50,10, 1, 2, CLOTH, CLR_BLUE),
+		0, 0,	0,	    8, 0, 10, 50,10, 1, 2, CLOTH, CLR_BLUE, O_DRSLOT(HEAD_DR|CLOAK_DR)),
 CLOAK("oilskin cloak", "slippery cloak",
 		0, 0,	0,	    8, 0, 10, 50,  9, 0, 3, CLOTH, HI_CLOTH),
 CLOAK("robe", (char *)0,
 		1, 1,	0,	    3, 0, 15, 50, 10, 2, 3, CLOTH, CLR_RED),
 CLOAK("white faceless robe", (char *)0,
-		1, 1,	0,	    0, 2, 20, 50, 10, 1, 3, CLOTH, CLR_WHITE),
+		1, 1,	0,	    0, 2, 20, 50, 10, 1, 3, CLOTH, CLR_WHITE, O_DRSLOT(HEAD_DR|CLOAK_DR)),
 CLOAK("black faceless robe", (char *)0,
-		1, 1,	COLD_RES,	    0, 2, 20, 50, 10, 2, 3, CLOTH, CLR_BLACK),
+		1, 1,	COLD_RES,	    0, 2, 20, 50, 10, 2, 3, CLOTH, CLR_BLACK, O_DRSLOT(HEAD_DR|CLOAK_DR)),
 CLOAK("smoky violet faceless robe", (char *)0,
-		1, 1,	COLD_RES,	    0, 2, 20,500, 10, 3, 3, CLOTH, CLR_MAGENTA),
+		1, 1,	COLD_RES,	    0, 2, 20,500, 10, 3, 3, CLOTH, CLR_MAGENTA, O_DRSLOT(HEAD_DR|CLOAK_DR)),
 CLOAK("alchemy smock", "apron",
 		0, 1,	POISON_RES, 9, 0, 10, 50, 10, 1, 3, CLOTH, CLR_WHITE),
 CLOAK("Leo Nemaeus hide", "lion skin",

--- a/src/objects.c
+++ b/src/objects.c
@@ -13,6 +13,7 @@
 #define O_NOWISH(x)		C08(x)
 #define O_SIZE(x)		C09(x)
 #define O_SKILL(x)		C11(x)
+#define O_DRSLOT(x)		C11(x)
 #define O_MAT(x)		C12(x)
 #define O_MATSPEC(x)	C13(x)
 #define O_DTYPE(x)		C14(x)
@@ -590,21 +591,26 @@ BOW("atlatl", "notched stick",                      0, MZ_MEDIUM,  0, 12,  30,  
  * Only COPPER (including brass) corrodes.
  * Some creatures are vulnerable to SILVER.
  */
-#define ARMOR(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,sub,metal,c,...) \
+#define ARMOR(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,drslot,sub,metal,c,...) \
 	OBJECT( \
-		OBJ(name,desc), BITS(kn,0,1,0,mgc,1,0,0,size,0,0,sub,metal,0), power, \
+		OBJ(name,desc), BITS(kn,0,1,0,mgc,1,0,0,size,0,drslot,sub,metal,0), power, \
 		ARMOR_CLASS, prob, delay, wt, cost, \
 		{0}, {0}, 10 - ac, can, dr, wt, c, __VA_ARGS__ )
+
+#define SUIT(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, UPPER_TORSO_DR|LOWER_TORSO_DR, ARM_SUIT, metal, c, __VA_ARGS__)
+#define SHIRT(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, UPPER_TORSO_DR, ARM_SHIRT, metal, c, __VA_ARGS__)
 #define HELM(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, ARM_HELM, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, HEAD_DR, ARM_HELM, metal, c, __VA_ARGS__)
 #define CLOAK(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_MEDIUM, power, prob, delay, wt, cost, ac, dr, can, ARM_CLOAK, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, MZ_MEDIUM, power, prob, delay, wt, cost, ac, dr, can, HEAD_DR|UPPER_TORSO_DR|LOWER_TORSO_DR|LEG_DR, ARM_CLOAK, metal, c, __VA_ARGS__)
 #define SHIELD(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, ARM_SHIELD, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, 0, ARM_SHIELD, metal, c, __VA_ARGS__)
 #define GLOVES(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, ARM_GLOVES, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, ARM_DR, ARM_GLOVES, metal, c, __VA_ARGS__)
 #define BOOTS(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, ARM_BOOTS, metal, c, __VA_ARGS__)
+	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, LEG_DR, ARM_BOOTS, metal, c, __VA_ARGS__)
 
 /* helmets */
 HELM("sedge hat", "wide conical hat", /*Needs encyc entry*//*Needs tile*/
@@ -671,7 +677,7 @@ HELM("helm of drain resistance", "band", /*diadem of drain resistance*//*Needs t
  *	    the same defined in monst.c.
  */
 #define DRGN_ARMR(name,mgc,power,cost,ac,dr,color,...) \
-	ARMOR(name,(char *)0,1,mgc,MZ_HUGE,power,0,5,150,cost,ac,dr,0,ARM_SUIT,DRAGON_HIDE,color,__VA_ARGS__)
+	SUIT(name,(char *)0,1,mgc,MZ_HUGE,power,0,5,150,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
 /* 3.4.1: dragon scale mail reclassified as "magic" since magic is
    needed to create them */
 DRGN_ARMR("gray dragon scale mail",   1, ANTIMAGIC,  1200, 5, 4, CLR_GRAY),
@@ -700,103 +706,103 @@ DRGN_ARMR("green dragon scales",  0, POISON_RES, 500, 9, 2, CLR_GREEN),
 DRGN_ARMR("yellow dragon scales", 0, ACID_RES,   500, 9, 2, CLR_YELLOW),
 #undef DRGN_ARMR
 
-ARMOR("plate mail", (char *)0, /*Needs encyc entry*/
-	1, 0,   MZ_HUGE, 0,	44, 5, 225, 600,  5, 5, 3, ARM_SUIT, IRON, HI_METAL),
-ARMOR("high-elven plate", "runed plate mail", /*Needs encyc entry*/
-	0, 0,   MZ_HUGE, 0,	0, 5, 110, 	1200,  4, 6, 3, ARM_SUIT, MITHRIL, HI_MITHRIL),
-ARMOR("droven plate mail", "crested black plate", /*Needs encyc entry*/
-	0, 0,   MZ_HUGE, 0,	0, 5, 85, 	2000,  4, 6, 1, ARM_SUIT, SHADOWSTEEL, CLR_BLACK),
-ARMOR("elven toga", (char *)0, /*Needs encyc entry*//*Needs tile*/
-	1, 0,  MZ_LARGE, 0,	 0, 5,	 5,  100,10, 1, 2, ARM_SUIT, CLOTH, CLR_GREEN),
-ARMOR("noble's dress", "armored black dress", /*Needs encyc entry*/
-	0, 0,   MZ_HUGE, 0,	0, 5, 40, 2000,  6, 4, 3, ARM_SUIT, SHADOWSTEEL, CLR_BLACK),
-ARMOR("black dress", (char *)0, /*Needs encyc entry*/
-	1, 0,   MZ_HUGE, 0,	0, 5,  5,  500, 10, 0, 2, ARM_SHIRT, CLOTH, CLR_BLACK),
-ARMOR("consort's suit", "loud foppish suit", /*Needs encyc entry*//*Needs tile*/
-	0, 0,   MZ_HUGE, 0,	0, 5, 10, 	1000, 10, 1, 1, ARM_SUIT, CLOTH, CLR_BRIGHT_MAGENTA),
-ARMOR("gentleman's suit", "expensive clothes", /*Needs encyc entry*/
-	0, 0,   MZ_HUGE, 0,	0, 5, 10, 1000,  10, 1, 2, ARM_SUIT, CLOTH, CLR_BLACK),
-ARMOR("gentlewoman's dress", "expensive dress", /*Needs encyc entry*/
-	0, 0,   MZ_HUGE, 0,	0, 6,100, 1000,  10, 1, 3, ARM_SUIT, BONE, CLR_RED), /*Specifically, whale bone*/
-ARMOR("crystal plate mail", (char *)0, /*Needs encyc entry*/
-	1, 0,   MZ_HUGE, 0,	10, 5, 170, 2000,  7, 3, 0, ARM_SUIT, GLASS, HI_GLASS), /*Best armor, AC wise*/
+SUIT("plate mail", (char *)0, /*Needs encyc entry*/
+	1, 0,   MZ_HUGE, 0,	44, 5, 225, 600,  5, 5, 3, IRON, HI_METAL),
+SUIT("high-elven plate", "runed plate mail", /*Needs encyc entry*/
+	0, 0,   MZ_HUGE, 0,	0, 5, 110, 	1200,  4, 6, 3, MITHRIL, HI_MITHRIL),
+SUIT("droven plate mail", "crested black plate", /*Needs encyc entry*/
+	0, 0,   MZ_HUGE, 0,	0, 5, 85, 	2000,  4, 6, 1, SHADOWSTEEL, CLR_BLACK),
+SUIT("elven toga", (char *)0, /*Needs encyc entry*//*Needs tile*/
+	1, 0,  MZ_LARGE, 0,	 0, 5,	 5,  100,10, 1, 2, CLOTH, CLR_GREEN),
+SUIT("noble's dress", "armored black dress", /*Needs encyc entry*/
+	0, 0,   MZ_HUGE, 0,	0, 5, 40, 2000,  6, 4, 3, SHADOWSTEEL, CLR_BLACK),
+SHIRT("black dress", (char *)0, /*Needs encyc entry*/
+	1, 0,   MZ_HUGE, 0,	0, 5,  5,  500, 10, 0, 2, CLOTH, CLR_BLACK),
+SUIT("consort's suit", "loud foppish suit", /*Needs encyc entry*//*Needs tile*/
+	0, 0,   MZ_HUGE, 0,	0, 5, 10, 	1000, 10, 1, 1, CLOTH, CLR_BRIGHT_MAGENTA),
+SUIT("gentleman's suit", "expensive clothes", /*Needs encyc entry*/
+	0, 0,   MZ_HUGE, 0,	0, 5, 10, 1000,  10, 1, 2, CLOTH, CLR_BLACK),
+SUIT("gentlewoman's dress", "expensive dress", /*Needs encyc entry*/
+	0, 0,   MZ_HUGE, 0,	0, 6,100, 1000,  10, 1, 3, BONE, CLR_RED), /*Specifically, whale bone*/
+SUIT("crystal plate mail", (char *)0, /*Needs encyc entry*/
+	1, 0,   MZ_HUGE, 0,	10, 5, 170, 2000,  7, 3, 0, GLASS, HI_GLASS), /*Best armor, AC wise*/
 #ifdef TOURIST
-ARMOR("archaic plate mail", (char *)0, /*Needs encyc entry*/
-	1, 0,   MZ_HUGE, 0,	20, 5, 200, 400,  6, 4, 3, ARM_SUIT, COPPER, HI_COPPER),
+SUIT("archaic plate mail", (char *)0, /*Needs encyc entry*/
+	1, 0,   MZ_HUGE, 0,	20, 5, 200, 400,  6, 4, 3, COPPER, HI_COPPER),
 #else
-ARMOR("archaic plate mail", (char *)0,
-	1, 0,   MZ_HUGE, 0,	35, 5, 200, 400,  6, 4, 3, ARM_SUIT, COPPER, HI_COPPER),
+SUIT("archaic plate mail", (char *)0,
+	1, 0,   MZ_HUGE, 0,	35, 5, 200, 400,  6, 4, 3, COPPER, HI_COPPER),
 #endif
-ARMOR("harmonium plate", "red-lacquered bladed armor",
-	0, 0,   MZ_HUGE, 0,	 0, 5, 225,   1,  6, 4, 3, ARM_SUIT, METAL, CLR_RED),
-ARMOR("harmonium scale mail", "red-lacquered spiked scale mail",
-	0, 0,   MZ_HUGE, 0,	 0, 5, 125,   1,  8, 2, 3, ARM_SUIT, METAL, CLR_RED),
-ARMOR("plasteel armor", "hard white armor", /*Needs encyc entry*//*Needs tile*/
-	0, 0,   MZ_HUGE, 0,	 0, 5, 100,  500, 7, 3, 3, ARM_SUIT, PLASTIC, CLR_WHITE),
+SUIT("harmonium plate", "red-lacquered bladed armor",
+	0, 0,   MZ_HUGE, 0,	 0, 5, 225,   1,  6, 4, 3, METAL, CLR_RED),
+SUIT("harmonium scale mail", "red-lacquered spiked scale mail",
+	0, 0,   MZ_HUGE, 0,	 0, 5, 125,   1,  8, 2, 3, METAL, CLR_RED),
+SUIT("plasteel armor", "hard white armor", /*Needs encyc entry*//*Needs tile*/
+	0, 0,   MZ_HUGE, 0,	 0, 5, 100,  500, 7, 3, 3, PLASTIC, CLR_WHITE),
 // ARMOR("force armor", "gemstone-adorned clothing",
 	// 0, 0, 1, 0,	 0, 5,  50, 1000, 9, 3, ARM_SUIT, GEMSTONE, CLR_BRIGHT_GREEN),
-ARMOR("splint mail", (char *)0,
-	1, 0,   MZ_HUGE, 0,	62, 5, 200,  80,  7, 3, 1, ARM_SUIT, IRON, HI_METAL),
-ARMOR("barnacle armor", "giant shell armor",
-	0, 1,  MZ_LARGE, 0,	0, 10, 150, 1000,  7, 3, 1, ARM_SUIT, SHELL_MAT, CLR_GRAY),
-ARMOR("banded mail", (char *)0,
-	1, 0,   MZ_HUGE, 0,	72, 5, 175,  90,  7, 3, 0, ARM_SUIT, IRON, HI_METAL),
-ARMOR("dwarvish mithril-coat", (char *)0,
-	1, 0, MZ_MEDIUM, 0,	10, 1,  40, 240,   7, 3, 3, ARM_SUIT, MITHRIL, HI_MITHRIL),
-ARMOR("elven mithril-coat", (char *)0,
-	1, 0, MZ_MEDIUM, 0,	15, 1,  20, 240,  7, 2, 3, ARM_SUIT, MITHRIL, HI_MITHRIL),
-ARMOR("chain mail", (char *)0,
-	1, 0,  MZ_LARGE, 0,	72, 5, 150,  75,  8, 3, 1, ARM_SUIT, IRON, HI_METAL),
-ARMOR("droven chain mail", "crested black mail", /*Needs encyc entry*/
-	0, 0,  MZ_LARGE, 0,	0, 5,   50,  1000,  8, 4, 2, ARM_SUIT, SHADOWSTEEL, CLR_BLACK),
-ARMOR("orcish chain mail", "crude chain mail",
-	0, 0,  MZ_LARGE, 0,	20, 5, 150,  75,  8, 2, 1, ARM_SUIT, IRON, CLR_BLACK),
-ARMOR("scale mail", (char *)0,
-	1, 0,  MZ_LARGE, 0,	72, 5, 125,  45,  8, 2, 0, ARM_SUIT, IRON, HI_METAL),
-ARMOR("studded leather armor", (char *)0,
-	1, 0,  MZ_LARGE, 0,	72, 3,  50,  15,  9, 2, 1, ARM_SUIT, LEATHER, HI_LEATHER),
-ARMOR("ring mail", (char *)0,
-	1, 0,  MZ_LARGE, 0,	72, 5, 125, 100,  9, 2, 0, ARM_SUIT, IRON, HI_METAL),
-ARMOR("orcish ring mail", "crude ring mail",
-	0, 0,  MZ_LARGE, 0,	20, 5, 125,  80,  9, 1, 1, ARM_SUIT, IRON, CLR_BLACK),
-ARMOR("leather armor", (char *)0,
-	1, 0,  MZ_LARGE, 0,	82, 3,  40,   5, 10, 2, 0, ARM_SUIT, LEATHER, HI_LEATHER),
+SUIT("splint mail", (char *)0,
+	1, 0,   MZ_HUGE, 0,	62, 5, 200,  80,  7, 3, 1, IRON, HI_METAL),
+SUIT("barnacle armor", "giant shell armor",
+	0, 1,  MZ_LARGE, 0,	0, 10, 150, 1000,  7, 3, 1, SHELL_MAT, CLR_GRAY),
+SUIT("banded mail", (char *)0,
+	1, 0,   MZ_HUGE, 0,	72, 5, 175,  90,  7, 3, 0, IRON, HI_METAL),
+SUIT("dwarvish mithril-coat", (char *)0,
+	1, 0, MZ_MEDIUM, 0,	10, 1,  40, 240,   7, 3, 3, MITHRIL, HI_MITHRIL),
+SUIT("elven mithril-coat", (char *)0,
+	1, 0, MZ_MEDIUM, 0,	15, 1,  20, 240,  7, 2, 3, MITHRIL, HI_MITHRIL),
+SUIT("chain mail", (char *)0,
+	1, 0,  MZ_LARGE, 0,	72, 5, 150,  75,  8, 3, 1, IRON, HI_METAL),
+SUIT("droven chain mail", "crested black mail", /*Needs encyc entry*/
+	0, 0,  MZ_LARGE, 0,	0, 5,   50,  1000,  8, 4, 2, SHADOWSTEEL, CLR_BLACK),
+SUIT("orcish chain mail", "crude chain mail",
+	0, 0,  MZ_LARGE, 0,	20, 5, 150,  75,  8, 2, 1, IRON, CLR_BLACK),
+SUIT("scale mail", (char *)0,
+	1, 0,  MZ_LARGE, 0,	72, 5, 125,  45,  8, 2, 0, IRON, HI_METAL),
+SUIT("studded leather armor", (char *)0,
+	1, 0,  MZ_LARGE, 0,	72, 3,  50,  15,  9, 2, 1, LEATHER, HI_LEATHER),
+SUIT("ring mail", (char *)0,
+	1, 0,  MZ_LARGE, 0,	72, 5, 125, 100,  9, 2, 0, IRON, HI_METAL),
+SUIT("orcish ring mail", "crude ring mail",
+	0, 0,  MZ_LARGE, 0,	20, 5, 125,  80,  9, 1, 1, IRON, CLR_BLACK),
+SUIT("leather armor", (char *)0,
+	1, 0,  MZ_LARGE, 0,	82, 3,  40,   5, 10, 2, 0, LEATHER, HI_LEATHER),
 //ARMOR(name,desc,
    //kn,mgc,blk,power,prob,delay,wt,cost,ac,dr,can,sub,metal,c)
-ARMOR("living armor", "giant sea anemone",
-	0, 1,  MZ_LARGE, 0,	0, 6,  80,  500, 10, 2, 0, ARM_SUIT, FLESH, CLR_ORANGE),
-ARMOR("jacket", (char *)0,
-	1, 0, MZ_MEDIUM, 0,	12, 0,	20,  10, 10, 1, 2, ARM_SUIT, LEATHER, HI_LEATHER, O_MATSPEC(IDED|UNIDED)),
-ARMOR("straitjacket", "long-sleeved jacket", /*Needs encyc entry*//*Needs tile*/
-	0, 0, MZ_MEDIUM, 0,	0, 0,   15,  10, 10, 1, 2, ARM_SUIT, CLOTH, CLR_WHITE),
-ARMOR("healer uniform","clean white clothes", /*Needs encyc entry*//*Needs tile*/
-	0, 0, MZ_MEDIUM, SICK_RES,	0, 0,	30,  10, 10, 1, 0, ARM_SUIT, CLOTH, CLR_WHITE),
+SUIT("living armor", "giant sea anemone",
+	0, 1,  MZ_LARGE, 0,	0, 6,  80,  500, 10, 2, 0, FLESH, CLR_ORANGE),
+SUIT("jacket", (char *)0,
+	1, 0, MZ_MEDIUM, 0,	12, 0,	20,  10, 10, 1, 2, LEATHER, HI_LEATHER, O_MATSPEC(IDED|UNIDED)),
+SUIT("straitjacket", "long-sleeved jacket", /*Needs encyc entry*//*Needs tile*/
+	0, 0, MZ_MEDIUM, 0,	0, 0,   15,  10, 10, 1, 2, CLOTH, CLR_WHITE),
+SUIT("healer uniform","clean white clothes", /*Needs encyc entry*//*Needs tile*/
+	0, 0, MZ_MEDIUM, SICK_RES,	0, 0,	30,  10, 10, 1, 0, CLOTH, CLR_WHITE),
 #ifdef TOURIST
 /* shirts */
 /*ARMOR("Hawaiian shorts", "flowery shorts and lei",
 	1, 0, 0, 0,	 0, 0,	 5,   3, 10, 0, ARM_SUIT, CLOTH, CLR_MAGENTA),
 */
-ARMOR("Hawaiian shirt", "flowery shirt",
-	0, 0, MZ_MEDIUM, 0,	 10, 0,	 5,   3, 10, 0, 0, ARM_SHIRT, CLOTH, CLR_MAGENTA),
-ARMOR("T-shirt", (char *)0, /*Needs encyc entry*/
-	1, 0, MZ_MEDIUM, 0,	 5, 0,	 5,   2, 10, 0, 0, ARM_SHIRT, CLOTH, CLR_WHITE),
-ARMOR("ichcahuipilli", "thick undershirt", /*Needs encyc entry*/
-	1, 0, MZ_MEDIUM, 0,	 0, 3,	 10,   2, 10, 0, 0, ARM_SHIRT, CLOTH, CLR_WHITE),
+SHIRT("Hawaiian shirt", "flowery shirt",
+	0, 0, MZ_MEDIUM, 0,	 10, 0,	 5,   3, 10, 0, 0, CLOTH, CLR_MAGENTA),
+SHIRT("T-shirt", (char *)0, /*Needs encyc entry*/
+	1, 0, MZ_MEDIUM, 0,	 5, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
+SHIRT("ichcahuipilli", "thick undershirt", /*Needs encyc entry*/
+	1, 0, MZ_MEDIUM, 0,	 0, 3,	 10,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 # ifdef CONVICT
-ARMOR("striped shirt", (char *)0, /*Needs encyc entry*/
-	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, ARM_SHIRT, CLOTH, CLR_GRAY),
+SHIRT("striped shirt", (char *)0, /*Needs encyc entry*/
+	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_GRAY),
 # endif /* CONVICT */
 #endif
 /*Ruffled shirts are little different from other shirts*/
-ARMOR("ruffled shirt", (char *)0, /*Needs encyc entry*/
-	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, ARM_SHIRT, CLOTH, CLR_WHITE),
+SHIRT("ruffled shirt", (char *)0, /*Needs encyc entry*/
+	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 /* victorian underwear, on the other hand, inflicts a penalty to AC but grants MC 3 */
-ARMOR("victorian underwear", "white dress",
-	0, 0, MZ_MEDIUM, 		  0,	 0, 5,	 5,   10, 10, 2, 3, ARM_SHIRT, CLOTH, CLR_WHITE),	/* needs special case to be 'bulky' */
-ARMOR("jumpsuit", "silvery clothes",/*Needs encyc entry*//*Needs tile*/
-	0, 0, MZ_HUGE, REFLECTING,	 0, 5,	 5, 1000, 10, 1, 3, ARM_SUIT, PLASTIC, HI_SILVER),
-ARMOR("bodyglove", "tight black clothes", /*Needs encyc entry*//*Needs tile*/
-	0, 0, MZ_HUGE, SICK_RES,	 0, 5,	 5, 1000, 10, 0, 3, ARM_SHIRT, PLASTIC, CLR_BLACK),
+SHIRT("victorian underwear", "white dress",
+	0, 0, MZ_MEDIUM, 		  0,	 0, 5,	 5,   10, 10, 2, 3, CLOTH, CLR_WHITE),	/* needs special case to be 'bulky' */
+SUIT("jumpsuit", "silvery clothes",/*Needs encyc entry*//*Needs tile*/
+	0, 0, MZ_HUGE, REFLECTING,	 0, 5,	 5, 1000, 10, 1, 3, PLASTIC, HI_SILVER),
+SHIRT("bodyglove", "tight black clothes", /*Needs encyc entry*//*Needs tile*/
+	0, 0, MZ_HUGE, SICK_RES,	 0, 5,	 5, 1000, 10, 0, 3, PLASTIC, CLR_BLACK),
 /* cloaks */
 /*  'cope' is not a spelling mistake... leave it be */
 CLOAK("mummy wrapping", (char *)0,
@@ -857,7 +863,7 @@ SHIELD("shield of reflection", "polished shield",
 /*#define SHIELD(name,desc,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,metal,c) \
      ARMOR(name,desc,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,ARM_SHIELD,metal,c) */
 #define DRGN_SHIELD(name,mgc,power,cost,ac,dr,color,...)						\
-	ARMOR(name,(char *)0,1,mgc,MZ_LARGE,power,0,0,75,cost,ac,dr,0,ARM_SHIELD,DRAGON_HIDE,color,__VA_ARGS__)
+	SHIELD(name,(char *)0,1,mgc,MZ_LARGE,power,0,0,75,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
 /* 3.4.1: dragon scale mail reclassified as "magic" since magic is
    needed to create them */
 DRGN_SHIELD("gray dragon scale shield", 1, ANTIMAGIC,  1200, 7, 0, CLR_GRAY),
@@ -940,6 +946,8 @@ BOOTS("fumble boots", "riding boots",
 		0, 1,  FUMBLING,  12, 2, 20, 30, 10, 1, 0, LEATHER, HI_LEATHER),
 BOOTS("flying boots", "snow boots",
 		0, 1,  FLYING,12, 2, 15, 30,  9, 1, 0, LEATHER, HI_LEATHER),
+#undef SUIT
+#undef SHIRT
 #undef HELM
 #undef CLOAK
 #undef SHIELD

--- a/src/objects.c
+++ b/src/objects.c
@@ -351,28 +351,28 @@ WEAPON(("katana", "samurai sword"),
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  4, 40, 80,  1, S,   P_LONG_SWORD, IRON, FALSE, HI_METAL),
 /* special swords set up for artifacts and future weapons*/
-WEAPON(("vibroblade", "gray short sword"), /*Needs encyc entry*//*Needs tile*/
+WEAPON(("vibroblade", "gray short sword", "short sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_SMALL,  0,  5,1000, 0, P,   P_SHORT_SWORD, PLASTIC, FALSE, CLR_GRAY),
 WEAPON(("tsurugi", "long samurai sword"),
 	DMG(D(16)), DMG(D(8), D(2,6)),
 	0, 0,   MZ_HUGE,  0, 60,500,  2, S,   P_TWO_HANDED_SWORD, METAL, FALSE, HI_METAL),
-WEAPON(("runesword", "runed black blade"),
+WEAPON(("runesword", "runed black blade", "runed blade"),
 	DMG(D(10), D(4)), DMG(D(10), F(1)),
 	0, 0,  MZ_LARGE,  0, 40,300,  0, S,   P_BROAD_SWORD, IRON, FALSE, CLR_BLACK),
-WEAPON(("white vibrosword", "white sword"), /*Needs encyc entry*//*Needs tile*/
+WEAPON(("white vibrosword", "white sword", "long sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  0, 40,8000, 1, P|S, P_LONG_SWORD,  SILVER, FALSE, CLR_WHITE),
-WEAPON(("gold-bladed vibrosword", "black and gold sword"), /*Needs encyc entry*//*Needs tile*/
+WEAPON(("gold-bladed vibrosword", "black and gold sword", "long sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  0, 53,8000, 1, P|S, P_LONG_SWORD,    GOLD, FALSE, CLR_BLACK),
-WEAPON(("red-eyed vibrosword", "blue-glowing sword"), /*Needs encyc entry*//*Needs tile*/
+WEAPON(("red-eyed vibrosword", "blue-glowing sword", "long sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  0, 10,8000, 1, P|S, P_LONG_SWORD, PLASTIC, FALSE, CLR_GRAY),
-WEAPON(("white vibrozanbato", "curved white sword"),
+WEAPON(("white vibrozanbato", "curved white sword", "long curved sword"),
 	DMG(D(16)), DMG(D(8), D(2,6)),
 	0, 0,   MZ_HUGE,  0, 60,16000,2, S,   P_TWO_HANDED_SWORD, SILVER, FALSE, CLR_WHITE),
-WEAPON(("gold-bladed vibrozanbato", "curved black and gold sword"),
+WEAPON(("gold-bladed vibrozanbato", "curved black and gold sword", "long curved sword"),
 	DMG(D(16)), DMG(D(8), D(2,6)),
 	0, 0,   MZ_HUGE,  0, 80,16000,2, S,   P_TWO_HANDED_SWORD, GOLD, FALSE, CLR_BLACK),
 
@@ -410,13 +410,13 @@ WEAPON(("naginata", "samurai-sword polearm"),
 WEAPON(("lance"),
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_LARGE,  4, 80, 10,  0, P,   P_LANCE, IRON, FALSE, HI_METAL),
-WEAPON(("force pike", "long gray spear"),/*Needs tile*/
+WEAPON(("force pike", "long gray spear", "long spear"),/*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 30,1000, 2, P|S, P_LANCE, PLASTIC, FALSE, CLR_GRAY),
-WEAPON(("white vibrospear", "long white spear"),/*Needs tile*/
+WEAPON(("white vibrospear", "long white spear", "long spear"),/*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 30,1000, 2, P|S, P_LANCE, PLASTIC, FALSE, CLR_WHITE),
-WEAPON(("gold-bladed vibrospear", "long black and gold spear"),/*Needs tile*/
+WEAPON(("gold-bladed vibrospear", "long black and gold spear", "long spear"),/*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 30,1000, 2, P|S, P_LANCE, GOLD, FALSE, CLR_BLACK),
 WEAPON(("elven lance", "runed lance"), /*Needs encyc entry*//*Needs tile*/
@@ -539,10 +539,10 @@ GUN(("gun", "unfamiliar gun"),                        0,  MZ_MEDIUM, 0,  25,  25
 GUN(("long gun", "unfamiliar long gun"),              0,    MZ_HUGE, 0,  30,  150, 22, -1,  1, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
 GUN(("heavy gun", "unfamiliar heavy gun"),            0,    MZ_HUGE, 0, 100, 2000, 20,  8, -4, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
  /*Needs encyc entry*/
-GUN(("hand blaster", "hard black handmirror"),        0,  MZ_MEDIUM, 0,   2, 1000, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BLACK), /*Needs tile*/
-GUN(("arm blaster",  "hard white bracer"),            0,   MZ_LARGE, 0,   8, 4500, 15,  6,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_WHITE), /*Needs tile*/
-GUN(("mass-shadow pistol",  "rectangular device"),    0,  MZ_MEDIUM, 0,   4, 4500, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_GRAY), /*Needs tile*/
-GUN(("cutting laser","hard tan lozenge"),             0,   MZ_SMALL, 0,   1, 1000,  3, -1,  3,WP_BLASTER, PLASTIC, P_FIREARM, CLR_YELLOW), /*Needs tile*/
+GUN(("hand blaster", "hard black handmirror", "hard handmirror"), 0,  MZ_MEDIUM, 0,   2, 1000, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BLACK), /*Needs tile*/
+GUN(("arm blaster",  "hard white bracer", "hard bracer"),         0,   MZ_LARGE, 0,   8, 4500, 15,  6,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_WHITE), /*Needs tile*/
+GUN(("mass-shadow pistol",  "rectangular device"),                0,  MZ_MEDIUM, 0,   4, 4500, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_GRAY), /*Needs tile*/
+GUN(("cutting laser","hard tan lozenge", "hard lozenge"),         0,   MZ_SMALL, 0,   1, 1000,  3, -1,  3,WP_BLASTER, PLASTIC, P_FIREARM, CLR_YELLOW), /*Needs tile*/
 
 GUN(("raygun", "hard handle ending in glassy disks"), 0,  MZ_MEDIUM, 0,   8, 3000, 15,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BRIGHT_CYAN), /*Needs tile*/
 BULLET(("bullet", "pellet"),
@@ -551,29 +551,29 @@ BULLET(("bullet", "pellet"),
 BULLET(("silver bullet", "silver pellet"),
 	DMG(D(2, 8), F(4)), DMG(D(2, 6), F(4)),
 	0,    MZ_TINY, 0,  1,  15, 0,  WP_BULLET,   P,  SILVER, -P_FIREARM, HI_SILVER),/*Needs tile*/
-BULLET(("shotgun shell", "red tube"),
+BULLET(("shotgun shell", "red tube", "tube"),
 	DMG(D(2, 12), F(4)), DMG(D(2, 6), F(4)),
 	0,    MZ_TINY, 0,  1,  10,10,   WP_SHELL,   S,   METAL, -P_FIREARM, CLR_RED),/*Needs tile*/
-BULLET(("frag grenade", "green spheriod"),
+BULLET(("frag grenade", "green spheroid", "spheroid"),
 	DMG(D(2)), DMG(D(2)),
 	0,   MZ_SMALL, 0,  5, 350, 0, WP_GRENADE,   B,    IRON, -P_FIREARM, CLR_GREEN),/*Needs tile*/
-BULLET(("gas grenade", "lime spheriod"),
+BULLET(("gas grenade", "lime spheroid", "spheroid"),
 	DMG(D(2)), DMG(D(2)),
 	0,   MZ_SMALL, 0,  2, 350, 0, WP_GRENADE,   B,    IRON, -P_FIREARM, CLR_BRIGHT_GREEN),/*Needs tile*/
 BULLET(("rocket", "firework"),
 	DMG(D(2, 12), F(4)), DMG(D(2, 20), F(4)),
 	0,   MZ_SMALL, 0, 20, 450, 0,  WP_ROCKET,   B,  SILVER, -P_FIREARM, CLR_BLUE),/*Needs tile*/
-BULLET(("stick of dynamite", "red stick"),
+BULLET(("stick of dynamite", "red stick", "stick"),
 	DMG(D(1)), DMG(D(1)),
 	0,   MZ_SMALL, 0, 10, 150, 0, WP_GENERIC,   B, PLASTIC,     P_NONE, CLR_RED),/*Needs tile*/
 
-BULLET(("blaster bolt", "ruby bolt"),
+BULLET(("blaster bolt", "ruby bolt", "bolt"),
 	DMG(D(3, 6), F(6)), DMG(D(3, 8), F(8)),
 	0,    MZ_TINY, 0,  1,   0, 0, WP_BLASTER,   E,   METAL, -P_FIREARM, CLR_RED),/*Needs tile*/
-BULLET(("heavy blaster bolt", "scarlet bolt"),
+BULLET(("heavy blaster bolt", "scarlet bolt", "bolt"),
 	DMG(D(3, 10), F(10)), DMG(D(3, 12), F(12)),
 	0,    MZ_TINY, 0,  1,   0, 0, WP_BLASTER,   E,   METAL, -P_FIREARM, CLR_ORANGE),/*Needs tile*/
-BULLET(("laser beam", "green bolt"),
+BULLET(("laser beam", "green bolt", "bolt"),
 	DMG(D(3, 1), F(10)), DMG(D(3, 1), F(10)),
 	0,    MZ_TINY, 0,  1,   0, 0, WP_BLASTER,   E|S, METAL, -P_FIREARM, CLR_BRIGHT_GREEN),/*Needs tile*/
 //endif
@@ -643,11 +643,11 @@ HELM(("dunce cap", "conical hat"),
 		0, 1,  0,	3, 1,  4,   1, 10, 0, 0, CLOTH, CLR_BLUE),
 HELM(("war hat", "wide helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	2, 0, 60,  30, 8, 2, 2, IRON, HI_METAL),
-HELM(("flack helmet", "green bowl"), /*Needs encyc entry*/
+HELM(("flack helmet", "green bowl", "bowl"), /*Needs encyc entry*/
 		0, 0,  0,	0, 0, 10,  50, 9, 2, 1, PLASTIC, CLR_GREEN),
 HELM(("archaic helm", "helmet"),
 		0, 0,  0,   0, 1, 30,  12, 9, 2, 0, COPPER, HI_COPPER),
-HELM(("harmonium helm", "red-lacquered spined helm"),
+HELM(("harmonium helm", "red-lacquered spined helm", "spined helm"),
 		0, 0,  0,   0, 1, 45,   1, 9, 2, 0, METAL, CLR_RED),
 HELM(("elven helm", "runed helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 1, 10,   5, 9, 1, 0, WOOD, HI_WOOD),
@@ -655,13 +655,13 @@ HELM(("high-elven helm", "runed helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 1, 15,   5, 9, 2, 0, MITHRIL, HI_MITHRIL, O_MATSPEC(UNIDED)),
 HELM(("droven helm", "spider-shaped helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 1, 20,   5, 8, 2, 0, SHADOWSTEEL, CLR_BLACK),
-HELM(("plasteel helm", "white skull helm"), /*Needs encyc entry*//*Needs tile*/
+HELM(("plasteel helm", "white skull helm", "skull helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 1,  INFRAVISION,   0, 2, 25,  50, 8, 2, 2, PLASTIC, CLR_WHITE),
 HELM(("crystal helm", "fish bowl"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,   0, 2,150, 300, 9, 1, 0, GLASS, HI_GLASS, O_MATSPEC(UNIDED)),
 HELM(("pontiff's crown", "filigreed faceless helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,   0, 2, 90, 300, 8, 3, 0, GOLD, HI_GOLD, O_MATSPEC(IDED)),
-HELM(("shemagh", "white headscarf"), /*Needs encyc entry*//*Needs tile*/
+HELM(("shemagh", "white headscarf", "headscarf"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 0, 5,   5, 10, 0, 0, CLOTH, CLR_WHITE, O_MATSPEC(UNIDED)),
 
 /* With shuffled appearances... */
@@ -722,15 +722,15 @@ SUIT(("plate mail"), /*Needs encyc entry*/
 	1, 0,   MZ_HUGE, 0,	44, 5, 225, 600,  5, 5, 3, IRON, HI_METAL),
 SUIT(("high-elven plate", "runed plate mail"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 110, 	1200,  4, 6, 3, MITHRIL, HI_MITHRIL),
-SUIT(("droven plate mail", "crested black plate"), /*Needs encyc entry*/
+SUIT(("droven plate mail", "crested black plate", "crested plate mail"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 85, 	2000,  4, 6, 1, SHADOWSTEEL, CLR_BLACK),
 SUIT(("elven toga"), /*Needs encyc entry*//*Needs tile*/
 	1, 0,  MZ_LARGE, 0,	 0, 5,	 5,  100,10, 1, 2, CLOTH, CLR_GREEN),
-SUIT(("noble's dress", "armored black dress"), /*Needs encyc entry*/
+SUIT(("noble's dress", "armored black dress", "armored dress"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 40, 2000,  6, 4, 3, SHADOWSTEEL, CLR_BLACK),
-SHIRT(("black dress"), /*Needs encyc entry*/
+SHIRT(("black dress", (char *)0, "dress"), /*Needs encyc entry*/
 	1, 0,   MZ_HUGE, 0,	0, 5,  5,  500, 10, 0, 2, CLOTH, CLR_BLACK, O_DRSLOT(TORSO_DR)),
-SUIT(("consort's suit", "loud foppish suit"), /*Needs encyc entry*//*Needs tile*/
+SUIT(("consort's suit", "loud foppish suit", "clothes"), /*Needs encyc entry*//*Needs tile*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 10, 	1000, 10, 1, 1, CLOTH, CLR_BRIGHT_MAGENTA),
 SUIT(("gentleman's suit", "expensive clothes"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 10, 1000,  10, 1, 2, CLOTH, CLR_BLACK),
@@ -745,11 +745,11 @@ SUIT(("archaic plate mail"), /*Needs encyc entry*/
 SUIT(("archaic plate mail"),
 	1, 0,   MZ_HUGE, 0,	35, 5, 200, 400,  6, 4, 3, COPPER, HI_COPPER),
 #endif
-SUIT(("harmonium plate", "red-lacquered bladed armor"),
+SUIT(("harmonium plate", "red-lacquered bladed armor", "bladed armor"),
 	0, 0,   MZ_HUGE, 0,	 0, 5, 225,   1,  6, 4, 3, METAL, CLR_RED),
-SUIT(("harmonium scale mail", "red-lacquered spiked scale mail"),
+SUIT(("harmonium scale mail", "red-lacquered spiked scale mail", "spiked scale mail"),
 	0, 0,   MZ_HUGE, 0,	 0, 5, 125,   1,  8, 2, 3, METAL, CLR_RED),
-SUIT(("plasteel armor", "hard white armor"), /*Needs encyc entry*//*Needs tile*/
+SUIT(("plasteel armor", "hard white armor", "armor"), /*Needs encyc entry*//*Needs tile*/
 	0, 0,   MZ_HUGE, 0,	 0, 5, 100,  500, 7, 3, 3, PLASTIC, CLR_WHITE),
 // ARMOR(("force armor", "gemstone-adorned clothing"),
 	// 0, 0, 1, 0,	 0, 5,  50, 1000, 9, 3, ARM_SUIT, GEMSTONE, CLR_BRIGHT_GREEN),
@@ -765,7 +765,7 @@ SUIT(("elven mithril-coat"),
 	1, 0, MZ_MEDIUM, 0,	15, 1,  20, 240,  7, 2, 3, MITHRIL, HI_MITHRIL),
 SUIT(("chain mail"),
 	1, 0,  MZ_LARGE, 0,	72, 5, 150,  75,  8, 3, 1, IRON, HI_METAL),
-SUIT(("droven chain mail", "crested black mail"), /*Needs encyc entry*/
+SUIT(("droven chain mail", "crested black mail", "crested mail"), /*Needs encyc entry*/
 	0, 0,  MZ_LARGE, 0,	0, 5,   50,  1000,  8, 4, 2, SHADOWSTEEL, CLR_BLACK),
 SUIT(("orcish chain mail", "crude chain mail"),
 	0, 0,  MZ_LARGE, 0,	20, 5, 150,  75,  8, 2, 1, IRON, CLR_BLACK),
@@ -787,21 +787,21 @@ SUIT(("jacket"),
 	1, 0, MZ_MEDIUM, 0,	12, 0,	20,  10, 10, 1, 2, LEATHER, HI_LEATHER, O_MATSPEC(IDED|UNIDED)),
 SUIT(("straitjacket", "long-sleeved jacket"), /*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_MEDIUM, 0,	0, 0,   15,  10, 10, 1, 2, CLOTH, CLR_WHITE),
-SUIT(("healer uniform","clean white clothes"), /*Needs encyc entry*//*Needs tile*/
+SUIT(("healer uniform","clean white clothes", "clean clothes"), /*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_MEDIUM, SICK_RES,	0, 0,	30,  10, 10, 1, 0, CLOTH, CLR_WHITE),
 #ifdef TOURIST
 /* shirts */
 /*ARMOR(("Hawaiian shorts", "flowery shorts and lei"),
 	1, 0, 0, 0,	 0, 0,	 5,   3, 10, 0, ARM_SUIT, CLOTH, CLR_MAGENTA),
 */
-SHIRT(("Hawaiian shirt", "flowery shirt"),
+SHIRT(("Hawaiian shirt", "flowery shirt", "shirt"),
 	0, 0, MZ_MEDIUM, 0,	 10, 0,	 5,   3, 10, 0, 0, CLOTH, CLR_MAGENTA),
 SHIRT(("T-shirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 5, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 SHIRT(("ichcahuipilli", "thick undershirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 3,	 10,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 # ifdef CONVICT
-SHIRT(("striped shirt"), /*Needs encyc entry*/
+SHIRT(("striped shirt", (char *)0, "shirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_GRAY),
 # endif /* CONVICT */
 #endif
@@ -810,11 +810,11 @@ SHIRT(("ruffled shirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 /* victorian underwear, on the other hand, inflicts a penalty to AC but grants MC 3 */
 /* needs special case to be 'bulky' */
-SHIRT(("victorian underwear", "white dress"),
+SHIRT(("victorian underwear", "white dress", "dress"),
 	0, 0, MZ_MEDIUM, 		  0,	 0, 5,	 5,   10, 10, 2, 3, CLOTH, CLR_WHITE,  O_DRSLOT(TORSO_DR)),
-SUIT(("jumpsuit", "silvery clothes"),/*Needs encyc entry*//*Needs tile*/
+SUIT(("jumpsuit", "silvery clothes", "clothes"),/*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_HUGE, REFLECTING,	 0, 5,	 5, 1000, 10, 1, 3, PLASTIC, HI_SILVER, O_DRSLOT(ALL_DR)),
-SHIRT(("bodyglove", "tight black clothes"), /*Needs encyc entry*//*Needs tile*/
+SHIRT(("bodyglove", "tight black clothes", "tight clothes"), /*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_HUGE, SICK_RES,	 0, 5,	 5, 1000, 10, 0, 3, PLASTIC, CLR_BLACK, O_DRSLOT(ALL_DR)),
 /* cloaks */
 /*  'cope' is not a spelling mistake... leave it be */
@@ -832,11 +832,11 @@ CLOAK(("oilskin cloak", "slippery cloak"),
 		0, 0,	0,	    8, 0, 10, 50,  9, 0, 3, CLOTH, HI_CLOTH),
 CLOAK(("robe"),
 		1, 1,	0,	    3, 0, 15, 50, 10, 2, 3, CLOTH, CLR_RED),
-CLOAK(("white faceless robe"),
+CLOAK(("white faceless robe", (char *)0, "faceless robe"),
 		1, 1,	0,	    0, 2, 20, 50, 10, 1, 3, CLOTH, CLR_WHITE, O_DRSLOT(HEAD_DR|CLOAK_DR)),
-CLOAK(("black faceless robe"),
+CLOAK(("black faceless robe", (char *)0, "faceless robe"),
 		1, 1,	COLD_RES,	    0, 2, 20, 50, 10, 2, 3, CLOTH, CLR_BLACK, O_DRSLOT(HEAD_DR|CLOAK_DR)),
-CLOAK(("smoky violet faceless robe"),
+CLOAK(("smoky violet faceless robe", (char *)0, "faceless robe"),
 		1, 1,	COLD_RES,	    0, 2, 20,500, 10, 3, 3, CLOTH, CLR_MAGENTA, O_DRSLOT(HEAD_DR|CLOAK_DR)),
 CLOAK(("alchemy smock", "apron"),
 		0, 1,	POISON_RES, 9, 0, 10, 50, 10, 1, 3, CLOTH, CLR_WHITE),
@@ -857,11 +857,11 @@ CLOAK(("cloak of displacement", "piece of cloth"),
 /* shields */
 SHIELD(("buckler"),
 		1, 0,  MZ_SMALL, 0,	     6, 0, 30,	3,  9, 0, 0, WOOD, HI_WOOD),
-SHIELD(("elven shield", "blue and green shield"),
+SHIELD(("elven shield", "blue and green shield", "shield"),
 		0, 0,  MZ_SMALL, 0,	     2, 0, 30,	7,  8, 0, 2, WOOD, CLR_GREEN),
-SHIELD(("Uruk-hai shield", "white-handed shield"),
+SHIELD(("Uruk-hai shield", "white-handed shield", "shield"),
 		0, 0, MZ_MEDIUM, 0,	     2, 0, 50,	7,  8, 0, 1, IRON, HI_METAL),
-SHIELD(("orcish shield", "red-eyed shield"),
+SHIELD(("orcish shield", "red-eyed shield", "shield"),
 		0, 0, MZ_MEDIUM, 0,	     2, 0, 50,	7,  9, 0, 0, IRON, CLR_RED),
 SHIELD(("kite shield"),
 		1, 0,  MZ_LARGE, 0,	     6, 0,100, 10,  8, 0, 1, IRON, HI_METAL),
@@ -871,7 +871,7 @@ SHIELD(("dwarvish roundshield", "round shield"),
 		0, 0,  MZ_LARGE, 0,	     4, 0, 80, 10,  7, 0, 1, IRON, HI_METAL),
 SHIELD(("crystal shield", "shield"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  MZ_LARGE, 0,	     0, 0, 80,150,  9, 0, 0, GLASS, HI_GLASS, O_MATSPEC(UNIDED)),
-SHIELD(("shield of reflection", "polished shield"),
+SHIELD(("shield of reflection", "polished shield", "smooth shield"),
 		0, 1,  MZ_LARGE, REFLECTING, 3, 0, 60, 50,  8, 0, 0, SILVER, HI_SILVER),
 /*#define SHIELD(names,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,metal,c) \
      ARMOR(names,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,ARM_SHIELD,metal,c) */
@@ -905,11 +905,11 @@ GLOVES(("archaic gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		1, 0,  0,	   0, 2, 25, 10, 8, 2, 0, COPPER, HI_COPPER),
 GLOVES(("long gloves"),
 		1, 0,  0,	   0, 1,  5,  8, 10, 2, 1, CLOTH, CLR_WHITE),
-GLOVES(("harmonium gauntlets", "red-lacquered hooked gauntlets"), /*Needs encyc entry*//*Needs tile*/
+GLOVES(("harmonium gauntlets", "red-lacquered hooked gauntlets", "hooked gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 40,  1, 9, 2, 0, METAL, CLR_RED),
 GLOVES(("high-elven gauntlets", "runed gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 15, 50, 8, 2, 0, MITHRIL, HI_MITHRIL),
-GLOVES(("plasteel gauntlets", "hard white gauntlets"), /*Needs encyc entry*//*Needs tile*/
+GLOVES(("plasteel gauntlets", "hard white gauntlets", "gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 15, 50,  8, 2, 0, PLASTIC, CLR_WHITE),
 GLOVES(("gloves", "old gloves"),
 		0, 0,  0,	   8, 1, 10,  8, 10, 1, 0, LEATHER, HI_LEATHER, O_MATSPEC(IDED)),
@@ -933,9 +933,9 @@ BOOTS(("armored boots", "boots"),
 		0, 0,  0,	   0, 1, 75, 16,  8, 2, 1, IRON, HI_METAL, O_MATSPEC(IDED|UNIDED)),
 BOOTS(("archaic boots", "boots"),
 		0, 0,  0,	   0, 1, 75, 16,  8, 2, 1, COPPER, HI_COPPER,O_MATSPEC(UNIDED)),
-BOOTS(("harmonium boots", "red-lacquered boots"),
+BOOTS(("harmonium boots", "red-lacquered boots", "boots"),
 		0, 0,  0,	   0, 1, 95,  1,  8, 2, 1, METAL, CLR_RED),
-BOOTS(("plasteel boots", "hard white boots"), /*Needs encyc entry*//*Needs tile*/
+BOOTS(("plasteel boots", "hard white boots", "boots"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 25, 32,  8, 2, 1, PLASTIC, CLR_WHITE),
 BOOTS(("stilettos", "high-heeled shoes"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 1, 10, 60, 10, 0, 0, METAL, HI_METAL),
@@ -1113,7 +1113,7 @@ TOOL(("sensor pack", "rigid box"), /*Needs encyc entry*//*Needs tile*/
 								0,  MZ_SMALL, 0, 1, 1,   0, 15,2000, PLASTIC,CLR_WHITE),
 TOOL(("hypospray", "hammer-shaped device"), /*Needs encyc entry*//*Needs tile*/
 								0,  MZ_SMALL, 0, 1, 0,   0, 15, 500, PLASTIC,CLR_GRAY),
-TOOL(("hypospray ampule", "hard grey bottle"), /*Needs encyc entry*//*Needs tile*/
+TOOL(("hypospray ampule", "hard gray bottle", "hard bottle"), /*Needs encyc entry*//*Needs tile*/
 								0,   MZ_TINY, 0, 1, 0,   0,  1,  50, PLASTIC,CLR_GRAY),
 TOOL(("mask"),			1,  MZ_SMALL, 0, 0, 0,  10, 10,  80, LEATHER, CLR_WHITE),
 TOOL(("R'lyehian faceplate", "ebon pane"), /*Needs tile*/
@@ -1122,7 +1122,7 @@ TOOL(("living mask", "gilled jellyfish"),
 								0,  MZ_SMALL, 0, 1, 0,   0,  5, 200, FLESH, CLR_BLUE, O_POWER(MAGICAL_BREATHING)),
 TOOL(("lenses"),		1,   MZ_TINY, 0, 0, 0,   5,  3,  80, GLASS, HI_GLASS), /*Needs encyc entry*/
 TOOL(("blindfold"),    1,   MZ_TINY, 0, 0, 0,  45,  2,  20, CLOTH, CLR_GRAY),
-TOOL(("android visor", "black blindfold"),
+TOOL(("android visor", "black blindfold", "blindfold"),
 								0,   MZ_TINY, 0, 0, 0,   0,  2,  40, CLOTH, CLR_BLACK),
 TOOL(("towel"),        1,   MZ_TINY, 0, 0, 0,  45,  2,  50, CLOTH, CLR_MAGENTA),
 #ifdef STEED
@@ -1133,10 +1133,10 @@ TOOL(("leash"),        1,  MZ_SMALL, 0, 0, 0,  70, 12,  20, LEATHER, HI_LEATHER)
 #endif
 TOOL(("stethoscope"),  1,  MZ_SMALL, 0, 0, 0,  25,  4,  75, IRON, HI_METAL),
 TOOL(("tinning kit"),  1, MZ_MEDIUM, 0, 0, 1,  15,100,  30, IRON, HI_METAL),
-TOOL(("bullet fabber", "white box with a yellow fiddly bit"),/*Needs tile*/
+TOOL(("bullet fabber", "white box with a yellow fiddly bit", "fiddly box"),/*Needs tile*/
 								0, MZ_MEDIUM, 0, 1, 0,   0, 20,  30, PLASTIC, CLR_WHITE),
 TOOL(("upgrade kit"),  1, MZ_MEDIUM, 0, 0, 0,  40,100,  30, COPPER, HI_COPPER),/*Needs encyc entry*//*Needs tile*/
-TOOL(("power pack", "little white cube"), /*Needs encyc entry*//*Needs tile*/
+TOOL(("power pack", "little white cube", "little cube"), /*Needs encyc entry*//*Needs tile*/
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  300, PLASTIC, CLR_WHITE),
 TOOL(("trephination kit"),  
 								1, MZ_MEDIUM, 0, 0, 1,   5, 10,  30, METAL, HI_METAL),/*Needs encyc entry*//*Needs tile*/
@@ -1145,41 +1145,29 @@ TOOL(("can of grease"),1,  MZ_SMALL, 0, 0, 1,  15, 15,  20, IRON, HI_METAL),
 TOOL(("figurine"),     1,  MZ_SMALL, 0, 1, 0,  20, 50,  80, MINERAL, HI_MINERAL),
 /*Keep in sync with doll mvar flags*/
 TOOL(("effigy",   (char *)0),     1,   MZ_TINY, 1, 1, 0,  20,  5,  80, LEATHER, HI_LEATHER),
-TOOL(("doll of jumping",   "Pole-vaulter doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BLUE),
-TOOL(("doll of friendship",   "Bard doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BRIGHT_GREEN),
-TOOL(("doll of chastity",   "Priest doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL(("doll of cleaving",   "Berserker doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_RED),
-TOOL(("doll of satiation",   "Chef doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL(("doll of good health",   "Healer doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL(("doll of full healing",   "Nurse doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL(("doll of destruction",   "Dancing doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, HI_COPPER),
-TOOL(("doll of memory",   "Scholar doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BRIGHT_BLUE),
-TOOL(("doll of binding",   "Heretic doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BROWN),
-TOOL(("doll of preservation",   "Umbrella-wielding doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_YELLOW),
-TOOL(("doll of quick-drawing",   "Archaeologist doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BROWN),
-TOOL(("doll of wand-charging",   "Wandsman doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BRIGHT_BLUE),
-TOOL(("doll of stealing",   "Thief doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BLACK),
-TOOL(("doll of mollification",   "High priest doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, HI_GOLD),
-TOOL(("doll of clear-thinking",   "Madman doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_GRAY),
-TOOL(("doll of mind-blasting",   "Squid-parasitized doll"),
-								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_MAGENTA),
-TOOL(("doll's tear",   "milky gemstone"),
+
+#define DOLL(names, color) \
+	TOOL(DEF_BLINDNAME(names, "doll"), 0, MZ_TINY, 1, 1, 0, 0, 1, 80, CLOTH, color)
+
+DOLL(("doll of jumping",        "Pole-vaulter doll"),      CLR_BLUE),
+DOLL(("doll of friendship",     "Bard doll"),              CLR_BRIGHT_GREEN),
+DOLL(("doll of chastity",       "Priest doll"),            CLR_WHITE),
+DOLL(("doll of cleaving",       "Berserker doll"),         CLR_RED),
+DOLL(("doll of satiation",      "Chef doll"),              CLR_WHITE),
+DOLL(("doll of good health",    "Healer doll"),            CLR_WHITE),
+DOLL(("doll of full healing",   "Nurse doll"),             CLR_WHITE),
+DOLL(("doll of destruction",    "Dancing doll"),           HI_COPPER),
+DOLL(("doll of memory",         "Scholar doll"),           CLR_BRIGHT_BLUE),
+DOLL(("doll of binding",        "Heretic doll"),           CLR_BROWN),
+DOLL(("doll of preservation",   "Umbrella-wielding doll"), CLR_YELLOW),
+DOLL(("doll of quick-drawing",  "Archaeologist doll"),     CLR_BROWN),
+DOLL(("doll of wand-charging",  "Wandsman doll"),          CLR_BRIGHT_BLUE),
+DOLL(("doll of stealing",       "Thief doll"),             CLR_BLACK),
+DOLL(("doll of mollification",  "High priest doll"),       HI_GOLD),
+DOLL(("doll of clear-thinking", "Madman doll"),            CLR_GRAY),
+DOLL(("doll of mind-blasting",  "Squid-parasitized doll"), CLR_MAGENTA),
+#undef DOLL
+TOOL(("doll's tear",   "milky gemstone", "gem"),
 								0,   MZ_TINY, 0, 1, 0,   0,  1,8000, GEMSTONE, CLR_WHITE),
 TOOL(("holy symbol of the black mother", "tarnished triple goat-head"), 
 								0,   MZ_TINY, 0, 1, 0,   0, 50,8000, SILVER, CLR_BLACK),
@@ -1222,12 +1210,12 @@ WEPTOOL(("seismic hammer", "dull metallic hammer"),
 WEPTOOL(("torch"),
 	DMG(D(6)), DMG(D(3)),
 	1,  MZ_SMALL, 0, 0, 15, 10,   5,  0, B,   P_CLUB, WOOD, HI_WOOD),
-WEPTOOL(("shadowlander's torch", "black torch"),
+WEPTOOL(("shadowlander's torch", "black torch", "torch"),
 	DMG(D(6)), DMG(D(3)),
 	0,  MZ_SMALL, 0, 0, 10, 10,  50,  0, B,   P_CLUB, WOOD, CLR_BLACK),
-WEPTOOL(("sunrod", "gold rod"),
+WEPTOOL(("sunrod", "rod"),
 	DMG(D(6)), DMG(D(3)),
-	1,  MZ_SMALL, 0, 0,  5, 20,  50,  0, B,   P_MACE, GOLD, HI_GOLD),
+	1,  MZ_SMALL, 0, 0,  5, 20,  50,  0, B,   P_MACE, GOLD, HI_GOLD, O_MATSPEC(UNIDED)),
 /* 
  * Lightsabers get 3x dice when lit, and go down to 1d2 damage when unlit
  */

--- a/src/objects.c
+++ b/src/objects.c
@@ -25,6 +25,16 @@
 #define O_COST(x)		C21(x)
 #define O_NUT(x)		C27(x)
 
+/* modifying the blindname of an object */
+#define DEF_BLINDNAME(names, blindname) (SETNAMES(names, C03(blindname)))
+#define SETNAMES(names, ...) SET03(C02(((char *)0)), C03(((char *)0)), ##__VA_ARGS__, FILLNAMES__(DEPAREN(names)))
+#define FILLNAMES__(...) FILLNAMES_(NARGS(__VA_ARGS__), __VA_ARGS__)
+#define FILLNAMES_(...)	FILLNAMES(__VA_ARGS__)
+#define FILLNAMES(N, ...) FILLNAMES##N(__VA_ARGS__)
+#define FILLNAMES01(a)     C01((a))
+#define FILLNAMES02(a,b)   C01((a)), C02((b))
+#define FILLNAMES03(a,b,c) C01((a)), C02((b)), C03((c))
+
 /* setting damage dice in a non-awful way */
 #define DMG_(...) DMG__(__VA_ARGS__)
 #define DMG__(ocn, ocd, bonn, bond, flat) \
@@ -72,7 +82,7 @@ struct monst { struct monst *dummy; };	/* lint: struct obj's union */
 /* objects have symbols: ) [ = " ( % ! ? + / $ * ` 0 _ . */
 
 /*
- *	Note:  OBJ() and BITS() macros are used to avoid exceeding argument
+ *	Note:  () and BITS() macros are used to avoid exceeding argument
  *	limits imposed by some compilers.  The ctnr field of BITS currently
  *	does not map into struct objclass, and is ignored in the expansion.
  *	The 0 in the expansion corresponds to oc_pre_discovered, which is
@@ -81,9 +91,8 @@ struct monst { struct monst *dummy; };	/* lint: struct obj's union */
 
 #ifndef OBJECTS_PASS_2_
 /* first pass -- object descriptive text */
-# define OBJ(name,desc) name,desc
-# define OBJECT(obj,bits,prp,sym,prob,dly,wt,cost,sdam,ldam,oc1,oc2,oc3,nut,color,...) \
-	{obj}
+# define OBJECT(names,bits,prp,sym,prob,dly,wt,cost,sdam,ldam,oc1,oc2,oc3,nut,color,...) \
+	{SETNAMES(names)}
 
 NEARDATA struct objdescr obj_descr[] = {
 #else
@@ -94,7 +103,7 @@ NEARDATA struct objdescr obj_descr[] = {
 	C05(mgc), C06(chrg), C07(uniq), C08(nwsh), \
 	C09(size), C10(tuf), C11(dir), C12(mtrl), \
 	C13(shwmat), C14(sub)
-# define OBJECT(obj,bits,prp,sym,prob,dly,wt,cost,sdam,ldam,oc1,oc2,oc3,nut,color,...) \
+# define OBJECT(names,bits,prp,sym,prob,dly,wt,cost,sdam,ldam,oc1,oc2,oc3,nut,color,...) \
 	{0, 0, (char *)0, SET27( \
 	bits, \
 	C15(prp), C16(sym), C17(dly), C18(color), \
@@ -113,34 +122,34 @@ NEARDATA struct objdescr obj_descr[] = {
 NEARDATA struct objclass objects[] = {
 #endif
 /* dummy object[0] -- description [2nd arg] *must* be NULL */
-	OBJECT(OBJ("strange object",(char *)0), BITS(1,0,0,0,0,0,0,0,0,0,0,P_NONE,0,0),
+	OBJECT(("strange object",(char *)0), BITS(1,0,0,0,0,0,0,0,0,0,0,P_NONE,0,0),
 			0, ILLOBJ_CLASS, 0, 0, 0, 0, {0}, {0}, 0, 0, 0, 0, 0),
 
 /* weapons ... */
-#define WEAPON(name,app,sdam,ldam,kn,mg,size,prob,wt,cost,hitbon,typ,sub,metal,shwmat,color,...) \
+#define WEAPON(names,sdam,ldam,kn,mg,size,prob,wt,cost,hitbon,typ,sub,metal,shwmat,color,...) \
 	OBJECT( \
-		OBJ(name,app), BITS(kn,mg,1,0,0,1,0,0,size,0,typ,sub,metal,shwmat), 0, \
+		names, BITS(kn,mg,1,0,0,1,0,0,size,0,typ,sub,metal,shwmat), 0, \
 		WEAPON_CLASS, prob, 0, \
 		wt, cost, sdam, ldam, hitbon, WP_GENERIC, 0, wt, color, __VA_ARGS__ )
-#define PROJECTILE(name,app,sdam,ldam,kn,prob,wt,cost,hitbon,metal,sub,color,...) \
+#define PROJECTILE(names,sdam,ldam,kn,prob,wt,cost,hitbon,metal,sub,color,...) \
 	OBJECT( \
-		OBJ(name,app), \
+		names, \
 		BITS(kn,1,1,0,0,1,0,0,MZ_TINY,0,PIERCE,sub,metal,0), 0, \
 		WEAPON_CLASS, prob, 0, \
 		wt, cost, sdam, ldam, hitbon, WP_GENERIC, 0, wt, color, __VA_ARGS__)
-#define BOW(name, app, kn, size, prob, wt, cost, hitbon, metal, sub, color) \
+#define BOW(names,kn,size,prob,wt,cost,hitbon,metal,sub,color) \
 	OBJECT( \
-		OBJ(name,app), BITS(kn,0,1,0,0,1,0,0,size,0,0,sub,metal,0), 0, \
+		names, BITS(kn,0,1,0,0,1,0,0,size,0,0,sub,metal,0), 0, \
 		WEAPON_CLASS, prob, 0, \
 		wt, cost, { 0 }, { 0 }, hitbon, WP_GENERIC, 0, wt, color)
-#define BULLET(name,app,sdam,ldam,kn,size,prob,wt,cost,hitbon,ammotyp,typ,metal,sub,color,...) \
+#define BULLET(names,sdam,ldam,kn,size,prob,wt,cost,hitbon,ammotyp,typ,metal,sub,color,...) \
 	OBJECT( \
-		OBJ(name,app), BITS(kn,1,1,0,0,1,0,0,size,0,typ,sub,metal,0), 0, \
+		names, BITS(kn,1,1,0,0,1,0,0,size,0,typ,sub,metal,0), 0, \
 		WEAPON_CLASS, prob, 0, \
 		wt, cost, sdam, ldam, hitbon, ammotyp, 0, wt, color, __VA_ARGS__)
-#define GUN(name,app,kn,size,prob,wt,cost,range,rof,hitbon,ammotyp,metal,sub,color,...) \
+#define GUN(names,kn,size,prob,wt,cost,range,rof,hitbon,ammotyp,metal,sub,color,...) \
 	OBJECT( \
-		OBJ(name,app), BITS(kn,0,1,0,0,1,0,0,size,0,0,sub,metal,0), 0, \
+		names, BITS(kn,0,1,0,0,1,0,0,size,0,0,sub,metal,0), 0, \
 		WEAPON_CLASS, prob, 0, \
 		wt, cost, DMG(F(range)), DMG(F(rof)), hitbon, ammotyp, 0, wt, color, __VA_ARGS__)
 
@@ -153,355 +162,355 @@ NEARDATA struct objclass objects[] = {
 #define E EXPLOSION
 
 /* missiles */
-PROJECTILE("arrow", (char *)0,
+PROJECTILE(("arrow"),
 		DMG(D(6)), DMG(D(6)),
 		1, 50, 1, 2,  0, IRON,   -P_BOW, HI_METAL),
-PROJECTILE("elven arrow", "runed arrow",
+PROJECTILE(("elven arrow", "runed arrow"),
 		DMG(D(7)), DMG(D(5)),
 		0, 18, 1, 2,  2, WOOD,   -P_BOW, HI_WOOD),
-PROJECTILE("orcish arrow", "crude arrow",
+PROJECTILE(("orcish arrow", "crude arrow"),
 		DMG(D(5)), DMG(D(8)),
 		0, 18, 1, 2, -1, IRON,   -P_BOW, CLR_BLACK),
-PROJECTILE("silver arrow", (char *)0,
+PROJECTILE(("silver arrow"),
 		DMG(D(6)), DMG(D(6)),
 		1, 12, 1, 5,  0, SILVER, -P_BOW, HI_SILVER),
-PROJECTILE("golden arrow", (char *)0, /*Needs encyc entry*//*Needs tile*/
+PROJECTILE(("golden arrow"), /*Needs encyc entry*//*Needs tile*/
 		DMG(D(13)), DMG(D(13)),
 		1,  9, 2,10,  0, GOLD,   -P_BOW, HI_GOLD),
-PROJECTILE("ancient arrow", (char *)0, /*Needs encyc entry*//*Needs tile*/
+PROJECTILE(("ancient arrow"), /*Needs encyc entry*//*Needs tile*/
 		DMG(D(10)), DMG(D(10)),
 		1,  0, 1,10,  0, METAL,  -P_BOW, CLR_BLACK),
-PROJECTILE("ya", "bamboo arrow",
+PROJECTILE(("ya", "bamboo arrow"),
 		DMG(D(7)), DMG(D(7)),
 		0, 15, 1, 4,  1, METAL,  -P_BOW, HI_METAL),
-PROJECTILE("crossbow bolt", (char *)0,
+PROJECTILE(("crossbow bolt"),
 		DMG(D(4), F(1)), DMG(D(6), F(1)),
 		1, 55, 1, 2,  0, IRON,   -P_CROSSBOW, HI_METAL),
-PROJECTILE("droven bolt", "crossbow bolt", /*Needs encyc entry*/
+PROJECTILE(("droven bolt", "crossbow bolt"), /*Needs encyc entry*/
 		DMG(D(9), F(1)), DMG(D(6), F(1)),
 		0,  0, 1, 2,  2, OBSIDIAN_MT, -P_CROSSBOW, CLR_BLACK, O_MATSPEC(UNIDED)),
 
-WEAPON("dart", (char *)0,
+WEAPON(("dart"),
 	DMG(D(3)), DMG(D(2)),
 	1, 1,   MZ_TINY, 58,  1,  2,  0, P,   -P_DART, IRON, FALSE, HI_METAL),
-WEAPON("shuriken", "throwing star",
+WEAPON(("shuriken", "throwing star"),
 	DMG(D(8)), DMG(D(6)),
 	0, 1,   MZ_TINY, 33,  1,  5,  2, P|S, -P_SHURIKEN, IRON, FALSE, HI_METAL),
-WEAPON("boomerang", (char *)0,
+WEAPON(("boomerang"),
 	DMG(D(9)), DMG(D(9)),
 	1, 1,  MZ_SMALL, 13,  5, 20,  0, B,   -P_BOOMERANG, WOOD, FALSE, HI_WOOD),
-WEAPON("chakram", "circular blade", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("chakram", "circular blade"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(9)), DMG(D(9)),
 	1, 1,  MZ_SMALL,  6,  5, 20,  0, S,   -P_BOOMERANG, SILVER, IDED|UNIDED, HI_SILVER),
-WEAPON("spike", (char *)0, /*Needs encyc entry*/
+WEAPON(("spike"), /*Needs encyc entry*/
 	DMG(D(3)), DMG(D(1)),
 	1, 1,   MZ_TINY,  0,  1,  2,  0, P,   -P_DART, BONE, IDED|UNIDED, CLR_WHITE),
 
 /* spears */
-WEAPON("spear", (char *)0,
+WEAPON(("spear"),
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_LARGE, 50, 25,  3,  0, P,   P_SPEAR, IRON, FALSE, HI_METAL),
-WEAPON("elven spear", "runed spear",
+WEAPON(("elven spear", "runed spear"),
 	DMG(D(7)), DMG(D(7)),
 	0, 0,  MZ_LARGE, 10, 10,  3,  2, P,   P_SPEAR, WOOD, FALSE, HI_WOOD),
-WEAPON("droven spear", "long spear", /*Needs encyc entry*/
+WEAPON(("droven spear", "long spear"), /*Needs encyc entry*/
 	DMG(D(12)), DMG(D(12)),
 	0, 0,   MZ_HUGE,  0, 15,  3,  2, P,   P_SPEAR, OBSIDIAN_MT, UNIDED, CLR_BLACK),
-WEAPON("orcish spear", "crude spear",
+WEAPON(("orcish spear", "crude spear"),
 	DMG(D(5)), DMG(D(10)),
 	0, 0,  MZ_LARGE, 13, 25,  3, -1, P,   P_SPEAR, IRON, FALSE, CLR_BLACK),
-WEAPON("dwarvish spear", "stout spear",
+WEAPON(("dwarvish spear", "stout spear"),
 	DMG(D(9)), DMG(D(9)),
 	0, 0,  MZ_LARGE, 12, 30,  3,  0, P,   P_SPEAR, IRON, FALSE, HI_METAL),
-WEAPON("javelin", "throwing spear",
+WEAPON(("javelin", "throwing spear"),
 	DMG(D(6)), DMG(D(6)),
 	0, 1,  MZ_LARGE, 10, 20,  3,  0, P,   P_SPEAR, IRON, FALSE, HI_METAL),
 
-WEAPON("trident", (char *)0, /*Needs encyc entry*/
+WEAPON(("trident"), /*Needs encyc entry*/
 	DMG(D(6), F(1)), DMG(D(3, 4)),
 	1, 0,  MZ_LARGE,  8, 25,  5,  0, P,   P_TRIDENT, IRON, FALSE, HI_METAL),
 
 /* blades */
-WEAPON("dagger", (char *)0,
+WEAPON(("dagger"),
 	DMG(D(4)), DMG(D(3)),
 	1, 1,  MZ_SMALL, 24, 10,  4,  2, P,   P_DAGGER, IRON, FALSE, HI_METAL),
-WEAPON("elven dagger", "runed dagger",
+WEAPON(("elven dagger", "runed dagger"),
 	DMG(D(5)), DMG(D(3)),
 	0, 1,  MZ_SMALL,  7,  3,  4,  4, P,   P_DAGGER, WOOD, FALSE, HI_WOOD),
-WEAPON("droven dagger", "dagger", /*Needs encyc entry*/
+WEAPON(("droven dagger", "dagger"), /*Needs encyc entry*/
 	DMG(D(8)), DMG(D(6)),
 	0, 1,  MZ_SMALL,  0,  5, 12,  4, P,   P_DAGGER, OBSIDIAN_MT, UNIDED, CLR_BLACK),
-WEAPON("orcish dagger", "crude dagger",
+WEAPON(("orcish dagger", "crude dagger"),
 	DMG(D(3)), DMG(D(5)),
 	0, 1,  MZ_SMALL,  9, 10,  5,  1, P,   P_DAGGER, IRON, FALSE, CLR_BLACK),
-WEAPON("athame", (char *)0,
+WEAPON(("athame"),
 	DMG(D(4)), DMG(D(4)),
 	1, 1,  MZ_SMALL,  0, 10,  4,  2, S,   P_DAGGER, IRON, FALSE, HI_METAL),
-WEAPON("set of crow talons", "set of three feather-etched daggers",
+WEAPON(("set of crow talons", "set of three feather-etched daggers"),
 	DMG(D(4)), DMG(D(3)),
 	0, 0,  MZ_SMALL,  0,  9,200,  2, S,   P_DAGGER, METAL, FALSE, HI_METAL),
-WEAPON("tecpatl", "notched dagger",
+WEAPON(("tecpatl", "notched dagger"),
 	DMG(D(8)), DMG(D(6)),
 	0, 1,  MZ_SMALL,  0,  5, 12,  4, P,   P_DAGGER, OBSIDIAN_MT, FALSE, CLR_BLACK),
-WEAPON("scalpel", (char *)0,
+WEAPON(("scalpel"),
 	DMG(D(3)), DMG(D(1)),
 	1, 1,  MZ_SMALL,  0,  5,  6,  3, S,   P_KNIFE, METAL, FALSE, HI_METAL),
-WEAPON("knife", (char *)0,
+WEAPON(("knife"),
 	DMG(D(5)), DMG(D(3)),
 	1, 1,  MZ_SMALL, 14,  5,  4,  2, P|S, P_KNIFE, IRON, FALSE, HI_METAL),
-WEAPON("stiletto", (char *)0,
+WEAPON(("stiletto"),
 	DMG(D(6)), DMG(D(2)),
 	1, 1,  MZ_SMALL,  4,  5,  4,  1, P, P_KNIFE, IRON, FALSE, HI_METAL),
-WEAPON("worm tooth", (char *)0,
+WEAPON(("worm tooth"),
 	DMG(D(2)), DMG(D(2)),
 	1, 0,  MZ_SMALL,  0, 20,  2,  0, P,   P_KNIFE, MINERAL, FALSE, CLR_WHITE),
-WEAPON("crysknife", (char *)0,
+WEAPON(("crysknife"),
 	DMG(D(10)), DMG(D(10)),
 	1, 0,  MZ_SMALL,  0, 20,100,  3, P,   P_KNIFE, MINERAL, FALSE, CLR_WHITE),
 
-WEAPON("sickle", (char *)0, /* Vs plants: +6 to hit and double damage */
+WEAPON(("sickle"), /* Vs plants: +6 to hit and double damage */
 	DMG(D(4)), DMG(D(1)),
 	1, 1,  MZ_SMALL, 22, 20,  4, -2, S,   P_HARVEST, IRON, FALSE, HI_METAL),
-WEAPON("elven sickle", "runed sickle", /* Vs plants: +6 to hit and double damage *//*Needs tile*/
+WEAPON(("elven sickle", "runed sickle"), /* Vs plants: +6 to hit and double damage *//*Needs tile*/
 	DMG(D(6)), DMG(D(3)),
 	0, 1,  MZ_SMALL,  0,  5,  4,  0, S,   P_HARVEST, WOOD, FALSE, HI_WOOD),
 
-WEAPON("axe", (char *)0,
+WEAPON(("axe"),
 	DMG(D(6)), DMG(D(4)),
 	1, 0, MZ_MEDIUM, 20, 60,  8,  0, S,   P_AXE, IRON, FALSE, HI_METAL),
-WEAPON("battle-axe", "double-bitted axe",/* was "double-headed" ? */
+WEAPON(("battle-axe", "double-bitted axe"),/* was "double-headed" ? */
 	DMG(D(8), D(4)), DMG(D(6), D(2,4)),
 	0, 0,   MZ_HUGE, 16,120, 40,  0, S,   P_AXE, IRON, FALSE, HI_METAL),
-WEAPON("moon axe", "two-handed axe", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("moon axe", "two-handed axe"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(6)), DMG(D(6)),	/* die size modified by phase of moon */
 	0, 0,   MZ_HUGE, 12,160, 40,  0, S,   P_AXE, SILVER, UNIDED, HI_SILVER),
 
 /* swords */
-WEAPON("short sword", (char *)0,
+WEAPON(("short sword"),
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_SMALL,  8, 30, 10,  0, P,   P_SHORT_SWORD, IRON, FALSE, HI_METAL),
-WEAPON("elven short sword", "runed short sword",
+WEAPON(("elven short sword", "runed short sword"),
 	DMG(D(7)), DMG(D(7)),
 	0, 0,  MZ_SMALL,  2, 10, 10,  2, P,   P_SHORT_SWORD, WOOD, FALSE, HI_WOOD),
-WEAPON("droven short sword", "short sword", /*Needs encyc entry*/
+WEAPON(("droven short sword", "short sword"), /*Needs encyc entry*/
 	DMG(D(9)), DMG(D(9)),
 	0, 0,  MZ_SMALL,  0, 15, 10,  2, P,   P_SHORT_SWORD, OBSIDIAN_MT, UNIDED, CLR_BLACK),
-WEAPON("orcish short sword", "crude short sword",
+WEAPON(("orcish short sword", "crude short sword"),
 	DMG(D(5)), DMG(D(10)),
 	0, 0,  MZ_SMALL,  3, 30, 10, -1, P,   P_SHORT_SWORD, IRON, FALSE, CLR_BLACK),
-WEAPON("dwarvish short sword", "broad short sword",
+WEAPON(("dwarvish short sword", "broad short sword"),
 	DMG(D(8)), DMG(D(7)),
 	0, 0,  MZ_SMALL,  2, 35, 10,  0, P|S, P_SHORT_SWORD, IRON, FALSE, HI_METAL),
-WEAPON("mirrorblade", "polished short sword",
+WEAPON(("mirrorblade", "polished short sword"),
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_SMALL,  0, 40,100,  0, P,   P_SHORT_SWORD, SILVER, FALSE, HI_SILVER),
 
-WEAPON("scimitar", "curved sword",
+WEAPON(("scimitar", "curved sword"),
 	DMG(D(8)), DMG(D(8)),
 	0, 0, MZ_MEDIUM, 14, 40, 15,  0, S,   P_SCIMITAR, IRON, FALSE, HI_METAL),
-WEAPON("high-elven warsword", "runed curved sword",
+WEAPON(("high-elven warsword", "runed curved sword"),
 	DMG(D(10)), DMG(D(10)),
 	0, 0, MZ_MEDIUM,  1, 20,150,  2, S,   P_SCIMITAR, MITHRIL, UNIDED, HI_MITHRIL),
-WEAPON("rapier", (char *)0,
+WEAPON(("rapier"),
 	DMG(D(6)), DMG(D(4)),
 	1, 0, MZ_MEDIUM,  6, 28, 20,  2, P,   P_SABER, METAL, FALSE, HI_METAL),
-WEAPON("saber", (char *)0,
+WEAPON(("saber"),
 	DMG(D(8)), DMG(D(8)),
 	1, 0, MZ_MEDIUM,  6, 34, 75,  0, S,   P_SABER, SILVER, IDED|UNIDED, HI_SILVER),
-WEAPON("crow quill", "feather-etched rapier",
+WEAPON(("crow quill", "feather-etched rapier"),
 	DMG(D(8)), DMG(D(8)),
 	0, 0, MZ_MEDIUM,  0, 34,200,  2, P,   P_SABER, METAL, FALSE, HI_METAL),
-WEAPON("rakuyo", "double-bladed saber",
+WEAPON(("rakuyo", "double-bladed saber"),
 	DMG(D(8)), DMG(D(8)),
 	0, 0, MZ_MEDIUM,  0, 38,500,  2, P|S, P_SABER, METAL, FALSE, HI_METAL),
-WEAPON("rakuyo-saber", "latch-pommeled saber",
+WEAPON(("rakuyo-saber", "latch-pommeled saber"),
 	DMG(D(8)), DMG(D(8)),
 	0, 0, MZ_MEDIUM,  0, 28,400,  2, P|S, P_SABER, METAL, FALSE, HI_METAL),
-WEAPON("rakuyo-dagger", "latch-pommeled dagger",
+WEAPON(("rakuyo-dagger", "latch-pommeled dagger"),
 	DMG(D(4)), DMG(D(3)),
 	0, 0,  MZ_SMALL,  0, 10,100,  2, P|S, P_DAGGER, METAL, FALSE, HI_METAL),
-WEAPON("broadsword", (char *)0,
+WEAPON(("broadsword"),
 	DMG(D(2, 4)), DMG(D(6), F(1)),
 	1, 0,  MZ_LARGE,  8, 70, 10,  0, S,   P_BROAD_SWORD, IRON, FALSE, HI_METAL),
-WEAPON("elven broadsword", "runed broadsword",
+WEAPON(("elven broadsword", "runed broadsword"),
 	DMG(D(6), D(4)), DMG(D(6), F(2)),
 	0, 0,  MZ_LARGE,  4, 20, 10,  2, S,   P_BROAD_SWORD, WOOD, FALSE, HI_WOOD),
-WEAPON("long sword", (char *)0,
+WEAPON(("long sword"),
 	DMG(D(8)), DMG(D(12)),
 	1, 0, MZ_MEDIUM, 46, 40, 15,  0, S|P, P_LONG_SWORD, IRON, FALSE, HI_METAL),
-WEAPON("crystal sword", (char *)0, /*Needs encyc entry*//*Needs tile*/
+WEAPON(("crystal sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(2, 8)), DMG(D(2, 12)),
 	1, 0,  MZ_LARGE, 2, 120,300,  0, S|P, P_LONG_SWORD, GLASS, FALSE, HI_GLASS),
-WEAPON("two-handed sword", (char *)0,
+WEAPON(("two-handed sword"),
 	DMG(D(12)), DMG(D(3, 6)),
 	1, 0,   MZ_HUGE, 22,150, 50,  0, S,   P_TWO_HANDED_SWORD, IRON, FALSE, HI_METAL),
-WEAPON("droven greatsword", "two-handed sword", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("droven greatsword", "two-handed sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(18)), DMG(D(30)),
 	0, 0,   MZ_HUGE,  0,120, 50,  2, S,   P_TWO_HANDED_SWORD, OBSIDIAN_MT, UNIDED, CLR_BLACK),
-WEAPON("katana", "samurai sword",
+WEAPON(("katana", "samurai sword"),
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  4, 40, 80,  1, S,   P_LONG_SWORD, IRON, FALSE, HI_METAL),
 /* special swords set up for artifacts and future weapons*/
-WEAPON("vibroblade", "gray short sword", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("vibroblade", "gray short sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_SMALL,  0,  5,1000, 0, P,   P_SHORT_SWORD, PLASTIC, FALSE, CLR_GRAY),
-WEAPON("tsurugi", "long samurai sword",
+WEAPON(("tsurugi", "long samurai sword"),
 	DMG(D(16)), DMG(D(8), D(2,6)),
 	0, 0,   MZ_HUGE,  0, 60,500,  2, S,   P_TWO_HANDED_SWORD, METAL, FALSE, HI_METAL),
-WEAPON("runesword", "runed black blade",
+WEAPON(("runesword", "runed black blade"),
 	DMG(D(10), D(4)), DMG(D(10), F(1)),
 	0, 0,  MZ_LARGE,  0, 40,300,  0, S,   P_BROAD_SWORD, IRON, FALSE, CLR_BLACK),
-WEAPON("white vibrosword", "white sword", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("white vibrosword", "white sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  0, 40,8000, 1, P|S, P_LONG_SWORD,  SILVER, FALSE, CLR_WHITE),
-WEAPON("gold-bladed vibrosword", "black and gold sword", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("gold-bladed vibrosword", "black and gold sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  0, 53,8000, 1, P|S, P_LONG_SWORD,    GOLD, FALSE, CLR_BLACK),
-WEAPON("red-eyed vibrosword", "blue-glowing sword", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("red-eyed vibrosword", "blue-glowing sword"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(12)),
 	0, 0, MZ_MEDIUM,  0, 10,8000, 1, P|S, P_LONG_SWORD, PLASTIC, FALSE, CLR_GRAY),
-WEAPON("white vibrozanbato", "curved white sword",
+WEAPON(("white vibrozanbato", "curved white sword"),
 	DMG(D(16)), DMG(D(8), D(2,6)),
 	0, 0,   MZ_HUGE,  0, 60,16000,2, S,   P_TWO_HANDED_SWORD, SILVER, FALSE, CLR_WHITE),
-WEAPON("gold-bladed vibrozanbato", "curved black and gold sword",
+WEAPON(("gold-bladed vibrozanbato", "curved black and gold sword"),
 	DMG(D(16)), DMG(D(8), D(2,6)),
 	0, 0,   MZ_HUGE,  0, 80,16000,2, S,   P_TWO_HANDED_SWORD, GOLD, FALSE, CLR_BLACK),
 
-WEAPON("double force-blade", "double-bladed weapon",
+WEAPON(("double force-blade", "double-bladed weapon"),
 	DMG(D(6)), DMG(D(4)),
 	0, 0,   MZ_HUGE,  0, 40,1000, 2, S,   P_QUARTERSTAFF, PLASTIC, FALSE, CLR_RED),
 						    /* 2x, but slower */
-WEAPON("force blade", "latch-ended blade",
+WEAPON(("force blade", "latch-ended blade"),
 	DMG(D(6)), DMG(D(4)),
 	0, 0,  MZ_SMALL,  0, 20,500,  2, S,   P_SHORT_SWORD, PLASTIC, FALSE, CLR_RED),
 
-WEAPON("force sword", "hard segmented sword",
+WEAPON(("force sword", "hard segmented sword"),
 	DMG(D(8)), DMG(D(6)),
 	0, 0, MZ_MEDIUM,  0, 40,1000, 2, P|B, P_BROAD_SWORD, PLASTIC, FALSE, HI_SILVER),
-WEAPON("force whip", "segmented whip",
+WEAPON(("force whip", "segmented whip"),
 	DMG(D(6)), DMG(D(4)),
 	0, 0, MZ_MEDIUM,  0, 40,1000, 2, P|S, P_WHIP, PLASTIC, FALSE, CLR_ORANGE),
 /* polearms */
 /* spear-type */
-WEAPON("partisan", "vulgar polearm",
+WEAPON(("partisan", "vulgar polearm"),
 	DMG(D(6)), DMG(D(6), F(1)),
 	0, 0,   MZ_HUGE,  5, 80, 10,  0, P,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("ranseur", "hilted polearm",
+WEAPON(("ranseur", "hilted polearm"),
 	DMG(D(2, 4)), DMG(D(2, 4)),
 	0, 0,   MZ_HUGE,  5, 50,  6,  0, P,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("spetum", "forked polearm",
+WEAPON(("spetum", "forked polearm"),
 	DMG(D(6), F(1)), DMG(D(2, 6)),
 	0, 0,   MZ_HUGE,  5, 50,  5,  0, P,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("glaive", "single-edged polearm",
+WEAPON(("glaive", "single-edged polearm"),
 	DMG(D(6)), DMG(D(10)),
 	0, 0,   MZ_HUGE,  7, 75,  6,  0, S,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("naginata", "samurai-sword polearm",
+WEAPON(("naginata", "samurai-sword polearm"),
 	DMG(D(8)), DMG(D(10)),
 	0, 0,   MZ_HUGE,  1, 75, 90,  1, S,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("lance", (char *)0,
+WEAPON(("lance"),
 	DMG(D(6)), DMG(D(8)),
 	1, 0,  MZ_LARGE,  4, 80, 10,  0, P,   P_LANCE, IRON, FALSE, HI_METAL),
-WEAPON("force pike", "long gray spear",/*Needs tile*/
+WEAPON(("force pike", "long gray spear"),/*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 30,1000, 2, P|S, P_LANCE, PLASTIC, FALSE, CLR_GRAY),
-WEAPON("white vibrospear", "long white spear",/*Needs tile*/
+WEAPON(("white vibrospear", "long white spear"),/*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 30,1000, 2, P|S, P_LANCE, PLASTIC, FALSE, CLR_WHITE),
-WEAPON("gold-bladed vibrospear", "long black and gold spear",/*Needs tile*/
+WEAPON(("gold-bladed vibrospear", "long black and gold spear"),/*Needs tile*/
 	DMG(D(6)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 30,1000, 2, P|S, P_LANCE, GOLD, FALSE, CLR_BLACK),
-WEAPON("elven lance", "runed lance", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("elven lance", "runed lance"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(8)), DMG(D(8)),
 	0, 0,  MZ_LARGE,  0, 60, 10,  2, P,   P_LANCE, WOOD, FALSE, HI_WOOD),
-WEAPON("droven lance", "lance", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("droven lance", "lance"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(10)), DMG(D(10)),
 	0, 0,   MZ_HUGE,  0, 60, 10,  2, P,   P_LANCE, OBSIDIAN_MT, UNIDED, CLR_BLACK),
 /* axe-type */
-WEAPON("halberd", "angled poleaxe",
+WEAPON(("halberd", "angled poleaxe"),
 	DMG(D(10)), DMG(D(2, 6)),
 	0, 0,   MZ_HUGE,  8, 75, 10, 0, P|S, P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("bardiche", "long poleaxe",
+WEAPON(("bardiche", "long poleaxe"),
 	DMG(D(2, 4)), DMG(D(3, 4)),
 	0, 0,   MZ_HUGE,  4, 80,  7, 0, S,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("voulge", "pole cleaver",
+WEAPON(("voulge", "pole cleaver"),
 	DMG(D(2, 4)), DMG(D(2, 4)),
 	0, 0,   MZ_HUGE,  4, 50,  5, 0, S,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("dwarvish mattock", "broad pick",
+WEAPON(("dwarvish mattock", "broad pick"),
 	DMG(D(12)), DMG(D(8), D(2, 6)),
 	0, 0,   MZ_HUGE, 13,120, 50,-1, P|B, P_PICK_AXE, IRON, FALSE, HI_METAL),
 
 /* curved/hooked */
-WEAPON("fauchard", "pole sickle",
+WEAPON(("fauchard", "pole sickle"),
 	DMG(D(6)), DMG(D(8)),
 	0, 0,   MZ_HUGE,  5, 60,  5,  0, P|S, P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("guisarme", "pruning hook",
+WEAPON(("guisarme", "pruning hook"),
 	DMG(D(2, 4)), DMG(D(8)),
 	0, 0,   MZ_HUGE,  5, 80,  5,  0, S,   P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("bill-guisarme", "hooked polearm",
+WEAPON(("bill-guisarme", "hooked polearm"),
 	DMG(D(2, 4)), DMG(D(10)),
 	0, 0,   MZ_HUGE,  3, 80,  7,  0, P|S, P_POLEARMS, IRON, FALSE, HI_METAL),
 /* other */
-WEAPON("lucern hammer", "pronged polearm",
+WEAPON(("lucern hammer", "pronged polearm"),
 	DMG(D(2, 4)), DMG(D(6)),
 	0, 0,   MZ_HUGE,  4, 85,  7,  0, B|P, P_POLEARMS, IRON, FALSE, HI_METAL),
-WEAPON("bec de corbin", "beaked polearm",
+WEAPON(("bec de corbin", "beaked polearm"),
 	DMG(D(8)), DMG(D(6)),
 	0, 0,   MZ_HUGE,  3, 75,  8,  0, B|P, P_POLEARMS, IRON, FALSE, HI_METAL),
 
-WEAPON("scythe", (char *)0, 
+WEAPON(("scythe"), 
 	DMG(D(2, 4)), DMG(D(2, 4)), /* Vs plants: +6 to hit and double damage */
 	1, 0,   MZ_HUGE,  5, 75,  6, -2, S,   P_HARVEST, IRON, FALSE, HI_METAL),
 
 /* bludgeons */
-WEAPON("mace", (char *)0,
+WEAPON(("mace"),
 	DMG(D(6), F(1)), DMG(D(6)),
 	1, 0, MZ_MEDIUM, 40, 30,  5,  0, B,   P_MACE, IRON, FALSE, HI_METAL),
-WEAPON("elven mace", "runed mace", /*Needs encyc entry*/
+WEAPON(("elven mace", "runed mace"), /*Needs encyc entry*/
 	DMG(D(7), F(1)), DMG(D(7)),
 	0, 0, MZ_MEDIUM,  0, 10,  5,  2, B,   P_MACE, WOOD, FALSE, HI_WOOD),
-WEAPON("morning star", (char *)0,
+WEAPON(("morning star"),
 	DMG(D(2, 4)), DMG(D(6), F(1)),
 	1, 0, MZ_MEDIUM, 12, 80, 10,  0, B|P, P_MORNING_STAR, IRON, FALSE, HI_METAL),
-WEAPON("war hammer", (char *)0,
+WEAPON(("war hammer"),
 	DMG(D(4), F(1)), DMG(D(4)),
 	1, 0, MZ_MEDIUM, 15, 50,  5,  0, B,   P_HAMMER, IRON, FALSE, HI_METAL),
-WEAPON("club", (char *)0,
+WEAPON(("club"),
 	DMG(D(6)), DMG(D(3)),
 	1, 0, MZ_MEDIUM, 11, 10,  3,  0, B,   P_CLUB, WOOD, FALSE, HI_WOOD),
-WEAPON("clawed hand", (char *)0,
+WEAPON(("clawed hand"),
 	DMG(D(12)), DMG(D(6)),
 	1, 0, MZ_MEDIUM,  0, 10, 300, 0, P|S, P_CLUB, BONE, FALSE, CLR_GRAY),
-WEAPON("macuahuitl", "obsidian-edged club",
+WEAPON(("macuahuitl", "obsidian-edged club"),
 	DMG(D(8)), DMG(D(6)),
 	0, 0, MZ_MEDIUM,  0, 40, 10,  0, B|S, P_CLUB, WOOD, FALSE, HI_WOOD),
-WEAPON("quarterstaff", "staff",
+WEAPON(("quarterstaff", "staff"),
 	DMG(D(6)), DMG(D(6)),
 	0, 0,   MZ_HUGE, 10, 40,  5,  0, B,   P_QUARTERSTAFF, WOOD, FALSE, HI_WOOD),
-WEAPON("khakkhara", "monk's staff", /*Needs encyc entry*//*Needs tile*/
+WEAPON(("khakkhara", "monk's staff"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(6)), DMG(D(4)),
 	0, 0,   MZ_HUGE,  2,120, 50,  0, B|P, P_QUARTERSTAFF, SILVER, IDED, HI_SILVER),
-WEAPON("kamerel vajra", "short mace", /*Needs encyc entry*/
+WEAPON(("kamerel vajra", "short mace"), /*Needs encyc entry*/
 	DMG(D(6)), DMG(D(6)),	/* very different dice for different litness states */
 	0, 0, MZ_MEDIUM,  0, 10,800,  1, S|E, P_MACE, GOLD, UNIDED, HI_GOLD),
-WEAPON("bar", (char *)0,
+WEAPON(("bar"),
 	DMG(D(8)), DMG(D(6)),
 	1, 0,   MZ_HUGE, 0, 400, 10,-10, B,   P_QUARTERSTAFF, IRON, IDED|UNIDED, HI_METAL),
 /* two-piece */
-WEAPON("aklys", "thonged club",
+WEAPON(("aklys", "thonged club"),
 	DMG(D(6)), DMG(D(3)),
 	0, 0, MZ_MEDIUM,  8, 15,  4,  0, B,   P_CLUB, IRON, FALSE, HI_METAL),
-WEAPON("flail", (char *)0,
+WEAPON(("flail"),
 	DMG(D(6), F(1)), DMG(D(2, 4)),
 	1, 0, MZ_MEDIUM, 35, 15,  4,  0, B,   P_FLAIL, IRON, FALSE, HI_METAL),
 /* misc */
-WEAPON("bullwhip", (char *)0,
+WEAPON(("bullwhip"),
 	DMG(D(2)), DMG(D(1)),
 	1, 0, MZ_MEDIUM,  5, 10,  4,  0, B,   P_WHIP, LEATHER, FALSE, CLR_BROWN),
-WEAPON("viperwhip", (char *)0,
+WEAPON(("viperwhip"),
 	DMG(D(4)), DMG(D(3)),
 	1, 0, MZ_MEDIUM,  2, 30, 40,  2, P,   P_WHIP, SILVER, IDED|UNIDED, HI_SILVER),
 
-WEAPON("bestial claw", (char *)0,
+WEAPON(("bestial claw"),
 	DMG(D(10)), DMG(D(8)),
 	1, 0, MZ_MEDIUM,  0, 10,100,  0, S|P, P_BARE_HANDED_COMBAT, BONE, FALSE, CLR_WHITE),
 
@@ -510,74 +519,74 @@ WEAPON("bestial claw", (char *)0,
 /* Firearms */
 //ifdef FIREARMS
  /*Needs encyc entry*/
-GUN("flintlock", "broken hand-crossbow",            0,   MZ_LARGE, 0,  10,   50,  8, -2,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("flintlock", "broken hand-crossbow"),            0,   MZ_LARGE, 0,  10,   50,  8, -2,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
 
-GUN("pistol", "broken hand-crossbow",               0,   MZ_SMALL, 0,  12,  100, 15,  1,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("submachine gun", "strange broken crossbow",    0,   MZ_SMALL, 0,  25,  250, 10,  3, -1, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("heavy machine gun", "strange broken crossbow", 0,    MZ_HUGE, 0, 100, 2000, 20,  8, -4, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("rifle", "broken crossbow",                     0,    MZ_HUGE, 0,  30,  150, 22, -1,  1, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("assault rifle", "broken crossbow",             0,  MZ_MEDIUM, 0,  40, 1000, 20,  5, -2, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("sniper rifle", "broken crossbow",              0,    MZ_HUGE, 0,  50, 4000, 25, -3,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("shotgun", "broken crossbow",                   0,  MZ_MEDIUM, 0,  35,  200,  3, -1,  3,  WP_SHELL, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("auto shotgun", "strange broken crossbow",      0,    MZ_HUGE, 0,  60, 1500,  3,  2,  0,  WP_SHELL, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("rocket launcher", "metal tube",                0,    MZ_HUGE, 0, 100, 3500, 20, -5, -4, WP_ROCKET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
-GUN("grenade launcher", "strange broken crossbow",  0,   MZ_LARGE, 0,  55, 1500,  6, -3, -3,WP_GRENADE, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("pistol", "broken hand-crossbow"),               0,   MZ_SMALL, 0,  12,  100, 15,  1,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("submachine gun", "strange broken crossbow"),    0,   MZ_SMALL, 0,  25,  250, 10,  3, -1, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("heavy machine gun", "strange broken crossbow"), 0,    MZ_HUGE, 0, 100, 2000, 20,  8, -4, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("rifle", "broken crossbow"),                     0,    MZ_HUGE, 0,  30,  150, 22, -1,  1, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("assault rifle", "broken crossbow"),             0,  MZ_MEDIUM, 0,  40, 1000, 20,  5, -2, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("sniper rifle", "broken crossbow"),              0,    MZ_HUGE, 0,  50, 4000, 25, -3,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("shotgun", "broken crossbow"),                   0,  MZ_MEDIUM, 0,  35,  200,  3, -1,  3,  WP_SHELL, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("auto shotgun", "strange broken crossbow"),      0,    MZ_HUGE, 0,  60, 1500,  3,  2,  0,  WP_SHELL, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("rocket launcher", "metal tube"),                0,    MZ_HUGE, 0, 100, 3500, 20, -5, -4, WP_ROCKET, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
+GUN(("grenade launcher", "strange broken crossbow"),  0,   MZ_LARGE, 0,  55, 1500,  6, -3, -3,WP_GRENADE, IRON, P_FIREARM, HI_METAL), /*Needs tile*/
 
-GUN("BFG", "ovoid device",                          0,    MZ_HUGE, 0, 100, 3000,100,  3,  0,WP_ROCKET|WP_GRENADE|WP_BULLET|WP_SHELL|WP_ROCKET,
+GUN(("BFG", "ovoid device"),                          0,    MZ_HUGE, 0, 100, 3000,100,  3,  0,WP_ROCKET|WP_GRENADE|WP_BULLET|WP_SHELL|WP_ROCKET,
                                                                                                 SILVER, P_FIREARM, HI_SILVER), /*Needs tile*/
-GUN("handgun", "unfamiliar handgun",                0,   MZ_SMALL, 0,  12,  100, 15,  1,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
-GUN("gun", "unfamiliar gun",                        0,  MZ_MEDIUM, 0,  25,  250, 10,  3, -1, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
-GUN("long gun", "unfamiliar long gun",              0,    MZ_HUGE, 0,  30,  150, 22, -1,  1, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
-GUN("heavy gun", "unfamiliar heavy gun",            0,    MZ_HUGE, 0, 100, 2000, 20,  8, -4, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
+GUN(("handgun", "unfamiliar handgun"),                0,   MZ_SMALL, 0,  12,  100, 15,  1,  0, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
+GUN(("gun", "unfamiliar gun"),                        0,  MZ_MEDIUM, 0,  25,  250, 10,  3, -1, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
+GUN(("long gun", "unfamiliar long gun"),              0,    MZ_HUGE, 0,  30,  150, 22, -1,  1, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
+GUN(("heavy gun", "unfamiliar heavy gun"),            0,    MZ_HUGE, 0, 100, 2000, 20,  8, -4, WP_BULLET, IRON, P_FIREARM, HI_METAL),/*Needs tile*/
  /*Needs encyc entry*/
-GUN("hand blaster", "hard black handmirror",        0,  MZ_MEDIUM, 0,   2, 1000, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BLACK), /*Needs tile*/
-GUN("arm blaster",  "hard white bracer",            0,   MZ_LARGE, 0,   8, 4500, 15,  6,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_WHITE), /*Needs tile*/
-GUN("mass-shadow pistol",  "rectangular device",    0,  MZ_MEDIUM, 0,   4, 4500, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_GRAY), /*Needs tile*/
-GUN("cutting laser","hard tan lozenge",             0,   MZ_SMALL, 0,   1, 1000,  3, -1,  3,WP_BLASTER, PLASTIC, P_FIREARM, CLR_YELLOW), /*Needs tile*/
+GUN(("hand blaster", "hard black handmirror"),        0,  MZ_MEDIUM, 0,   2, 1000, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BLACK), /*Needs tile*/
+GUN(("arm blaster",  "hard white bracer"),            0,   MZ_LARGE, 0,   8, 4500, 15,  6,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_WHITE), /*Needs tile*/
+GUN(("mass-shadow pistol",  "rectangular device"),    0,  MZ_MEDIUM, 0,   4, 4500, 10,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_GRAY), /*Needs tile*/
+GUN(("cutting laser","hard tan lozenge"),             0,   MZ_SMALL, 0,   1, 1000,  3, -1,  3,WP_BLASTER, PLASTIC, P_FIREARM, CLR_YELLOW), /*Needs tile*/
 
-GUN("raygun", "hard handle ending in glassy disks", 0,  MZ_MEDIUM, 0,   8, 3000, 15,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BRIGHT_CYAN), /*Needs tile*/
-BULLET("bullet", "pellet",
+GUN(("raygun", "hard handle ending in glassy disks"), 0,  MZ_MEDIUM, 0,   8, 3000, 15,  1,  0,WP_BLASTER, PLASTIC, P_FIREARM, CLR_BRIGHT_CYAN), /*Needs tile*/
+BULLET(("bullet", "pellet"),
 	DMG(D(2, 8), F(4)), DMG(D(2, 6), F(4)),
 	0,    MZ_TINY, 0,  1,   5, 0,  WP_BULLET,   P,   METAL, -P_FIREARM, HI_METAL),/*Needs tile*/
-BULLET("silver bullet", "silver pellet",
+BULLET(("silver bullet", "silver pellet"),
 	DMG(D(2, 8), F(4)), DMG(D(2, 6), F(4)),
 	0,    MZ_TINY, 0,  1,  15, 0,  WP_BULLET,   P,  SILVER, -P_FIREARM, HI_SILVER),/*Needs tile*/
-BULLET("shotgun shell", "red tube",
+BULLET(("shotgun shell", "red tube"),
 	DMG(D(2, 12), F(4)), DMG(D(2, 6), F(4)),
 	0,    MZ_TINY, 0,  1,  10,10,   WP_SHELL,   S,   METAL, -P_FIREARM, CLR_RED),/*Needs tile*/
-BULLET("frag grenade", "green spheriod",
+BULLET(("frag grenade", "green spheriod"),
 	DMG(D(2)), DMG(D(2)),
 	0,   MZ_SMALL, 0,  5, 350, 0, WP_GRENADE,   B,    IRON, -P_FIREARM, CLR_GREEN),/*Needs tile*/
-BULLET("gas grenade", "lime spheriod",
+BULLET(("gas grenade", "lime spheriod"),
 	DMG(D(2)), DMG(D(2)),
 	0,   MZ_SMALL, 0,  2, 350, 0, WP_GRENADE,   B,    IRON, -P_FIREARM, CLR_BRIGHT_GREEN),/*Needs tile*/
-BULLET("rocket", "firework",
+BULLET(("rocket", "firework"),
 	DMG(D(2, 12), F(4)), DMG(D(2, 20), F(4)),
 	0,   MZ_SMALL, 0, 20, 450, 0,  WP_ROCKET,   B,  SILVER, -P_FIREARM, CLR_BLUE),/*Needs tile*/
-BULLET("stick of dynamite", "red stick",
+BULLET(("stick of dynamite", "red stick"),
 	DMG(D(1)), DMG(D(1)),
 	0,   MZ_SMALL, 0, 10, 150, 0, WP_GENERIC,   B, PLASTIC,     P_NONE, CLR_RED),/*Needs tile*/
 
-BULLET("blaster bolt", "ruby bolt",
+BULLET(("blaster bolt", "ruby bolt"),
 	DMG(D(3, 6), F(6)), DMG(D(3, 8), F(8)),
 	0,    MZ_TINY, 0,  1,   0, 0, WP_BLASTER,   E,   METAL, -P_FIREARM, CLR_RED),/*Needs tile*/
-BULLET("heavy blaster bolt", "scarlet bolt",
+BULLET(("heavy blaster bolt", "scarlet bolt"),
 	DMG(D(3, 10), F(10)), DMG(D(3, 12), F(12)),
 	0,    MZ_TINY, 0,  1,   0, 0, WP_BLASTER,   E,   METAL, -P_FIREARM, CLR_ORANGE),/*Needs tile*/
-BULLET("laser beam", "green bolt",
+BULLET(("laser beam", "green bolt"),
 	DMG(D(3, 1), F(10)), DMG(D(3, 1), F(10)),
 	0,    MZ_TINY, 0,  1,   0, 0, WP_BLASTER,   E|S, METAL, -P_FIREARM, CLR_BRIGHT_GREEN),/*Needs tile*/
 //endif
 
 /* bows */
-BOW("bow", (char *)0,			                    1,  MZ_LARGE, 24, 30,  60,  0, WOOD, P_BOW, HI_WOOD),
-BOW("elven bow", "runed bow",	                    0,  MZ_LARGE, 12, 20,  60,  2, WOOD, P_BOW, HI_WOOD),
-BOW("orcish bow", "crude bow",	                    0,  MZ_LARGE, 12, 30,  60, -2, WOOD, P_BOW, CLR_BLACK),
-BOW("yumi", "long bow",			                    0,  MZ_LARGE,  0, 30,  60,  0, WOOD, P_BOW, HI_WOOD),
-BOW("sling", (char *)0,			                    1, MZ_MEDIUM, 40,  3,  20, -1, LEATHER, P_SLING, HI_LEATHER),
-BOW("crossbow", (char *)0,		                    1,  MZ_LARGE, 45, 50,  40,  1, WOOD, P_CROSSBOW, HI_WOOD),
-BOW("droven crossbow", "spider-emblemed crossbow",	0,  MZ_LARGE,  0, 50, 120,  4, SILVER, P_CROSSBOW, CLR_BLACK), /*Needs encyc entry*/
-BOW("atlatl", "notched stick",                      0, MZ_MEDIUM,  0, 12,  30,  0, WOOD, P_SPEAR, HI_WOOD), /*Needs encyc entry*/
+BOW(("bow"),                                          1,  MZ_LARGE, 24, 30,  60,  0, WOOD, P_BOW, HI_WOOD),
+BOW(("elven bow", "runed bow"),                       0,  MZ_LARGE, 12, 20,  60,  2, WOOD, P_BOW, HI_WOOD),
+BOW(("orcish bow", "crude bow"),                      0,  MZ_LARGE, 12, 30,  60, -2, WOOD, P_BOW, CLR_BLACK),
+BOW(("yumi", "long bow"),                             0,  MZ_LARGE,  0, 30,  60,  0, WOOD, P_BOW, HI_WOOD),
+BOW(("sling"),                                        1, MZ_MEDIUM, 40,  3,  20, -1, LEATHER, P_SLING, HI_LEATHER),
+BOW(("crossbow"),                                     1,  MZ_LARGE, 45, 50,  40,  1, WOOD, P_CROSSBOW, HI_WOOD),
+BOW(("droven crossbow", "spider-emblemed crossbow"),  0,  MZ_LARGE,  0, 50, 120,  4, SILVER, P_CROSSBOW, CLR_BLACK), /*Needs encyc entry*/
+BOW(("atlatl", "notched stick"),                      0, MZ_MEDIUM,  0, 12,  30,  0, WOOD, P_SPEAR, HI_WOOD), /*Needs encyc entry*/
 
 #undef WEAPON
 #undef PROJECTILE
@@ -591,80 +600,80 @@ BOW("atlatl", "notched stick",                      0, MZ_MEDIUM,  0, 12,  30,  
  * Only COPPER (including brass) corrodes.
  * Some creatures are vulnerable to SILVER.
  */
-#define ARMOR(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,drslot,sub,metal,c,...) \
+#define ARMOR(names,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,drslot,sub,metal,c,...) \
 	OBJECT( \
-		OBJ(name,desc), BITS(kn,0,1,0,mgc,1,0,0,size,0,drslot,sub,metal,0), power, \
+		names, BITS(kn,0,1,0,mgc,1,0,0,size,0,drslot,sub,metal,0), power, \
 		ARMOR_CLASS, prob, delay, wt, cost, \
 		{0}, {0}, 10 - ac, can, dr, wt, c, __VA_ARGS__ )
 
-#define SUIT(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, TORSO_DR, ARM_SUIT, metal, c, __VA_ARGS__)
-#define SHIRT(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, UPPER_TORSO_DR, ARM_SHIRT, metal, c, __VA_ARGS__)
-#define HELM(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, HEAD_DR, ARM_HELM, metal, c, __VA_ARGS__)
-#define CLOAK(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_MEDIUM, power, prob, delay, wt, cost, ac, dr, can, CLOAK_DR, ARM_CLOAK, metal, c, __VA_ARGS__)
-#define SHIELD(name,desc,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, 0, ARM_SHIELD, metal, c, __VA_ARGS__)
-#define GLOVES(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, ARM_DR, ARM_GLOVES, metal, c, __VA_ARGS__)
-#define BOOTS(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
-	ARMOR(name, desc, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, LEG_DR, ARM_BOOTS, metal, c, __VA_ARGS__)
+#define SUIT(names,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, TORSO_DR, ARM_SUIT, metal, c, __VA_ARGS__)
+#define SHIRT(names,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, UPPER_TORSO_DR, ARM_SHIRT, metal, c, __VA_ARGS__)
+#define HELM(names,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, HEAD_DR, ARM_HELM, metal, c, __VA_ARGS__)
+#define CLOAK(names,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, MZ_MEDIUM, power, prob, delay, wt, cost, ac, dr, can, CLOAK_DR, ARM_CLOAK, metal, c, __VA_ARGS__)
+#define SHIELD(names,kn,mgc,size,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, size, power, prob, delay, wt, cost, ac, dr, can, 0, ARM_SHIELD, metal, c, __VA_ARGS__)
+#define GLOVES(names,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, ARM_DR, ARM_GLOVES, metal, c, __VA_ARGS__)
+#define BOOTS(names,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c,...) \
+	ARMOR(names, kn, mgc, MZ_SMALL, power, prob, delay, wt, cost, ac, dr, can, LEG_DR, ARM_BOOTS, metal, c, __VA_ARGS__)
 
 /* helmets */
-HELM("sedge hat", "wide conical hat", /*Needs encyc entry*//*Needs tile*/
+HELM(("sedge hat", "wide conical hat"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	3, 1,  3,   8,10, 1, 0, VEGGY, CLR_YELLOW),
-HELM("leather helm", "leather hat",
+HELM(("leather helm", "leather hat"),
 		0, 0,  0,	5, 1,  5,   8,10, 1, 0, LEATHER, HI_LEATHER),
-HELM("orcish helm", "skull cap",
+HELM(("orcish helm", "skull cap"),
 		0, 0,  0,	5, 1, 30,  10, 9, 0, 0, IRON, CLR_BLACK),
-HELM("dwarvish helm", "hard hat",
+HELM(("dwarvish helm", "hard hat"),
 		0, 0,  0,	5, 1, 40,  20, 9, 1, 0, IRON, HI_METAL),
-HELM("gnomish pointy hat", "conical hat",
+HELM(("gnomish pointy hat", "conical hat"),
 		0, 0,  0,	0, 1,  3,   2,10, 0, 0, CLOTH, CLR_RED),
-HELM("fedora", (char *)0,
+HELM(("fedora"),
 		1, 0,  0,	0, 0,  3,   1,10, 0, 0, CLOTH, CLR_BROWN),
-HELM("cornuthaum", "conical hat",
+HELM(("cornuthaum", "conical hat"),
 		0, 1,  CLAIRVOYANT,
 					3, 1,  4,  80,10, 0, 2, CLOTH, CLR_BLUE),
-HELM("witch hat", "wide-brimmed conical hat",
+HELM(("witch hat", "wide-brimmed conical hat"),
 		0, 1,  0,   0, 1,  4,  80,10, 0, 2, CLOTH, CLR_BLACK),
-HELM("dunce cap", "conical hat",
+HELM(("dunce cap", "conical hat"),
 		0, 1,  0,	3, 1,  4,   1, 10, 0, 0, CLOTH, CLR_BLUE),
-HELM("war hat", "wide helm", /*Needs encyc entry*//*Needs tile*/
+HELM(("war hat", "wide helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	2, 0, 60,  30, 8, 2, 2, IRON, HI_METAL),
-HELM("flack helmet", "green bowl", /*Needs encyc entry*/
+HELM(("flack helmet", "green bowl"), /*Needs encyc entry*/
 		0, 0,  0,	0, 0, 10,  50, 9, 2, 1, PLASTIC, CLR_GREEN),
-HELM("archaic helm", "helmet",
+HELM(("archaic helm", "helmet"),
 		0, 0,  0,   0, 1, 30,  12, 9, 2, 0, COPPER, HI_COPPER),
-HELM("harmonium helm", "red-lacquered spined helm",
+HELM(("harmonium helm", "red-lacquered spined helm"),
 		0, 0,  0,   0, 1, 45,   1, 9, 2, 0, METAL, CLR_RED),
-HELM("elven helm", "runed helm", /*Needs encyc entry*//*Needs tile*/
+HELM(("elven helm", "runed helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 1, 10,   5, 9, 1, 0, WOOD, HI_WOOD),
-HELM("high-elven helm", "runed helm", /*Needs encyc entry*//*Needs tile*/
+HELM(("high-elven helm", "runed helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 1, 15,   5, 9, 2, 0, MITHRIL, HI_MITHRIL, O_MATSPEC(UNIDED)),
-HELM("droven helm", "spider-shaped helm", /*Needs encyc entry*//*Needs tile*/
+HELM(("droven helm", "spider-shaped helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 1, 20,   5, 8, 2, 0, SHADOWSTEEL, CLR_BLACK),
-HELM("plasteel helm", "white skull helm", /*Needs encyc entry*//*Needs tile*/
+HELM(("plasteel helm", "white skull helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 1,  INFRAVISION,   0, 2, 25,  50, 8, 2, 2, PLASTIC, CLR_WHITE),
-HELM("crystal helm", "fish bowl", /*Needs encyc entry*//*Needs tile*/
+HELM(("crystal helm", "fish bowl"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,   0, 2,150, 300, 9, 1, 0, GLASS, HI_GLASS, O_MATSPEC(UNIDED)),
-HELM("pontiff's crown", "filigreed faceless helm", /*Needs encyc entry*//*Needs tile*/
+HELM(("pontiff's crown", "filigreed faceless helm"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,   0, 2, 90, 300, 8, 3, 0, GOLD, HI_GOLD, O_MATSPEC(IDED)),
-HELM("shemagh", "white headscarf", /*Needs encyc entry*//*Needs tile*/
+HELM(("shemagh", "white headscarf"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	0, 0, 5,   5, 10, 0, 0, CLOTH, CLR_WHITE, O_MATSPEC(UNIDED)),
 
 /* With shuffled appearances... */
-HELM("helmet", "plumed helmet", /* circlet */
+HELM(("helmet", "plumed helmet"), /* circlet */
 		0, 0,  0,      8, 1, 30,  10, 9, 2, 0, IRON, HI_METAL),
-HELM("helm of brilliance", "etched helmet", /* crown of cognizance */
+HELM(("helm of brilliance", "etched helmet"), /* crown of cognizance */
 		0, 1,  0,	6, 1, 30,  50, 9, 1, 0, IRON, HI_METAL),
-HELM("helm of opposite alignment", "crested helmet", /* tiara of treachery */
+HELM(("helm of opposite alignment", "crested helmet"), /* tiara of treachery */
 		0, 1,  0,	6, 1, 30,  50, 9, 1, 0, IRON, HI_METAL),
-HELM("helm of telepathy", "visored helmet", /*tiara of telepathy*/ /*Note: 'visored' appearance gives +1 DR*/
+HELM(("helm of telepathy", "visored helmet"), /*tiara of telepathy*/ /*Note: 'visored' appearance gives +1 DR*/
 		0, 1,  TELEPAT, 2, 1, 30,  50, 9, 1, 0, IRON, HI_METAL),
-HELM("helm of drain resistance", "band", /*diadem of drain resistance*//*Needs tile*//*Note: 'band' appearance gives -1 DR*/
+HELM(("helm of drain resistance", "band"), /*diadem of drain resistance*//*Needs tile*//*Note: 'band' appearance gives -1 DR*/
 		0, 1,  DRAIN_RES, 2, 1, 30,  50, 9, 1, 0, GOLD, HI_GOLD),
 
 /* suits of armor */
@@ -676,276 +685,280 @@ HELM("helm of drain resistance", "band", /*diadem of drain resistance*//*Needs t
  *	(2) That the order of the dragon scale mail and dragon scales is the
  *	    the same defined in monst.c.
  */
-#define DRGN_ARMR(name,mgc,power,cost,ac,dr,color,...) \
-	SUIT(name,(char *)0,1,mgc,MZ_HUGE,power,0,5,150,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
+#define DRGN_MAIL(names,mgc,power,cost,ac,dr,color,...) \
+	SUIT(DEF_BLINDNAME(names, "dragon scale mail"),1,mgc,MZ_HUGE,power,0,5,150,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
 /* 3.4.1: dragon scale mail reclassified as "magic" since magic is
    needed to create them */
-DRGN_ARMR("gray dragon scale mail",   1, ANTIMAGIC,  1200, 5, 4, CLR_GRAY),
-DRGN_ARMR("silver dragon scale mail", 1, REFLECTING, 1200, 5, 4, DRAGON_SILVER),
-DRGN_ARMR("shimmering dragon scale mail", 1, DISPLACED, 1200, 5, 4, CLR_CYAN),
-DRGN_ARMR("red dragon scale mail",    1, FIRE_RES,    900, 5, 4, CLR_RED),
-DRGN_ARMR("white dragon scale mail",  1, COLD_RES,    900, 5, 4, CLR_WHITE),
-DRGN_ARMR("orange dragon scale mail", 1, FREE_ACTION,   900, 5, 4, CLR_ORANGE),
-DRGN_ARMR("black dragon scale mail",  1, DISINT_RES, 1200, 5, 4, CLR_BLACK),
-DRGN_ARMR("blue dragon scale mail",   1, SHOCK_RES,   900, 5, 4, CLR_BLUE),
-DRGN_ARMR("green dragon scale mail",  1, POISON_RES,  900, 5, 4, CLR_GREEN),
-DRGN_ARMR("yellow dragon scale mail", 1, ACID_RES,    900, 5, 4, CLR_YELLOW),
+DRGN_MAIL(("gray dragon scale mail"),   1, ANTIMAGIC,  1200, 5, 4, CLR_GRAY),
+DRGN_MAIL(("silver dragon scale mail"), 1, REFLECTING, 1200, 5, 4, DRAGON_SILVER),
+DRGN_MAIL(("shimmering dragon scale mail"), 1, DISPLACED, 1200, 5, 4, CLR_CYAN),
+DRGN_MAIL(("red dragon scale mail"),    1, FIRE_RES,    900, 5, 4, CLR_RED),
+DRGN_MAIL(("white dragon scale mail"),  1, COLD_RES,    900, 5, 4, CLR_WHITE),
+DRGN_MAIL(("orange dragon scale mail"), 1, FREE_ACTION,   900, 5, 4, CLR_ORANGE),
+DRGN_MAIL(("black dragon scale mail"),  1, DISINT_RES, 1200, 5, 4, CLR_BLACK),
+DRGN_MAIL(("blue dragon scale mail"),   1, SHOCK_RES,   900, 5, 4, CLR_BLUE),
+DRGN_MAIL(("green dragon scale mail"),  1, POISON_RES,  900, 5, 4, CLR_GREEN),
+DRGN_MAIL(("yellow dragon scale mail"), 1, ACID_RES,    900, 5, 4, CLR_YELLOW),
+#undef DRGN_MAIL
 
+#define DRGN_SCALES(names,mgc,power,cost,ac,dr,color,...) \
+	SUIT(DEF_BLINDNAME(names, "dragon scales"),1,mgc,MZ_HUGE,power,0,5,150,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
 /* For now, only dragons leave these. */
 /* 3.4.1: dragon scales left classified as "non-magic"; they confer
    magical properties but are produced "naturally" */
-DRGN_ARMR("gray dragon scales",   0, ANTIMAGIC,  700, 9, 2, CLR_GRAY),
-DRGN_ARMR("silver dragon scales", 0, REFLECTING, 700, 9, 2, DRAGON_SILVER),
-DRGN_ARMR("shimmering dragon scales", 0, DISPLACED,  700, 9, 2, CLR_CYAN),
-DRGN_ARMR("red dragon scales",    0, FIRE_RES,   500, 9, 2, CLR_RED),
-DRGN_ARMR("white dragon scales",  0, COLD_RES,   500, 9, 2, CLR_WHITE),
-DRGN_ARMR("orange dragon scales", 0, FREE_ACTION,  500, 9, 2, CLR_ORANGE),
-DRGN_ARMR("black dragon scales",  0, DISINT_RES, 700, 9, 2, CLR_BLACK),
-DRGN_ARMR("blue dragon scales",   0, SHOCK_RES,  500, 9, 2, CLR_BLUE),
-DRGN_ARMR("green dragon scales",  0, POISON_RES, 500, 9, 2, CLR_GREEN),
-DRGN_ARMR("yellow dragon scales", 0, ACID_RES,   500, 9, 2, CLR_YELLOW),
-#undef DRGN_ARMR
+DRGN_SCALES(("gray dragon scales"),   0, ANTIMAGIC,  700, 9, 2, CLR_GRAY),
+DRGN_SCALES(("silver dragon scales"), 0, REFLECTING, 700, 9, 2, DRAGON_SILVER),
+DRGN_SCALES(("shimmering dragon scales"), 0, DISPLACED,  700, 9, 2, CLR_CYAN),
+DRGN_SCALES(("red dragon scales"),    0, FIRE_RES,   500, 9, 2, CLR_RED),
+DRGN_SCALES(("white dragon scales"),  0, COLD_RES,   500, 9, 2, CLR_WHITE),
+DRGN_SCALES(("orange dragon scales"), 0, FREE_ACTION,  500, 9, 2, CLR_ORANGE),
+DRGN_SCALES(("black dragon scales"),  0, DISINT_RES, 700, 9, 2, CLR_BLACK),
+DRGN_SCALES(("blue dragon scales"),   0, SHOCK_RES,  500, 9, 2, CLR_BLUE),
+DRGN_SCALES(("green dragon scales"),  0, POISON_RES, 500, 9, 2, CLR_GREEN),
+DRGN_SCALES(("yellow dragon scales"), 0, ACID_RES,   500, 9, 2, CLR_YELLOW),
+#undef DRGN_SCALES
 
-SUIT("plate mail", (char *)0, /*Needs encyc entry*/
+SUIT(("plate mail"), /*Needs encyc entry*/
 	1, 0,   MZ_HUGE, 0,	44, 5, 225, 600,  5, 5, 3, IRON, HI_METAL),
-SUIT("high-elven plate", "runed plate mail", /*Needs encyc entry*/
+SUIT(("high-elven plate", "runed plate mail"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 110, 	1200,  4, 6, 3, MITHRIL, HI_MITHRIL),
-SUIT("droven plate mail", "crested black plate", /*Needs encyc entry*/
+SUIT(("droven plate mail", "crested black plate"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 85, 	2000,  4, 6, 1, SHADOWSTEEL, CLR_BLACK),
-SUIT("elven toga", (char *)0, /*Needs encyc entry*//*Needs tile*/
+SUIT(("elven toga"), /*Needs encyc entry*//*Needs tile*/
 	1, 0,  MZ_LARGE, 0,	 0, 5,	 5,  100,10, 1, 2, CLOTH, CLR_GREEN),
-SUIT("noble's dress", "armored black dress", /*Needs encyc entry*/
+SUIT(("noble's dress", "armored black dress"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 40, 2000,  6, 4, 3, SHADOWSTEEL, CLR_BLACK),
-SHIRT("black dress", (char *)0, /*Needs encyc entry*/
+SHIRT(("black dress"), /*Needs encyc entry*/
 	1, 0,   MZ_HUGE, 0,	0, 5,  5,  500, 10, 0, 2, CLOTH, CLR_BLACK, O_DRSLOT(TORSO_DR)),
-SUIT("consort's suit", "loud foppish suit", /*Needs encyc entry*//*Needs tile*/
+SUIT(("consort's suit", "loud foppish suit"), /*Needs encyc entry*//*Needs tile*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 10, 	1000, 10, 1, 1, CLOTH, CLR_BRIGHT_MAGENTA),
-SUIT("gentleman's suit", "expensive clothes", /*Needs encyc entry*/
+SUIT(("gentleman's suit", "expensive clothes"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 5, 10, 1000,  10, 1, 2, CLOTH, CLR_BLACK),
-SUIT("gentlewoman's dress", "expensive dress", /*Needs encyc entry*/
+SUIT(("gentlewoman's dress", "expensive dress"), /*Needs encyc entry*/
 	0, 0,   MZ_HUGE, 0,	0, 6,100, 1000,  10, 1, 3, BONE, CLR_RED), /*Specifically, whale bone*/
-SUIT("crystal plate mail", (char *)0, /*Needs encyc entry*/
+SUIT(("crystal plate mail"), /*Needs encyc entry*/
 	1, 0,   MZ_HUGE, 0,	10, 5, 170, 2000,  7, 3, 0, GLASS, HI_GLASS), /*Best armor, AC wise*/
 #ifdef TOURIST
-SUIT("archaic plate mail", (char *)0, /*Needs encyc entry*/
+SUIT(("archaic plate mail"), /*Needs encyc entry*/
 	1, 0,   MZ_HUGE, 0,	20, 5, 200, 400,  6, 4, 3, COPPER, HI_COPPER),
 #else
-SUIT("archaic plate mail", (char *)0,
+SUIT(("archaic plate mail"),
 	1, 0,   MZ_HUGE, 0,	35, 5, 200, 400,  6, 4, 3, COPPER, HI_COPPER),
 #endif
-SUIT("harmonium plate", "red-lacquered bladed armor",
+SUIT(("harmonium plate", "red-lacquered bladed armor"),
 	0, 0,   MZ_HUGE, 0,	 0, 5, 225,   1,  6, 4, 3, METAL, CLR_RED),
-SUIT("harmonium scale mail", "red-lacquered spiked scale mail",
+SUIT(("harmonium scale mail", "red-lacquered spiked scale mail"),
 	0, 0,   MZ_HUGE, 0,	 0, 5, 125,   1,  8, 2, 3, METAL, CLR_RED),
-SUIT("plasteel armor", "hard white armor", /*Needs encyc entry*//*Needs tile*/
+SUIT(("plasteel armor", "hard white armor"), /*Needs encyc entry*//*Needs tile*/
 	0, 0,   MZ_HUGE, 0,	 0, 5, 100,  500, 7, 3, 3, PLASTIC, CLR_WHITE),
-// ARMOR("force armor", "gemstone-adorned clothing",
+// ARMOR(("force armor", "gemstone-adorned clothing"),
 	// 0, 0, 1, 0,	 0, 5,  50, 1000, 9, 3, ARM_SUIT, GEMSTONE, CLR_BRIGHT_GREEN),
-SUIT("splint mail", (char *)0,
+SUIT(("splint mail"),
 	1, 0,   MZ_HUGE, 0,	62, 5, 200,  80,  7, 3, 1, IRON, HI_METAL),
-SUIT("barnacle armor", "giant shell armor",
+SUIT(("barnacle armor", "giant shell armor"),
 	0, 1,  MZ_LARGE, 0,	0, 10, 150, 1000,  7, 3, 1, SHELL_MAT, CLR_GRAY),
-SUIT("banded mail", (char *)0,
+SUIT(("banded mail"),
 	1, 0,   MZ_HUGE, 0,	72, 5, 175,  90,  7, 3, 0, IRON, HI_METAL),
-SUIT("dwarvish mithril-coat", (char *)0,
+SUIT(("dwarvish mithril-coat"),
 	1, 0, MZ_MEDIUM, 0,	10, 1,  40, 240,   7, 3, 3, MITHRIL, HI_MITHRIL),
-SUIT("elven mithril-coat", (char *)0,
+SUIT(("elven mithril-coat"),
 	1, 0, MZ_MEDIUM, 0,	15, 1,  20, 240,  7, 2, 3, MITHRIL, HI_MITHRIL),
-SUIT("chain mail", (char *)0,
+SUIT(("chain mail"),
 	1, 0,  MZ_LARGE, 0,	72, 5, 150,  75,  8, 3, 1, IRON, HI_METAL),
-SUIT("droven chain mail", "crested black mail", /*Needs encyc entry*/
+SUIT(("droven chain mail", "crested black mail"), /*Needs encyc entry*/
 	0, 0,  MZ_LARGE, 0,	0, 5,   50,  1000,  8, 4, 2, SHADOWSTEEL, CLR_BLACK),
-SUIT("orcish chain mail", "crude chain mail",
+SUIT(("orcish chain mail", "crude chain mail"),
 	0, 0,  MZ_LARGE, 0,	20, 5, 150,  75,  8, 2, 1, IRON, CLR_BLACK),
-SUIT("scale mail", (char *)0,
+SUIT(("scale mail"),
 	1, 0,  MZ_LARGE, 0,	72, 5, 125,  45,  8, 2, 0, IRON, HI_METAL),
-SUIT("studded leather armor", (char *)0,
+SUIT(("studded leather armor"),
 	1, 0,  MZ_LARGE, 0,	72, 3,  50,  15,  9, 2, 1, LEATHER, HI_LEATHER),
-SUIT("ring mail", (char *)0,
+SUIT(("ring mail"),
 	1, 0,  MZ_LARGE, 0,	72, 5, 125, 100,  9, 2, 0, IRON, HI_METAL),
-SUIT("orcish ring mail", "crude ring mail",
+SUIT(("orcish ring mail", "crude ring mail"),
 	0, 0,  MZ_LARGE, 0,	20, 5, 125,  80,  9, 1, 1, IRON, CLR_BLACK),
-SUIT("leather armor", (char *)0,
+SUIT(("leather armor"),
 	1, 0,  MZ_LARGE, 0,	82, 3,  40,   5, 10, 2, 0, LEATHER, HI_LEATHER),
-//ARMOR(name,desc,
+//ARMOR(names,
    //kn,mgc,blk,power,prob,delay,wt,cost,ac,dr,can,sub,metal,c)
-SUIT("living armor", "giant sea anemone",
+SUIT(("living armor", "giant sea anemone"),
 	0, 1,  MZ_LARGE, 0,	0, 6,  80,  500, 10, 2, 0, FLESH, CLR_ORANGE),
-SUIT("jacket", (char *)0,
+SUIT(("jacket"),
 	1, 0, MZ_MEDIUM, 0,	12, 0,	20,  10, 10, 1, 2, LEATHER, HI_LEATHER, O_MATSPEC(IDED|UNIDED)),
-SUIT("straitjacket", "long-sleeved jacket", /*Needs encyc entry*//*Needs tile*/
+SUIT(("straitjacket", "long-sleeved jacket"), /*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_MEDIUM, 0,	0, 0,   15,  10, 10, 1, 2, CLOTH, CLR_WHITE),
-SUIT("healer uniform","clean white clothes", /*Needs encyc entry*//*Needs tile*/
+SUIT(("healer uniform","clean white clothes"), /*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_MEDIUM, SICK_RES,	0, 0,	30,  10, 10, 1, 0, CLOTH, CLR_WHITE),
 #ifdef TOURIST
 /* shirts */
-/*ARMOR("Hawaiian shorts", "flowery shorts and lei",
+/*ARMOR(("Hawaiian shorts", "flowery shorts and lei"),
 	1, 0, 0, 0,	 0, 0,	 5,   3, 10, 0, ARM_SUIT, CLOTH, CLR_MAGENTA),
 */
-SHIRT("Hawaiian shirt", "flowery shirt",
+SHIRT(("Hawaiian shirt", "flowery shirt"),
 	0, 0, MZ_MEDIUM, 0,	 10, 0,	 5,   3, 10, 0, 0, CLOTH, CLR_MAGENTA),
-SHIRT("T-shirt", (char *)0, /*Needs encyc entry*/
+SHIRT(("T-shirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 5, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
-SHIRT("ichcahuipilli", "thick undershirt", /*Needs encyc entry*/
+SHIRT(("ichcahuipilli", "thick undershirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 3,	 10,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 # ifdef CONVICT
-SHIRT("striped shirt", (char *)0, /*Needs encyc entry*/
+SHIRT(("striped shirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_GRAY),
 # endif /* CONVICT */
 #endif
 /*Ruffled shirts are little different from other shirts*/
-SHIRT("ruffled shirt", (char *)0, /*Needs encyc entry*/
+SHIRT(("ruffled shirt"), /*Needs encyc entry*/
 	1, 0, MZ_MEDIUM, 0,	 0, 0,	 5,   2, 10, 0, 0, CLOTH, CLR_WHITE),
 /* victorian underwear, on the other hand, inflicts a penalty to AC but grants MC 3 */
 /* needs special case to be 'bulky' */
-SHIRT("victorian underwear", "white dress",
+SHIRT(("victorian underwear", "white dress"),
 	0, 0, MZ_MEDIUM, 		  0,	 0, 5,	 5,   10, 10, 2, 3, CLOTH, CLR_WHITE,  O_DRSLOT(TORSO_DR)),
-SUIT("jumpsuit", "silvery clothes",/*Needs encyc entry*//*Needs tile*/
+SUIT(("jumpsuit", "silvery clothes"),/*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_HUGE, REFLECTING,	 0, 5,	 5, 1000, 10, 1, 3, PLASTIC, HI_SILVER, O_DRSLOT(ALL_DR)),
-SHIRT("bodyglove", "tight black clothes", /*Needs encyc entry*//*Needs tile*/
+SHIRT(("bodyglove", "tight black clothes"), /*Needs encyc entry*//*Needs tile*/
 	0, 0, MZ_HUGE, SICK_RES,	 0, 5,	 5, 1000, 10, 0, 3, PLASTIC, CLR_BLACK, O_DRSLOT(ALL_DR)),
 /* cloaks */
 /*  'cope' is not a spelling mistake... leave it be */
-CLOAK("mummy wrapping", (char *)0,
+CLOAK(("mummy wrapping"),
 		1, 0,	0,	    0, 0,  3,  2, 10, 0, 1, CLOTH, CLR_GRAY),
-CLOAK("elven cloak", "faded pall",
+CLOAK(("elven cloak", "faded pall"),
 		0, 1,	STEALTH,    7, 0, 10, 60,  9, 0, 3, CLOTH, CLR_BLACK),
-CLOAK("droven cloak", "cobwebbed cloak", /*Needs encyc entry*/
+CLOAK(("droven cloak", "cobwebbed cloak"), /*Needs encyc entry*/
 		0, 1,	0,      1, 0, 10, 60,  10, 0, 3, CLOTH, CLR_GRAY),
-CLOAK("orcish cloak", "coarse mantelet",
+CLOAK(("orcish cloak", "coarse mantelet"),
 		0, 0,	0,	    8, 0, 10, 40, 10, 0, 2, CLOTH, CLR_BLACK),
-CLOAK("dwarvish cloak", "hooded cloak",
+CLOAK(("dwarvish cloak", "hooded cloak"),
 		0, 0,	0,	    8, 0, 10, 50,10, 1, 2, CLOTH, CLR_BLUE, O_DRSLOT(HEAD_DR|CLOAK_DR)),
-CLOAK("oilskin cloak", "slippery cloak",
+CLOAK(("oilskin cloak", "slippery cloak"),
 		0, 0,	0,	    8, 0, 10, 50,  9, 0, 3, CLOTH, HI_CLOTH),
-CLOAK("robe", (char *)0,
+CLOAK(("robe"),
 		1, 1,	0,	    3, 0, 15, 50, 10, 2, 3, CLOTH, CLR_RED),
-CLOAK("white faceless robe", (char *)0,
+CLOAK(("white faceless robe"),
 		1, 1,	0,	    0, 2, 20, 50, 10, 1, 3, CLOTH, CLR_WHITE, O_DRSLOT(HEAD_DR|CLOAK_DR)),
-CLOAK("black faceless robe", (char *)0,
+CLOAK(("black faceless robe"),
 		1, 1,	COLD_RES,	    0, 2, 20, 50, 10, 2, 3, CLOTH, CLR_BLACK, O_DRSLOT(HEAD_DR|CLOAK_DR)),
-CLOAK("smoky violet faceless robe", (char *)0,
+CLOAK(("smoky violet faceless robe"),
 		1, 1,	COLD_RES,	    0, 2, 20,500, 10, 3, 3, CLOTH, CLR_MAGENTA, O_DRSLOT(HEAD_DR|CLOAK_DR)),
-CLOAK("alchemy smock", "apron",
+CLOAK(("alchemy smock", "apron"),
 		0, 1,	POISON_RES, 9, 0, 10, 50, 10, 1, 3, CLOTH, CLR_WHITE),
-CLOAK("Leo Nemaeus hide", "lion skin",
+CLOAK(("Leo Nemaeus hide", "lion skin"),
 		0, 1,	HALF_PHDAM,	    0, 10, 60, 1200, 10, 5, 0, DRAGON_HIDE, HI_GOLD),
-CLOAK("cloak", (char *)0,
+CLOAK(("cloak"),
 		1, 0,	0,	    8, 0, 15, 40, 10, 2, 1, LEATHER, CLR_BROWN, O_MATSPEC(IDED|UNIDED)),
 /* With shuffled appearances... */
-CLOAK("cloak of protection", "tattered cape",
+CLOAK(("cloak of protection", "tattered cape"),
 		0, 1,	PROTECTION, 9, 0, 10, 50,  9, 1, 3, CLOTH, HI_CLOTH),
-CLOAK("cloak of invisibility", "opera cloak",
+CLOAK(("cloak of invisibility", "opera cloak"),
 		0, 1,	INVIS,	   10, 0, 10, 60,  9, 0, 2, CLOTH, CLR_BLACK),
-CLOAK("cloak of magic resistance", "ornamental cope",
+CLOAK(("cloak of magic resistance", "ornamental cope"),
 		0, 1,	ANTIMAGIC,  2, 0, 10, 60, 10, 0, 3, CLOTH, CLR_WHITE),
-CLOAK("cloak of displacement", "piece of cloth",
+CLOAK(("cloak of displacement", "piece of cloth"),
 		0, 1,	DISPLACED, 10, 0, 10, 50,  9, 0, 2, CLOTH, CLR_BRIGHT_MAGENTA),
 
 /* shields */
-SHIELD("buckler", (char *)0,
+SHIELD(("buckler"),
 		1, 0,  MZ_SMALL, 0,	     6, 0, 30,	3,  9, 0, 0, WOOD, HI_WOOD),
-SHIELD("elven shield", "blue and green shield",
+SHIELD(("elven shield", "blue and green shield"),
 		0, 0,  MZ_SMALL, 0,	     2, 0, 30,	7,  8, 0, 2, WOOD, CLR_GREEN),
-SHIELD("Uruk-hai shield", "white-handed shield",
+SHIELD(("Uruk-hai shield", "white-handed shield"),
 		0, 0, MZ_MEDIUM, 0,	     2, 0, 50,	7,  8, 0, 1, IRON, HI_METAL),
-SHIELD("orcish shield", "red-eyed shield",
+SHIELD(("orcish shield", "red-eyed shield"),
 		0, 0, MZ_MEDIUM, 0,	     2, 0, 50,	7,  9, 0, 0, IRON, CLR_RED),
-SHIELD("kite shield", (char *)0,
+SHIELD(("kite shield"),
 		1, 0,  MZ_LARGE, 0,	     6, 0,100, 10,  8, 0, 1, IRON, HI_METAL),
-SHIELD("roundshield", "round shield",
+SHIELD(("roundshield", "round shield"),
 		0, 0,  MZ_LARGE, 0,	     1, 0,120,  7,  8, 0, 1, COPPER, HI_COPPER, O_MATSPEC(IDED)),
-SHIELD("dwarvish roundshield", "round shield",
+SHIELD(("dwarvish roundshield", "round shield"),
 		0, 0,  MZ_LARGE, 0,	     4, 0, 80, 10,  7, 0, 1, IRON, HI_METAL),
-SHIELD("crystal shield", "shield", /*Needs encyc entry*//*Needs tile*/
+SHIELD(("crystal shield", "shield"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  MZ_LARGE, 0,	     0, 0, 80,150,  9, 0, 0, GLASS, HI_GLASS, O_MATSPEC(UNIDED)),
-SHIELD("shield of reflection", "polished shield",
+SHIELD(("shield of reflection", "polished shield"),
 		0, 1,  MZ_LARGE, REFLECTING, 3, 0, 60, 50,  8, 0, 0, SILVER, HI_SILVER),
-/*#define SHIELD(name,desc,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,metal,c) \
-     ARMOR(name,desc,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,ARM_SHIELD,metal,c) */
-#define DRGN_SHIELD(name,mgc,power,cost,ac,dr,color,...)						\
-	SHIELD(name,(char *)0,1,mgc,MZ_LARGE,power,0,0,75,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
+/*#define SHIELD(names,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,metal,c) \
+     ARMOR(names,kn,mgc,blk,power,prob,delay,wt,cost,ac,can,ARM_SHIELD,metal,c) */
+#define DRGN_SHIELD(names,mgc,power,cost,ac,dr,color,...)						\
+	SHIELD(DEF_BLINDNAME(names, "dragon scale shield"),1,mgc,MZ_LARGE,power,0,0,75,cost,ac,dr,0,DRAGON_HIDE,color,__VA_ARGS__)
 /* 3.4.1: dragon scale mail reclassified as "magic" since magic is
    needed to create them */
-DRGN_SHIELD("gray dragon scale shield", 1, ANTIMAGIC,  1200, 7, 0, CLR_GRAY),
-DRGN_SHIELD("silver dragon scale shield", 1, REFLECTING, 1200, 7, 0, DRAGON_SILVER),
-DRGN_SHIELD("shimmering dragon scale shield", 1, DISPLACED, 1200, 7, 0, CLR_CYAN),
-DRGN_SHIELD("red dragon scale shield", 1, FIRE_RES,    900, 7, 0, CLR_RED),
-DRGN_SHIELD("white dragon scale shield", 1, COLD_RES,    900, 7, 0, CLR_WHITE),
-DRGN_SHIELD("orange dragon scale shield", 1, FREE_ACTION,   900, 7, 0, CLR_ORANGE),
-DRGN_SHIELD("black dragon scale shield", 1, DISINT_RES, 1200, 7, 0, CLR_BLACK),
-DRGN_SHIELD("blue dragon scale shield", 1, SHOCK_RES,   900, 7, 0, CLR_BLUE),
-DRGN_SHIELD("green dragon scale shield", 1, POISON_RES,  900, 7, 0, CLR_GREEN),
-DRGN_SHIELD("yellow dragon scale shield", 1, ACID_RES,   900, 7, 0, CLR_YELLOW),
+DRGN_SHIELD(("gray dragon scale shield"),       1, ANTIMAGIC,  1200, 7, 0, CLR_GRAY),
+DRGN_SHIELD(("silver dragon scale shield"),     1, REFLECTING, 1200, 7, 0, DRAGON_SILVER),
+DRGN_SHIELD(("shimmering dragon scale shield"), 1, DISPLACED,  1200, 7, 0, CLR_CYAN),
+DRGN_SHIELD(("red dragon scale shield"),        1, FIRE_RES,    900, 7, 0, CLR_RED),
+DRGN_SHIELD(("white dragon scale shield"),      1, COLD_RES,    900, 7, 0, CLR_WHITE),
+DRGN_SHIELD(("orange dragon scale shield"),     1, FREE_ACTION, 900, 7, 0, CLR_ORANGE),
+DRGN_SHIELD(("black dragon scale shield"),      1, DISINT_RES, 1200, 7, 0, CLR_BLACK),
+DRGN_SHIELD(("blue dragon scale shield"),       1, SHOCK_RES,   900, 7, 0, CLR_BLUE),
+DRGN_SHIELD(("green dragon scale shield"),      1, POISON_RES,  900, 7, 0, CLR_GREEN),
+DRGN_SHIELD(("yellow dragon scale shield"),     1, ACID_RES,    900, 7, 0, CLR_YELLOW),
+#undef DRGN_SHIELD
 
 /* gloves */
 /* these have their color but not material shuffled, so the IRON must stay
  * CLR_BROWN (== HI_LEATHER)
  */
-//define GLOVES(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c) \
-	ARMOR(name,desc,kn,mgc,0,power,prob,delay,wt,cost,ac,dr,can,ARM_GLOVES,metal,c)
-GLOVES("crystal gauntlets", "gauntlets", /*Needs encyc entry*//*Needs tile*/
+//define GLOVES(names,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c) \
+	ARMOR(names,kn,mgc,0,power,prob,delay,wt,cost,ac,dr,can,ARM_GLOVES,metal,c)
+GLOVES(("crystal gauntlets", "gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 20, 400, 9, 0, 0, GLASS, HI_GLASS, O_MATSPEC(UNIDED)),
-GLOVES("gauntlets", (char *)0, /*Needs encyc entry*//*Needs tile*/
+GLOVES(("gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		1, 0,  0,	   4, 2, 25, 10, 8, 2, 0, IRON, HI_METAL, O_MATSPEC(IDED|UNIDED)),
-GLOVES("archaic gauntlets", (char *)0, /*Needs encyc entry*//*Needs tile*/
+GLOVES(("archaic gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		1, 0,  0,	   0, 2, 25, 10, 8, 2, 0, COPPER, HI_COPPER),
-GLOVES("long gloves", (char *)0,
+GLOVES(("long gloves"),
 		1, 0,  0,	   0, 1,  5,  8, 10, 2, 1, CLOTH, CLR_WHITE),
-GLOVES("harmonium gauntlets", "red-lacquered hooked gauntlets", /*Needs encyc entry*//*Needs tile*/
+GLOVES(("harmonium gauntlets", "red-lacquered hooked gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 40,  1, 9, 2, 0, METAL, CLR_RED),
-GLOVES("high-elven gauntlets", "runed gauntlets", /*Needs encyc entry*//*Needs tile*/
+GLOVES(("high-elven gauntlets", "runed gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 15, 50, 8, 2, 0, MITHRIL, HI_MITHRIL),
-GLOVES("plasteel gauntlets", "hard white gauntlets", /*Needs encyc entry*//*Needs tile*/
+GLOVES(("plasteel gauntlets", "hard white gauntlets"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 15, 50,  8, 2, 0, PLASTIC, CLR_WHITE),
-GLOVES("gloves", "old gloves",
+GLOVES(("gloves", "old gloves"),
 		0, 0,  0,	   8, 1, 10,  8, 10, 1, 0, LEATHER, HI_LEATHER, O_MATSPEC(IDED)),
-GLOVES("gauntlets of fumbling", "padded gloves", /*"padded" should give +1 DR*/
+GLOVES(("gauntlets of fumbling", "padded gloves"), /*"padded" should give +1 DR*/
 		0, 1,  FUMBLING,   7, 1, 10, 50, 10, 1, 0, LEATHER, HI_LEATHER),
-GLOVES("gauntlets of power", "riding gloves",
+GLOVES(("gauntlets of power", "riding gloves"),
 		0, 1,  0,	   7, 1, 30, 50,  9, 1, 0, IRON, CLR_BROWN),
-GLOVES("orihalcyon gauntlets", "fighting gloves",/*Needs tile*/
+GLOVES(("orihalcyon gauntlets", "fighting gloves"),/*Needs tile*/
 		0, 1,  ANTIMAGIC,  7, 1, 30, 50,  8, 2, 0, METAL, CLR_BROWN),
-GLOVES("gauntlets of dexterity", "fencing gloves",
+GLOVES(("gauntlets of dexterity", "fencing gloves"),
 		0, 1,  0,	   7, 1, 10, 50,  8, 0, 0, LEATHER, HI_LEATHER),
 
 /* boots */
-//define BOOTS(name,desc,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c) \
-	ARMOR(name,desc,kn,mgc,0,power,prob,delay,wt,cost,ac,dr,can,ARM_BOOTS,metal,c)
-BOOTS("low boots", "walking shoes",
+//define BOOTS(names,kn,mgc,power,prob,delay,wt,cost,ac,dr,can,metal,c) \
+	ARMOR(names,kn,mgc,0,power,prob,delay,wt,cost,ac,dr,can,ARM_BOOTS,metal,c)
+BOOTS(("low boots", "walking shoes"),
 		0, 0,  0,	  25, 2, 10,  8, 10, 1, 0, LEATHER, HI_LEATHER),
-BOOTS("shoes", "hard shoes",
+BOOTS(("shoes", "hard shoes"),
 		0, 0,  0,	   7, 2, 50, 16,  9, 1, 0, IRON, HI_METAL, O_MATSPEC(IDED)),
-BOOTS("armored boots", "boots",
+BOOTS(("armored boots", "boots"),
 		0, 0,  0,	   0, 1, 75, 16,  8, 2, 1, IRON, HI_METAL, O_MATSPEC(IDED|UNIDED)),
-BOOTS("archaic boots", "boots",
+BOOTS(("archaic boots", "boots"),
 		0, 0,  0,	   0, 1, 75, 16,  8, 2, 1, COPPER, HI_COPPER,O_MATSPEC(UNIDED)),
-BOOTS("harmonium boots", "red-lacquered boots",
+BOOTS(("harmonium boots", "red-lacquered boots"),
 		0, 0,  0,	   0, 1, 95,  1,  8, 2, 1, METAL, CLR_RED),
-BOOTS("plasteel boots", "hard white boots", /*Needs encyc entry*//*Needs tile*/
+BOOTS(("plasteel boots", "hard white boots"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 25, 32,  8, 2, 1, PLASTIC, CLR_WHITE),
-BOOTS("stilettos", "high-heeled shoes", /*Needs encyc entry*//*Needs tile*/
+BOOTS(("stilettos", "high-heeled shoes"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 1, 10, 60, 10, 0, 0, METAL, HI_METAL),
-BOOTS("high boots", "jackboots",
+BOOTS(("high boots", "jackboots"),
 		0, 0,  0,	  15, 2, 20, 12, 10, 2, 0, LEATHER, HI_LEATHER),
-BOOTS("heeled boots", "tall boots",
+BOOTS(("heeled boots", "tall boots"),
 		1, 0,  0,	   0, 2, 20, 12, 10, 2, 0, LEATHER, CLR_BLACK),
-BOOTS("crystal boots", "boots", /*Needs encyc entry*//*Needs tile*/
+BOOTS(("crystal boots", "boots"), /*Needs encyc entry*//*Needs tile*/
 		0, 0,  0,	   0, 2, 60,300,  9, 0, 0, GLASS, HI_GLASS, O_MATSPEC(UNIDED)),
 /* With shuffled appearances... */
-BOOTS("speed boots", "combat boots",
+BOOTS(("speed boots", "combat boots"),
 		0, 1,  FAST,	  12, 2, 20, 50,  9, 0, 0, LEATHER, HI_LEATHER),
-BOOTS("water walking boots", "jungle boots",
+BOOTS(("water walking boots", "jungle boots"),
 		0, 1,  WWALKING,  12, 2, 20, 50, 10, 1, 0, LEATHER, HI_LEATHER),
-BOOTS("jumping boots", "hiking boots",
+BOOTS(("jumping boots", "hiking boots"),
 		0, 1,  JUMPING,   12, 2, 20, 50,  9, 1, 0, LEATHER, HI_LEATHER),
-BOOTS("elven boots", "mud boots",
+BOOTS(("elven boots", "mud boots"),
 		0, 1,  STEALTH,   12, 2, 10,  8,  9, 0, 0, WOOD, CLR_BROWN),
-BOOTS("kicking boots", "buckled boots",
+BOOTS(("kicking boots", "buckled boots"),
 		0, 1,  0,         12, 2, 15,  8,  9, 2, 0, IRON, CLR_BROWN),
-BOOTS("fumble boots", "riding boots",
+BOOTS(("fumble boots", "riding boots"),
 		0, 1,  FUMBLING,  12, 2, 20, 30, 10, 1, 0, LEATHER, HI_LEATHER),
-BOOTS("flying boots", "snow boots",
+BOOTS(("flying boots", "snow boots"),
 		0, 1,  FLYING,12, 2, 15, 30,  9, 1, 0, LEATHER, HI_LEATHER),
 #undef SUIT
 #undef SHIRT
@@ -957,235 +970,223 @@ BOOTS("flying boots", "snow boots",
 #undef ARMOR
 
 /* rings ... */
-#define RING(name,power,stone,cost,mgc,spec,mohs,metal,color,...) OBJECT( \
-		OBJ(name,stone), \
+#define RING(names,power,cost,mgc,spec,mohs,metal,color,...) OBJECT( \
+		DEF_BLINDNAME(names, "ring"), \
 		BITS(0,0,spec,0,mgc,spec,0,0,MZ_TINY,HARDGEM(mohs),0,P_NONE,metal,0), \
 		power, RING_CLASS, 0, 0, 3, cost, {0}, {0}, 0, 0, 0, 15, color,__VA_ARGS__ )
-RING("wishes", 0, "black",                  500, 1, 1, 4, PLATINUM, CLR_BLACK, O_NOWISH(1)),
-RING("adornment", ADORNED, "wooden",        100, 1, 1, 2, WOOD, HI_WOOD),
-RING("gain strength", 0, "granite",         150, 1, 1, 7, MINERAL, HI_MINERAL),
-RING("gain constitution", 0, "opal",        150, 1, 1, 7, GEMSTONE,  CLR_WHITE),
-RING("increase accuracy", 0, "clay",        150, 1, 1, 4, MINERAL, CLR_RED),
-RING("increase damage", 0, "coral",         150, 1, 1, 4, MINERAL, CLR_ORANGE),
-RING("protection", PROTECTION, "black onyx",100, 1, 1, 7, GEMSTONE, CLR_BLACK),
-RING("regeneration", REGENERATION, "moonstone",
-											200, 1, 0, 6, MINERAL, HI_MINERAL),
-RING("searching", SEARCHING, "tiger eye",   200, 1, 0, 6, GEMSTONE, CLR_BROWN),
-RING("stealth", STEALTH, "jade",            100, 1, 0, 6, GEMSTONE, CLR_GREEN),
-RING("sustain ability", FIXED_ABIL, "bronze",
-											100, 1, 0, 4, COPPER, HI_COPPER),
-RING("levitation", LEVITATION, "agate",     200, 1, 0, 7, GEMSTONE, CLR_RED),
-RING("hunger", HUNGER, "topaz",             100, 1, 0, 8, GEMSTONE, CLR_CYAN),
-RING("aggravate monster", AGGRAVATE_MONSTER, "sapphire",
-											150, 1, 0, 9, GEMSTONE, CLR_BLUE),
-RING("conflict", CONFLICT, "ruby",          300, 1, 0, 9, GEMSTONE, CLR_RED),
-RING("warning", WARNING, "diamond",         100, 1, 0,10, GEMSTONE, CLR_WHITE),
-RING("poison resistance", POISON_RES, "pearl",
-											150, 1, 0, 4, MINERAL, CLR_WHITE),
-RING("fire resistance", FIRE_RES, "iron",
-											200, 1, 0, 5, IRON, HI_METAL),
-RING("cold resistance", COLD_RES, "brass",
-											150, 1, 0, 4, COPPER, HI_COPPER),
-RING("shock resistance", SHOCK_RES, "copper",
-											150, 1, 0, 3, COPPER, HI_COPPER),
-RING("free action",     FREE_ACTION, "twisted",
-											200, 1, 0, 6, IRON, HI_METAL),
-RING("slow digestion",  SLOW_DIGESTION, "steel",
-											200, 1, 0, 8, IRON, HI_METAL),
-RING("teleportation", TELEPORT, "silver",   200, 1, 0, 3, SILVER, HI_SILVER),
-RING("teleport control", TELEPORT_CONTROL, "gold",
-											300, 1, 0, 3, GOLD, HI_GOLD),
-RING("polymorph", POLYMORPH, "ivory",       300, 1, 0, 4, BONE, CLR_WHITE),
-RING("polymorph control", POLYMORPH_CONTROL, "emerald",
-											300, 1, 0, 8, GEMSTONE, CLR_BRIGHT_GREEN),
-RING("invisibility", INVIS, "wire",  		150, 1, 0, 5, IRON, HI_METAL),
-RING("see invisible", SEE_INVIS, "engagement",
-											150, 1, 0, 5, GOLD, HI_METAL),
-RING("alacrity", FAST, "shiny",				100, 1, 0, 5, METAL, CLR_BRIGHT_CYAN),/*Needs tile*/
-RING("protection from shape changers", PROT_FROM_SHAPE_CHANGERS, "black signet",
-											100, 1, 0, 5, MITHRIL, CLR_BLACK),
+RING(("wishes", "black"), 0,                              500, 1, 1, 4, PLATINUM, CLR_BLACK, O_NOWISH(1)),
+RING(("adornment", "wooden"), ADORNED,                    100, 1, 1, 2, WOOD, HI_WOOD),
+RING(("gain strength", "granite"), 0,                     150, 1, 1, 7, MINERAL, HI_MINERAL),
+RING(("gain constitution", "opal"), 0,                    150, 1, 1, 7, GEMSTONE,  CLR_WHITE),
+RING(("increase accuracy", "clay"), 0,                    150, 1, 1, 4, MINERAL, CLR_RED),
+RING(("increase damage", "coral"), 0,                     150, 1, 1, 4, MINERAL, CLR_ORANGE),
+RING(("protection", "black onyx"), PROTECTION,            100, 1, 1, 7, GEMSTONE, CLR_BLACK),
+RING(("regeneration", "moonstone"), REGENERATION,         200, 1, 0, 6, MINERAL, HI_MINERAL),
+RING(("searching", "tiger eye"), SEARCHING,               200, 1, 0, 6, GEMSTONE, CLR_BROWN),
+RING(("stealth", "jade"), STEALTH,                        100, 1, 0, 6, GEMSTONE, CLR_GREEN),
+RING(("sustain ability", "bronze"), FIXED_ABIL,           100, 1, 0, 4, COPPER, HI_COPPER),
+RING(("levitation", "agate"), LEVITATION,                 200, 1, 0, 7, GEMSTONE, CLR_RED),
+RING(("hunger", "topaz"), HUNGER,                         100, 1, 0, 8, GEMSTONE, CLR_CYAN),
+RING(("aggravate monster", "sapphire"), AGGRAVATE_MONSTER,150, 1, 0, 9, GEMSTONE, CLR_BLUE),
+RING(("conflict", "ruby"), CONFLICT,                      300, 1, 0, 9, GEMSTONE, CLR_RED),
+RING(("warning", "diamond"), WARNING,                     100, 1, 0,10, GEMSTONE, CLR_WHITE),
+RING(("poison resistance", "pearl"), POISON_RES,          150, 1, 0, 4, MINERAL, CLR_WHITE),
+RING(("fire resistance", "iron"), FIRE_RES,               200, 1, 0, 5, IRON, HI_METAL),
+RING(("cold resistance", "brass"), COLD_RES,              150, 1, 0, 4, COPPER, HI_COPPER),
+RING(("shock resistance", "copper"), SHOCK_RES,           150, 1, 0, 3, COPPER, HI_COPPER),
+RING(("free action", "twisted"), FREE_ACTION,             200, 1, 0, 6, IRON, HI_METAL),
+RING(("slow digestion", "steel"), SLOW_DIGESTION,         200, 1, 0, 8, IRON, HI_METAL),
+RING(("teleportation", "silver"), TELEPORT,               200, 1, 0, 3, SILVER, HI_SILVER),
+RING(("teleport control", "gold"), TELEPORT_CONTROL,      300, 1, 0, 3, GOLD, HI_GOLD),
+RING(("polymorph", "ivory"), POLYMORPH,                   300, 1, 0, 4, BONE, CLR_WHITE),
+RING(("polymorph control", "emerald"), POLYMORPH_CONTROL, 300, 1, 0, 8, GEMSTONE, CLR_BRIGHT_GREEN),
+RING(("invisibility", "wire"), INVIS,  		            150, 1, 0, 5, IRON, HI_METAL),
+RING(("see invisible", "engagement"), SEE_INVIS,          150, 1, 0, 5, GOLD, HI_METAL),
+RING(("alacrity", "shiny"), FAST,				            100, 1, 0, 5, METAL, CLR_BRIGHT_CYAN),/*Needs tile*/
+RING(("protection from shape changers", "black signet"), PROT_FROM_SHAPE_CHANGERS,
+											            100, 1, 0, 5, MITHRIL, CLR_BLACK),
 #undef RING
 
 /* amulets ... - THE Amulet comes last because it is special */
-#define AMULET(name,desc,power,prob,...) OBJECT( \
-		OBJ(name,desc), BITS(0,0,0,0,1,0,0,0,0,MZ_TINY,0,P_NONE,IRON,0), power, \
+#define AMULET(names,power,prob,...) OBJECT( \
+		DEF_BLINDNAME(names, "amulet"), BITS(0,0,0,0,1,0,0,0,0,MZ_TINY,0,P_NONE,IRON,0), power, \
 		AMULET_CLASS, prob, 0, 20, 150, {0}, {0}, 0, 0, 0, 20, HI_METAL, __VA_ARGS__ )
 
-AMULET("amulet of drain resistance","warped",   DRAIN_RES,   60),
-AMULET("amulet of ESP",           "circular",   TELEPAT,    130),
-AMULET("amulet of life saving",   "spherical",  LIFESAVED,   70),
-AMULET("amulet of strangulation", "oval",       STRANGLED,  100),
-AMULET("amulet of restful sleep", "triangular", SLEEPING,   100),
-AMULET("amulet versus poison",    "pyramidal",  POISON_RES, 130),
-AMULET("amulet versus sickness",    "teardrop",  SICK_RES, 	 25),
-AMULET("amulet of change",        "square",     0,          110),
-AMULET("amulet versus curses",    "convex",     0,           55),/*Needs tile*/
+AMULET(("amulet of drain resistance","warped"),   DRAIN_RES,   60),
+AMULET(("amulet of ESP",           "circular"),   TELEPAT,    130),
+AMULET(("amulet of life saving",   "spherical"),  LIFESAVED,   70),
+AMULET(("amulet of strangulation", "oval"),       STRANGLED,  100),
+AMULET(("amulet of restful sleep", "triangular"), SLEEPING,   100),
+AMULET(("amulet versus poison",    "pyramidal"),  POISON_RES, 130),
+AMULET(("amulet versus sickness",    "teardrop"),  SICK_RES, 	 25),
+AMULET(("amulet of change",        "square"),     0,          110),
+AMULET(("amulet versus curses",    "convex"),     0,           55),/*Needs tile*/
 						/* POLYMORPH */
-AMULET("amulet of unchanging",    "concave",    UNCHANGING,	 45),
-AMULET("amulet of nullify magic", "pentagonal",  NULLMAGIC,  45),/*Needs tile*/
-AMULET("amulet of reflection",    "hexagonal",  REFLECTING,  70),
-AMULET("amulet of magical breathing", "octagonal",      MAGICAL_BREATHING, 60),
+AMULET(("amulet of unchanging",    "concave"),    UNCHANGING,	 45),
+AMULET(("amulet of nullify magic", "pentagonal"),  NULLMAGIC,  45),/*Needs tile*/
+AMULET(("amulet of reflection",    "hexagonal"),  REFLECTING,  70),
+AMULET(("amulet of magical breathing", "octagonal"),      MAGICAL_BREATHING, 60),
 
-AMULET("cheap plastic imitation of the Amulet of Yendor", "Amulet of Yendor", 0, 0,
+AMULET(("cheap plastic imitation of the Amulet of Yendor", "Amulet of Yendor"), 0, 0,
 	O_USKWN(1), O_MAGIC(0), O_MAT(PLASTIC), O_COST(20), O_NUT(1)),
-AMULET("Amulet of Yendor", "Amulet of Yendor", 0, 0, /* note: description == name */
+AMULET(("Amulet of Yendor", "Amulet of Yendor"), 0, 0, /* note: description == name */
 	O_USKWN(1), O_MAGIC(0), O_UNIQ(1), O_NOWISH(1), O_MAT(MITHRIL), O_COST(30000)),
 #undef AMULET
 
 /* tools ... */
 /* tools with weapon characteristics come last */
-#define TOOL(name,desc,kn,size,mrg,mgc,chg,prob,wt,cost,mat,color,...) \
-	OBJECT( OBJ(name,desc), \
+#define TOOL(names,kn,size,mrg,mgc,chg,prob,wt,cost,mat,color,...) \
+	OBJECT( names, \
 		BITS(kn,mrg,chg,0,mgc,chg,0,0,size,0,0,P_NONE,mat,0), \
 		0, TOOL_CLASS, prob, 0, \
 		wt, cost, {0}, {0}, 0, 0, 0, wt, color, __VA_ARGS__)
-#define CONTAINER(name,desc,kn,size,mgc,chg,prob,wt,cost,mat,color,...) \
-	OBJECT( OBJ(name,desc), \
+#define CONTAINER(names,kn,size,mgc,chg,prob,wt,cost,mat,color,...) \
+	OBJECT( names, \
 		BITS(kn,0,chg,1,mgc,chg,0,0,size,0,0,P_NONE,mat,0), \
 		0, TOOL_CLASS, prob, 0, \
 		wt, cost, {0}, {0}, 0, 0, 0, wt, color, __VA_ARGS__)
-#define WEPTOOL(name,desc,sdam,ldam,kn,size,mgc,chg,prob,wt,cost,hitbon,typ,sub,mat,clr,...) \
-	OBJECT( OBJ(name,desc), \
+#define WEPTOOL(names,sdam,ldam,kn,size,mgc,chg,prob,wt,cost,hitbon,typ,sub,mat,clr,...) \
+	OBJECT( names, \
 		BITS(kn,0,1,chg,mgc,1,0,0,size,0,typ,sub,mat,0), \
 		0, TOOL_CLASS, prob, 0, \
 		wt, cost, sdam, ldam, hitbon, WP_GENERIC, 0, wt, clr, __VA_ARGS__)
 /* containers */
-CONTAINER("box", (char *)0,             1,   MZ_HUGE, 0, 0,  30, 350,   8, WOOD, HI_WOOD),
-CONTAINER("massive stone crate", (char *)0,
+CONTAINER(("box"),             1,   MZ_HUGE, 0, 0,  30, 350,   8, WOOD, HI_WOOD),
+CONTAINER(("massive stone crate"),
 										1,MZ_GIGANTIC,0, 0,   0,6000,  80, MINERAL,HI_MINERAL),/*Needs tile*/
-CONTAINER("chest", (char *)0,           1,   MZ_HUGE, 0, 0,  30, 600,  16, WOOD, HI_WOOD),
-CONTAINER("magic chest", "big chest with 10 keyholes",
+CONTAINER(("chest"),           1,   MZ_HUGE, 0, 0,  30, 600,  16, WOOD, HI_WOOD),
+CONTAINER(("magic chest", "big chest with 10 keyholes"),
 										0,MZ_GIGANTIC,1, 0,  15,1001,7000, METAL, CLR_BRIGHT_MAGENTA),/*Needs tile*/
-CONTAINER("ice box", (char *)0,         1,   MZ_HUGE, 0, 0,   5, 250,  42, PLASTIC, CLR_WHITE),
-CONTAINER("sack", "bag",                0, MZ_MEDIUM, 0, 0,  20,  15,   2, CLOTH, HI_CLOTH),
-CONTAINER("oilskin sack", "bag",        0, MZ_MEDIUM, 0, 0,  20,  15, 100, CLOTH, HI_CLOTH),
-CONTAINER("bag of holding", "bag",      0, MZ_MEDIUM, 1, 0,  20,  15, 100, CLOTH, HI_CLOTH),
-CONTAINER("bag of tricks", "bag",       0, MZ_MEDIUM, 1, 1,  20,  15, 100, CLOTH, HI_CLOTH),
-#define HOSTAGE(name,desc,kn,mgc,chg,prob,ntrtn,wt,cost,mat,color,...) \
-	OBJECT( OBJ(name,desc), \
+CONTAINER(("ice box"),         1,   MZ_HUGE, 0, 0,   5, 250,  42, PLASTIC, CLR_WHITE),
+CONTAINER(("sack", "bag"),                0, MZ_MEDIUM, 0, 0,  20,  15,   2, CLOTH, HI_CLOTH),
+CONTAINER(("oilskin sack", "bag"),        0, MZ_MEDIUM, 0, 0,  20,  15, 100, CLOTH, HI_CLOTH),
+CONTAINER(("bag of holding", "bag"),      0, MZ_MEDIUM, 1, 0,  20,  15, 100, CLOTH, HI_CLOTH),
+CONTAINER(("bag of tricks", "bag"),       0, MZ_MEDIUM, 1, 1,  20,  15, 100, CLOTH, HI_CLOTH),
+#define HOSTAGE(names,kn,mgc,chg,prob,ntrtn,wt,cost,mat,color,...) \
+	OBJECT( names, \
 		BITS(kn,0,chg,1,mgc,chg,0,0,MZ_MEDIUM,0,0,P_NONE,mat), \
 		0, TOOL_CLASS, prob, 0, \
 		wt, cost, {0}, {0}, 0, ntrtn, 0, wt, color, __VA_ARGS__)
 
-//HOSTAGE("distressed princess", (char *)0,           1, 0, 0,  0, 350,.9*1450,  1600, CLOTH, CLR_WHITE),
+//HOSTAGE(("distressed princess"),           1, 0, 0,  0, 350,.9*1450,  1600, CLOTH, CLR_WHITE),
 #undef HOSTAGE
 #undef CONTAINER
 //OBJECT(obj,bits,prp,sym,prob,dly,wt,cost,sdam,ldam,oc1,oc2,oc3,nut,color) \
-//	{0, 0, (char *)0, bits, prp, sym, dly, COLOR_FIELD(color) \
+//	{0, 0, bits, prp, sym, dly, COLOR_FIELD(color) \
 //	 prob, wt, cost, sdam, ldam, oc1, oc2, oc3, nut}
 
 /* lock opening tools */
-//define TOOL(name,desc,kn,mrg,mgc,chg,prob,wt,cost,mat,color) \
-	OBJECT( OBJ(name,desc), \
+//define TOOL(names,kn,mrg,mgc,chg,prob,wt,cost,mat,color) \
+	OBJECT( names, \
 		BITS(kn,mrg,chg,0,mgc,chg,0,0,0,0,0,P_NONE,mat), \
 		0, TOOL_CLASS, prob, 0, \
 		wt, cost, 0, 0, 0, 0, 0, wt, color )
-TOOL("skeleton key", "key",              0,   MZ_TINY, 0, 0, 0,  80,  3,  10, IRON,    HI_METAL),
-TOOL("universal key", "key",	         0,   MZ_TINY, 0, 0, 0,   0,  3,  10, SILVER,  HI_SILVER, O_MATSPEC(UNIDED)),
+TOOL(("skeleton key", "key"),              0,   MZ_TINY, 0, 0, 0,  80,  3,  10, IRON,    HI_METAL),
+TOOL(("universal key", "key"),	         0,   MZ_TINY, 0, 0, 0,   0,  3,  10, SILVER,  HI_SILVER, O_MATSPEC(UNIDED)),
 #ifdef TOURIST
-TOOL("lock pick", (char *)0,             1,   MZ_TINY, 0, 0, 0,  60,  4,  20, IRON,    HI_METAL),
-TOOL("credit card", (char *)0,           1,   MZ_TINY, 0, 0, 0,   0,  1,  10, PLASTIC, CLR_WHITE),
+TOOL(("lock pick"),             1,   MZ_TINY, 0, 0, 0,  60,  4,  20, IRON,    HI_METAL),
+TOOL(("credit card"),           1,   MZ_TINY, 0, 0, 0,   0,  1,  10, PLASTIC, CLR_WHITE),
 #else
-TOOL("lock pick", (char *)0,             1,   MZ_TINY, 0, 0, 0,  60,  4,  20, IRON,    HI_METAL),
+TOOL(("lock pick"),             1,   MZ_TINY, 0, 0, 0,  60,  4,  20, IRON,    HI_METAL),
 #endif
 /* light sources */
-TOOL("tallow candle", "candle",          0,   MZ_TINY, 1, 0, 0,  15,  2,  10, WAX,     CLR_WHITE),
-TOOL("wax candle", "candle",             0,   MZ_TINY, 1, 0, 0,   5,  2,  20, WAX,     CLR_WHITE),
-TOOL("candle of invocation", "runed candle", 
+TOOL(("tallow candle", "candle"),          0,   MZ_TINY, 1, 0, 0,  15,  2,  10, WAX,     CLR_WHITE),
+TOOL(("wax candle", "candle"),             0,   MZ_TINY, 1, 0, 0,   5,  2,  20, WAX,     CLR_WHITE),
+TOOL(("candle of invocation", "runed candle"), 
                                          0,   MZ_TINY, 0, 1, 0,  15,  2,  50, WAX,     CLR_ORANGE, O_NOWISH(1)),
-TOOL("lantern", (char *)0,               1,  MZ_SMALL, 0, 0, 0,  20, 30,  12, COPPER,  CLR_YELLOW, O_MATSPEC(IDED|UNIDED)),
-TOOL("oil lamp", "lamp",                 0,  MZ_SMALL, 0, 0, 0,  30, 20,  10, COPPER,  CLR_YELLOW),
-TOOL("magic lamp", "lamp",               0,  MZ_SMALL, 0, 1, 0,  15, 20,  50, COPPER,  CLR_YELLOW, O_NOWISH(1)),
-// TOOL("shadowlander's torch", "black torch",
+TOOL(("lantern"),               1,  MZ_SMALL, 0, 0, 0,  20, 30,  12, COPPER,  CLR_YELLOW, O_MATSPEC(IDED|UNIDED)),
+TOOL(("oil lamp", "lamp"),                 0,  MZ_SMALL, 0, 0, 0,  30, 20,  10, COPPER,  CLR_YELLOW),
+TOOL(("magic lamp", "lamp"),               0,  MZ_SMALL, 0, 1, 0,  15, 20,  50, COPPER,  CLR_YELLOW, O_NOWISH(1)),
+// TOOL(("shadowlander's torch", "black torch"),
 								//       0,  MZ_SMALL, 0, 1, 0,  10, 20,  50, WOOD, CLR_BLACK),
 /* other tools */
 #ifdef TOURIST
-TOOL("expensive camera", (char *)0,
+TOOL(("expensive camera"),
 				                1,  MZ_SMALL, 0, 0, 1,  15, 12, 200, PLASTIC, CLR_BLACK),
-TOOL("mirror", "looking glass", 0,   MZ_TINY, 0, 0, 0,  45, 13,  10, GLASS, HI_SILVER),
+TOOL(("mirror", "looking glass"), 0,   MZ_TINY, 0, 0, 0,  45, 13,  10, GLASS, HI_SILVER),
 #else
-TOOL("mirror", "looking glass", 0,   MZ_TINY, 0, 0, 0,  60, 13,  10, GLASS, HI_SILVER),
+TOOL(("mirror", "looking glass"), 0,   MZ_TINY, 0, 0, 0,  60, 13,  10, GLASS, HI_SILVER),
 #endif
-TOOL("crystal ball", "glass orb",
+TOOL(("crystal ball", "glass orb"),
 								0,  MZ_SMALL, 0, 1, 1,  15, 50, 200, GLASS, HI_GLASS),
-TOOL("sensor pack", "rigid box", /*Needs encyc entry*//*Needs tile*/
+TOOL(("sensor pack", "rigid box"), /*Needs encyc entry*//*Needs tile*/
 								0,  MZ_SMALL, 0, 1, 1,   0, 15,2000, PLASTIC,CLR_WHITE),
-TOOL("hypospray", "hammer-shaped device", /*Needs encyc entry*//*Needs tile*/
+TOOL(("hypospray", "hammer-shaped device"), /*Needs encyc entry*//*Needs tile*/
 								0,  MZ_SMALL, 0, 1, 0,   0, 15, 500, PLASTIC,CLR_GRAY),
-TOOL("hypospray ampule", "hard grey bottle", /*Needs encyc entry*//*Needs tile*/
+TOOL(("hypospray ampule", "hard grey bottle"), /*Needs encyc entry*//*Needs tile*/
 								0,   MZ_TINY, 0, 1, 0,   0,  1,  50, PLASTIC,CLR_GRAY),
-TOOL("mask", (char *)0,			1,  MZ_SMALL, 0, 0, 0,  10, 10,  80, LEATHER, CLR_WHITE),
-TOOL("R'lyehian faceplate", "ebon pane", /*Needs tile*/
+TOOL(("mask"),			1,  MZ_SMALL, 0, 0, 0,  10, 10,  80, LEATHER, CLR_WHITE),
+TOOL(("R'lyehian faceplate", "ebon pane"), /*Needs tile*/
 								0,  MZ_SMALL, 0, 1, 0,   0, 15, 200, GLASS, CLR_BLACK, O_POWER(POISON_RES)),
-TOOL("living mask", "gilled jellyfish",  
+TOOL(("living mask", "gilled jellyfish"),  
 								0,  MZ_SMALL, 0, 1, 0,   0,  5, 200, FLESH, CLR_BLUE, O_POWER(MAGICAL_BREATHING)),
-TOOL("lenses", (char *)0,		1,   MZ_TINY, 0, 0, 0,   5,  3,  80, GLASS, HI_GLASS), /*Needs encyc entry*/
-TOOL("blindfold", (char *)0,    1,   MZ_TINY, 0, 0, 0,  45,  2,  20, CLOTH, CLR_GRAY),
-TOOL("android visor", "black blindfold",
+TOOL(("lenses"),		1,   MZ_TINY, 0, 0, 0,   5,  3,  80, GLASS, HI_GLASS), /*Needs encyc entry*/
+TOOL(("blindfold"),    1,   MZ_TINY, 0, 0, 0,  45,  2,  20, CLOTH, CLR_GRAY),
+TOOL(("android visor", "black blindfold"),
 								0,   MZ_TINY, 0, 0, 0,   0,  2,  40, CLOTH, CLR_BLACK),
-TOOL("towel", (char *)0,        1,   MZ_TINY, 0, 0, 0,  45,  2,  50, CLOTH, CLR_MAGENTA),
+TOOL(("towel"),        1,   MZ_TINY, 0, 0, 0,  45,  2,  50, CLOTH, CLR_MAGENTA),
 #ifdef STEED
-TOOL("saddle", (char *)0,       1,  MZ_LARGE, 0, 0, 0,   5,200, 150, LEATHER, HI_LEATHER),
-TOOL("leash", (char *)0,        1,  MZ_SMALL, 0, 0, 0,  60, 12,  20, LEATHER, HI_LEATHER),
+TOOL(("saddle"),       1,  MZ_LARGE, 0, 0, 0,   5,200, 150, LEATHER, HI_LEATHER),
+TOOL(("leash"),        1,  MZ_SMALL, 0, 0, 0,  60, 12,  20, LEATHER, HI_LEATHER),
 #else
-TOOL("leash", (char *)0,        1,  MZ_SMALL, 0, 0, 0,  70, 12,  20, LEATHER, HI_LEATHER),
+TOOL(("leash"),        1,  MZ_SMALL, 0, 0, 0,  70, 12,  20, LEATHER, HI_LEATHER),
 #endif
-TOOL("stethoscope", (char *)0,  1,  MZ_SMALL, 0, 0, 0,  25,  4,  75, IRON, HI_METAL),
-TOOL("tinning kit", (char *)0,  1, MZ_MEDIUM, 0, 0, 1,  15,100,  30, IRON, HI_METAL),
-TOOL("bullet fabber", "white box with a yellow fiddly bit",/*Needs tile*/
+TOOL(("stethoscope"),  1,  MZ_SMALL, 0, 0, 0,  25,  4,  75, IRON, HI_METAL),
+TOOL(("tinning kit"),  1, MZ_MEDIUM, 0, 0, 1,  15,100,  30, IRON, HI_METAL),
+TOOL(("bullet fabber", "white box with a yellow fiddly bit"),/*Needs tile*/
 								0, MZ_MEDIUM, 0, 1, 0,   0, 20,  30, PLASTIC, CLR_WHITE),
-TOOL("upgrade kit", (char *)0,  1, MZ_MEDIUM, 0, 0, 0,  40,100,  30, COPPER, HI_COPPER),/*Needs encyc entry*//*Needs tile*/
-TOOL("power pack", "little white cube", /*Needs encyc entry*//*Needs tile*/
+TOOL(("upgrade kit"),  1, MZ_MEDIUM, 0, 0, 0,  40,100,  30, COPPER, HI_COPPER),/*Needs encyc entry*//*Needs tile*/
+TOOL(("power pack", "little white cube"), /*Needs encyc entry*//*Needs tile*/
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  300, PLASTIC, CLR_WHITE),
-TOOL("trephination kit", (char *)0,  
+TOOL(("trephination kit"),  
 								1, MZ_MEDIUM, 0, 0, 1,   5, 10,  30, METAL, HI_METAL),/*Needs encyc entry*//*Needs tile*/
-TOOL("tin opener", (char *)0,   1,   MZ_TINY, 0, 0, 0,  20,  4,  30, IRON, HI_METAL),
-TOOL("can of grease", (char *)0,1,  MZ_SMALL, 0, 0, 1,  15, 15,  20, IRON, HI_METAL),
-TOOL("figurine", (char *)0,     1,  MZ_SMALL, 0, 1, 0,  20, 50,  80, MINERAL, HI_MINERAL),
+TOOL(("tin opener"),   1,   MZ_TINY, 0, 0, 0,  20,  4,  30, IRON, HI_METAL),
+TOOL(("can of grease"),1,  MZ_SMALL, 0, 0, 1,  15, 15,  20, IRON, HI_METAL),
+TOOL(("figurine"),     1,  MZ_SMALL, 0, 1, 0,  20, 50,  80, MINERAL, HI_MINERAL),
 /*Keep in sync with doll mvar flags*/
-TOOL("effigy",   (char *)0,     1,   MZ_TINY, 1, 1, 0,  20,  5,  80, LEATHER, HI_LEATHER),
-TOOL("doll of jumping",   "Pole-vaulter doll",
+TOOL(("effigy",   (char *)0),     1,   MZ_TINY, 1, 1, 0,  20,  5,  80, LEATHER, HI_LEATHER),
+TOOL(("doll of jumping",   "Pole-vaulter doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BLUE),
-TOOL("doll of friendship",   "Bard doll",
+TOOL(("doll of friendship",   "Bard doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BRIGHT_GREEN),
-TOOL("doll of chastity",   "Priest doll",
+TOOL(("doll of chastity",   "Priest doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL("doll of cleaving",   "Berserker doll",
+TOOL(("doll of cleaving",   "Berserker doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_RED),
-TOOL("doll of satiation",   "Chef doll",
+TOOL(("doll of satiation",   "Chef doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL("doll of good health",   "Healer doll",
+TOOL(("doll of good health",   "Healer doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL("doll of full healing",   "Nurse doll",
+TOOL(("doll of full healing",   "Nurse doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_WHITE),
-TOOL("doll of destruction",   "Dancing doll",
+TOOL(("doll of destruction",   "Dancing doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, HI_COPPER),
-TOOL("doll of memory",   "Scholar doll",
+TOOL(("doll of memory",   "Scholar doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BRIGHT_BLUE),
-TOOL("doll of binding",   "Heretic doll",
+TOOL(("doll of binding",   "Heretic doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BROWN),
-TOOL("doll of preservation",   "Umbrella-wielding doll",
+TOOL(("doll of preservation",   "Umbrella-wielding doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_YELLOW),
-TOOL("doll of quick-drawing",   "Archaeologist doll",
+TOOL(("doll of quick-drawing",   "Archaeologist doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BROWN),
-TOOL("doll of wand-charging",   "Wandsman doll",
+TOOL(("doll of wand-charging",   "Wandsman doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BRIGHT_BLUE),
-TOOL("doll of stealing",   "Thief doll",
+TOOL(("doll of stealing",   "Thief doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_BLACK),
-TOOL("doll of mollification",   "High priest doll",
+TOOL(("doll of mollification",   "High priest doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, HI_GOLD),
-TOOL("doll of clear-thinking",   "Madman doll",
+TOOL(("doll of clear-thinking",   "Madman doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_GRAY),
-TOOL("doll of mind-blasting",   "Squid-parasitized doll",
+TOOL(("doll of mind-blasting",   "Squid-parasitized doll"),
 								0,   MZ_TINY, 1, 1, 0,   0,  1,  80,  CLOTH, CLR_MAGENTA),
-TOOL("doll's tear",   "milky gemstone",
+TOOL(("doll's tear",   "milky gemstone"),
 								0,   MZ_TINY, 0, 1, 0,   0,  1,8000, GEMSTONE, CLR_WHITE),
-TOOL("holy symbol of the black mother", "tarnished triple goat-head", 
+TOOL(("holy symbol of the black mother", "tarnished triple goat-head"), 
 								0,   MZ_TINY, 0, 1, 0,   0, 50,8000, SILVER, CLR_BLACK),
-TOOL("magic marker", (char *)0, 1,   MZ_TINY, 0, 1, 1,  15,  2,  50, PLASTIC, CLR_RED),
+TOOL(("magic marker"), 1,   MZ_TINY, 0, 1, 1,  15,  2,  50, PLASTIC, CLR_RED),
 /* traps */
-TOOL("land mine",(char *)0,     1,  MZ_LARGE, 0, 0, 0,   0,300, 180, IRON, CLR_RED),
-TOOL("beartrap", (char *)0,     1,  MZ_LARGE, 0, 0, 0,   0,100,  60, IRON, HI_METAL),
+TOOL(("land mine",(char *)0),     1,  MZ_LARGE, 0, 0, 0,   0,300, 180, IRON, CLR_RED),
+TOOL(("beartrap"),     1,  MZ_LARGE, 0, 0, 0,   0,100,  60, IRON, HI_METAL),
 /* instruments */
 /* some code in invent.c and obj.h requires wooden flute .. drum of earthquake to be
    consecutive, with the wooden flute first and drum of earthquake last */
@@ -1193,77 +1194,77 @@ TOOL("beartrap", (char *)0,     1,  MZ_LARGE, 0, 0, 0,   0,100,  60, IRON, HI_ME
  *   but for magical instruments that information is very secondary to it being magic
  *   and also sounds weird (ie, a "wooden magic harp" vs a "magic harp")
  */
-TOOL("whistle", "whistle",         0,   MZ_TINY, 0, 0, 0, 60,  3, 10, METAL,   HI_METAL,   O_MATSPEC(IDED )),
-TOOL("magic whistle", "whistle",   0,   MZ_TINY, 0, 1, 0, 30,  3, 10, METAL,   HI_METAL,   O_MATSPEC(NIDED)),
+TOOL(("whistle", "whistle"),         0,   MZ_TINY, 0, 0, 0, 60,  3, 10, METAL,   HI_METAL,   O_MATSPEC(IDED )),
+TOOL(("magic whistle", "whistle"),   0,   MZ_TINY, 0, 1, 0, 30,  3, 10, METAL,   HI_METAL,   O_MATSPEC(NIDED)),
 /* "If tin whistles are made out of tin, what do they make foghorns out of?" */		   
-TOOL("flute", "flute",             0,  MZ_SMALL, 0, 0, 0,  4,  5, 12, WOOD,    HI_WOOD,    O_MATSPEC(IDED )),
-TOOL("magic flute", "flute",       0,  MZ_SMALL, 0, 1, 1,  2,  5, 36, WOOD,    HI_WOOD,    O_MATSPEC(NIDED)),
-TOOL("tooled horn", "horn",        0,  MZ_SMALL, 0, 0, 0,  5, 18, 15, BONE,    CLR_WHITE,  O_MATSPEC(IDED )),
-TOOL("frost horn", "horn",         0,  MZ_SMALL, 0, 1, 1,  2, 18, 50, BONE,    CLR_WHITE,  O_MATSPEC(NIDED)),
-TOOL("fire horn", "horn",          0,  MZ_SMALL, 0, 1, 1,  2, 18, 50, BONE,    CLR_WHITE,  O_MATSPEC(NIDED)),
-TOOL("horn of plenty", "horn",     0,  MZ_SMALL, 0, 1, 1,  2, 18, 50, BONE,    CLR_WHITE,  O_MATSPEC(NIDED)),
-TOOL("harp", "harp",               0, MZ_MEDIUM, 0, 0, 0,  4, 30, 50, WOOD,    HI_WOOD,    O_MATSPEC(IDED )),
-TOOL("magic harp", "harp",         0, MZ_MEDIUM, 0, 1, 1,  2, 30, 50, WOOD,    HI_WOOD,    O_MATSPEC(NIDED)),
-TOOL("bell", (char *)0,            1,   MZ_TINY, 0, 0, 0,  2, 30, 50, COPPER,  HI_COPPER,  O_MATSPEC(IDED )),
-TOOL("bugle", (char *)0,           1,  MZ_SMALL, 0, 0, 0,  4, 10, 15, COPPER,  HI_COPPER,  O_MATSPEC(IDED )),
-TOOL("drum", "drum",               0, MZ_MEDIUM, 0, 0, 0,  4, 25, 25, LEATHER, HI_LEATHER, O_MATSPEC(IDED )),
-TOOL("drum of earthquake", "drum", 0, MZ_MEDIUM, 0, 1, 1,  2, 25, 25, LEATHER, HI_LEATHER, O_MATSPEC(NIDED)),
+TOOL(("flute", "flute"),             0,  MZ_SMALL, 0, 0, 0,  4,  5, 12, WOOD,    HI_WOOD,    O_MATSPEC(IDED )),
+TOOL(("magic flute", "flute"),       0,  MZ_SMALL, 0, 1, 1,  2,  5, 36, WOOD,    HI_WOOD,    O_MATSPEC(NIDED)),
+TOOL(("tooled horn", "horn"),        0,  MZ_SMALL, 0, 0, 0,  5, 18, 15, BONE,    CLR_WHITE,  O_MATSPEC(IDED )),
+TOOL(("frost horn", "horn"),         0,  MZ_SMALL, 0, 1, 1,  2, 18, 50, BONE,    CLR_WHITE,  O_MATSPEC(NIDED)),
+TOOL(("fire horn", "horn"),          0,  MZ_SMALL, 0, 1, 1,  2, 18, 50, BONE,    CLR_WHITE,  O_MATSPEC(NIDED)),
+TOOL(("horn of plenty", "horn"),     0,  MZ_SMALL, 0, 1, 1,  2, 18, 50, BONE,    CLR_WHITE,  O_MATSPEC(NIDED)),
+TOOL(("harp", "harp"),               0, MZ_MEDIUM, 0, 0, 0,  4, 30, 50, WOOD,    HI_WOOD,    O_MATSPEC(IDED )),
+TOOL(("magic harp", "harp"),         0, MZ_MEDIUM, 0, 1, 1,  2, 30, 50, WOOD,    HI_WOOD,    O_MATSPEC(NIDED)),
+TOOL(("bell"),            1,   MZ_TINY, 0, 0, 0,  2, 30, 50, COPPER,  HI_COPPER,  O_MATSPEC(IDED )),
+TOOL(("bugle"),           1,  MZ_SMALL, 0, 0, 0,  4, 10, 15, COPPER,  HI_COPPER,  O_MATSPEC(IDED )),
+TOOL(("drum", "drum"),               0, MZ_MEDIUM, 0, 0, 0,  4, 25, 25, LEATHER, HI_LEATHER, O_MATSPEC(IDED )),
+TOOL(("drum of earthquake", "drum"), 0, MZ_MEDIUM, 0, 1, 1,  2, 25, 25, LEATHER, HI_LEATHER, O_MATSPEC(NIDED)),
 /* tools useful as weapons */
-WEPTOOL("pick-axe", (char *)0,
+WEPTOOL(("pick-axe"),
 	DMG(D(6)), DMG(D(3)),
 	1,  MZ_LARGE, 0, 0, 20, 80,  50,  0, P,   P_PICK_AXE, IRON, HI_METAL),
-WEPTOOL("seismic hammer", "dull metallic hammer",
+WEPTOOL(("seismic hammer", "dull metallic hammer"),
 	DMG(D(12)), DMG(D(10)),
 	0,   MZ_HUGE, 1, 1,  0,150, 250, -5, B,   P_HAMMER,  METAL, HI_METAL),
 /*
  * Torches work as clubs
  */
-WEPTOOL("torch", (char *)0,
+WEPTOOL(("torch"),
 	DMG(D(6)), DMG(D(3)),
 	1,  MZ_SMALL, 0, 0, 15, 10,   5,  0, B,   P_CLUB, WOOD, HI_WOOD),
-WEPTOOL("shadowlander's torch", "black torch",
+WEPTOOL(("shadowlander's torch", "black torch"),
 	DMG(D(6)), DMG(D(3)),
 	0,  MZ_SMALL, 0, 0, 10, 10,  50,  0, B,   P_CLUB, WOOD, CLR_BLACK),
-WEPTOOL("sunrod", "gold rod",
+WEPTOOL(("sunrod", "gold rod"),
 	DMG(D(6)), DMG(D(3)),
 	1,  MZ_SMALL, 0, 0,  5, 20,  50,  0, B,   P_MACE, GOLD, HI_GOLD),
 /* 
  * Lightsabers get 3x dice when lit, and go down to 1d2 damage when unlit
  */
-WEPTOOL("lightsaber", "sword hilt", /*Needs (better) encyc entry*/
+WEPTOOL(("lightsaber", "sword hilt"), /*Needs (better) encyc entry*/
 	DMG(D(8)), DMG(D(8)),
 	0,  MZ_SMALL, 1, 1,  0, 10, 500, -3, S|E, P_SABER, SILVER, HI_SILVER, O_MATSPEC(IDED|UNIDED)),
-WEPTOOL("beamsword",  "broadsword hilt", /*Needs encyc entry*/
+WEPTOOL(("beamsword",  "broadsword hilt"), /*Needs encyc entry*/
 	DMG(D(10)), DMG(D(10)),
 	0,  MZ_SMALL, 1, 1,  0, 20, 500, -3, S|E, P_BROAD_SWORD, GOLD, HI_GOLD, O_MATSPEC(IDED|UNIDED)),
-WEPTOOL("double lightsaber",  "long grip", /*Needs encyc entry*//*Needs tile*//*needs special case for 2handedness*/
+WEPTOOL(("double lightsaber",  "long grip"), /*Needs encyc entry*//*Needs tile*//*needs special case for 2handedness*/
 	DMG(D(10)), DMG(D(10)),
 	0,  MZ_SMALL, 1, 1,  0, 30,1000, -6, S|E, P_QUARTERSTAFF, PLATINUM, HI_SILVER, O_MATSPEC(IDED|UNIDED)),
-WEPTOOL("grappling hook", "hook",
+WEPTOOL(("grappling hook", "hook"),
 	DMG(D(2)), DMG(D(6)),
 	0, MZ_MEDIUM, 0, 0,  4, 30,  50,  0, B,   P_FLAIL, IRON, HI_METAL, O_MATSPEC(UNIDED)),
-WEPTOOL("shepherd's crook", "bent staff",
+WEPTOOL(("shepherd's crook", "bent staff"),
 	DMG(D(6)), DMG(D(4)),
 	0,   MZ_LARGE, 0, 0, 1,  30,   5, 0, B,   P_QUARTERSTAFF, WOOD, HI_WOOD),
 /* 3.4.1: unicorn horn left classified as "magic" */
-WEPTOOL("unicorn horn", (char *)0,
+WEPTOOL(("unicorn horn"),
 	DMG(D(12)), DMG(D(12)),
 	1, MZ_MEDIUM, 1, 0, 0,  20, 100,  0, P,   P_UNICORN_HORN, BONE, CLR_WHITE),
-WEPTOOL("spoon", (char *)0, /*Needs encyc entry*//*Needs tile*/
+WEPTOOL(("spoon"), /*Needs encyc entry*//*Needs tile*/
 	DMG(D(1)), DMG(D(1)),
 	1,   MZ_TINY, 0, 0, 0,   1,   1,  0, P,   P_KNIFE, IRON, HI_METAL),
 
 /* two special unique artifact tools */
-TOOL("Candelabrum of Invocation", "candelabrum", 0, MZ_SMALL, 0, 1, 0, 0, 10, 5000, GOLD, HI_GOLD,
+TOOL(("Candelabrum of Invocation", "candelabrum"), 0, MZ_SMALL, 0, 1, 0, 0, 10, 5000, GOLD, HI_GOLD,
 	O_USKWN(1), O_UNIQ(1), O_NOWISH(1), O_NUT(200)),
-TOOL("Bell of Opening",           "bell",        0,  MZ_TINY, 0, 1, 1, 0, 10, 5000, SILVER, HI_SILVER,
+TOOL(("Bell of Opening",           "bell"),        0,  MZ_TINY, 0, 1, 1, 0, 10, 5000, SILVER, HI_SILVER,
 	O_USKWN(1), O_UNIQ(1), O_NOWISH(1), O_MATSPEC(UNIDED), O_NUT(50)),
 #undef TOOL
 #undef WEPTOOL
 
 /* Comestibles ... */
-#define FOOD(name,prob,size,delay,wt,unk,tin,nutrition,color,...) OBJECT( \
-		OBJ(name,(char *)0), BITS(1,1,unk,0,0,0,0,0,size,0,0,P_NONE,tin,0), 0, \
+#define FOOD(names,prob,size,delay,wt,unk,tin,nutrition,color,...) OBJECT( \
+		names, BITS(1,1,unk,0,0,0,0,0,size,0,0,P_NONE,tin,0), 0, \
 		FOOD_CLASS, prob, delay, \
 		wt, nutrition / 20 + 5, {0}, {0}, 0, 0, 0, nutrition, color, __VA_ARGS__)
 /* all types of food (except tins & corpses) must have a delay of at least 1. */
@@ -1277,368 +1278,368 @@ TOOL("Bell of Opening",           "bell",        0,  MZ_TINY, 0, 1, 1, 0, 10, 50
 /* meatballs/sticks/rings are only created from objects via stone to flesh */
 
 /* meat */
-FOOD("tripe ration",          140,  MZ_SMALL,  2, 10, 0, FLESH, 200, CLR_BROWN),
-FOOD("corpse",                  0, MZ_MEDIUM,  1,  0, 0, FLESH,   0, CLR_BROWN),
-FOOD("egg",                    85,   MZ_TINY,  1,  1, 1, FLESH,  80, CLR_WHITE),
-FOOD("meatball",                0,   MZ_TINY,  1,  1, 0, FLESH,   5, CLR_BROWN),
-FOOD("meat stick",              0,   MZ_TINY,  1,  1, 0, FLESH,   5, CLR_BROWN),
-FOOD("massive chunk of meat",   0,MZ_GIGANTIC,20,400, 0, FLESH,2000, CLR_BROWN),
-FOOD("meat ring",               0,   MZ_TINY,  1,  1, 0, FLESH,   5, CLR_BROWN, O_MERGE(0)),
+FOOD(("tripe ration"),          140,  MZ_SMALL,  2, 10, 0, FLESH, 200, CLR_BROWN),
+FOOD(("corpse"),                  0, MZ_MEDIUM,  1,  0, 0, FLESH,   0, CLR_BROWN),
+FOOD(("egg"),                    85,   MZ_TINY,  1,  1, 1, FLESH,  80, CLR_WHITE),
+FOOD(("meatball"),                0,   MZ_TINY,  1,  1, 0, FLESH,   5, CLR_BROWN),
+FOOD(("meat stick"),              0,   MZ_TINY,  1,  1, 0, FLESH,   5, CLR_BROWN),
+FOOD(("massive chunk of meat"),   0,MZ_GIGANTIC,20,400, 0, FLESH,2000, CLR_BROWN),
+FOOD(("meat ring"),               0,   MZ_TINY,  1,  1, 0, FLESH,   5, CLR_BROWN, O_MERGE(0)),
 
 /* Body parts.... eeeww */
-FOOD("eyeball",                 0,   MZ_TINY,  1,  0, 0, FLESH,  10, CLR_WHITE),/*Needs tile*/
-FOOD("severed hand",            0,   MZ_TINY,  1,  0, 0, FLESH,  40, CLR_BROWN),/*Needs tile*/
+FOOD(("eyeball"),                 0,   MZ_TINY,  1,  0, 0, FLESH,  10, CLR_WHITE),/*Needs tile*/
+FOOD(("severed hand"),            0,   MZ_TINY,  1,  0, 0, FLESH,  40, CLR_BROWN),/*Needs tile*/
 
 /* fruits & veggies */
-FOOD("kelp frond",              0,  MZ_SMALL,  1,  1, 0, VEGGY,  30, CLR_GREEN),
-FOOD("eucalyptus leaf",         3,   MZ_TINY,  1,  1, 0, VEGGY,  30, CLR_GREEN),
+FOOD(("kelp frond"),              0,  MZ_SMALL,  1,  1, 0, VEGGY,  30, CLR_GREEN),
+FOOD(("eucalyptus leaf"),         3,   MZ_TINY,  1,  1, 0, VEGGY,  30, CLR_GREEN),
 /*Forbidden by Eve starts here:*/
-FOOD("apple",                  15,   MZ_TINY,  1,  2, 0, VEGGY,  50, CLR_RED),
-FOOD("orange",                 10,   MZ_TINY,  1,  2, 0, VEGGY,  80, CLR_ORANGE),
-FOOD("pear",                   10,   MZ_TINY,  1,  2, 0, VEGGY,  50, CLR_BRIGHT_GREEN),
-FOOD("melon",                  10,  MZ_SMALL,  1,  5, 0, VEGGY, 100, CLR_BRIGHT_GREEN),
-FOOD("banana",                 10,   MZ_TINY,  1,  2, 0, VEGGY,  80, CLR_YELLOW),
-FOOD("carrot",                 15,   MZ_TINY,  1,  2, 0, VEGGY,  50, CLR_ORANGE),
+FOOD(("apple"),                  15,   MZ_TINY,  1,  2, 0, VEGGY,  50, CLR_RED),
+FOOD(("orange"),                 10,   MZ_TINY,  1,  2, 0, VEGGY,  80, CLR_ORANGE),
+FOOD(("pear"),                   10,   MZ_TINY,  1,  2, 0, VEGGY,  50, CLR_BRIGHT_GREEN),
+FOOD(("melon"),                  10,  MZ_SMALL,  1,  5, 0, VEGGY, 100, CLR_BRIGHT_GREEN),
+FOOD(("banana"),                 10,   MZ_TINY,  1,  2, 0, VEGGY,  80, CLR_YELLOW),
+FOOD(("carrot"),                 15,   MZ_TINY,  1,  2, 0, VEGGY,  50, CLR_ORANGE),
 /*:and ends here*/
-FOOD("sprig of wolfsbane",      7,   MZ_TINY,  1,  1, 0, VEGGY,  40, CLR_GREEN),
-FOOD("clove of garlic",         7,   MZ_TINY,  1,  1, 0, VEGGY,  40, CLR_WHITE),
-FOOD("slime mold",             75,   MZ_TINY,  1,  5, 0, VEGGY, 250, HI_ORGANIC),
+FOOD(("sprig of wolfsbane"),      7,   MZ_TINY,  1,  1, 0, VEGGY,  40, CLR_GREEN),
+FOOD(("clove of garlic"),         7,   MZ_TINY,  1,  1, 0, VEGGY,  40, CLR_WHITE),
+FOOD(("slime mold"),             75,   MZ_TINY,  1,  5, 0, VEGGY, 250, HI_ORGANIC),
 
 /* people food */
-FOOD("lump of royal jelly",	    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("lump of soldier's jelly",  
+FOOD(("lump of royal jelly"),	    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
+FOOD(("lump of soldier's jelly"),  
 							    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("lump of dancer's jelly",
+FOOD(("lump of dancer's jelly"),
 							    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("lump of philosopher's jelly",
+FOOD(("lump of philosopher's jelly"),
 							    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("lump of priestess's jelly",
+FOOD(("lump of priestess's jelly"),
 							    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("lump of rhetor's jelly",
+FOOD(("lump of rhetor's jelly"),
 							    0,   MZ_TINY,  1,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("honeycomb",			    0,   MZ_TINY,  4, 10, 0, VEGGY, 800, CLR_YELLOW),
-FOOD("cream pie",              25,   MZ_TINY,  1, 10, 0, VEGGY, 100, CLR_WHITE),
-FOOD("candy bar",              13,   MZ_TINY,  1,  2, 0, VEGGY, 100, CLR_BROWN),
-FOOD("fortune cookie",         55,   MZ_TINY,  1,  1, 0, VEGGY,  40, CLR_YELLOW),
-FOOD("pancake",                25,   MZ_TINY,  2,  2, 0, VEGGY, 200, CLR_YELLOW),
-FOOD("lembas wafer",           20,   MZ_TINY,  2,  5, 0, VEGGY, 800, CLR_WHITE),
-FOOD("cram ration",            20,  MZ_SMALL,  3, 15, 0, VEGGY, 600, HI_ORGANIC),
-FOOD("food ration",           380,  MZ_SMALL,  5, 20, 0, VEGGY, 800, HI_ORGANIC),
-FOOD("protein pill",            0,   MZ_TINY,  1,  1, 0, VEGGY, 800, HI_ORGANIC), /*Needs encyc entry*//*Needs tile*/
-FOOD("K-ration",                0,  MZ_SMALL,  1, 10, 0, VEGGY, 400, HI_ORGANIC),
-FOOD("C-ration",                0,  MZ_SMALL,  1, 10, 0, VEGGY, 300, HI_ORGANIC),
-FOOD("tin",                    75,   MZ_TINY,  0, 10, 1, METAL,   0, HI_METAL),
+FOOD(("honeycomb"),			    0,   MZ_TINY,  4, 10, 0, VEGGY, 800, CLR_YELLOW),
+FOOD(("cream pie"),              25,   MZ_TINY,  1, 10, 0, VEGGY, 100, CLR_WHITE),
+FOOD(("candy bar"),              13,   MZ_TINY,  1,  2, 0, VEGGY, 100, CLR_BROWN),
+FOOD(("fortune cookie"),         55,   MZ_TINY,  1,  1, 0, VEGGY,  40, CLR_YELLOW),
+FOOD(("pancake"),                25,   MZ_TINY,  2,  2, 0, VEGGY, 200, CLR_YELLOW),
+FOOD(("lembas wafer"),           20,   MZ_TINY,  2,  5, 0, VEGGY, 800, CLR_WHITE),
+FOOD(("cram ration"),            20,  MZ_SMALL,  3, 15, 0, VEGGY, 600, HI_ORGANIC),
+FOOD(("food ration"),           380,  MZ_SMALL,  5, 20, 0, VEGGY, 800, HI_ORGANIC),
+FOOD(("protein pill"),            0,   MZ_TINY,  1,  1, 0, VEGGY, 800, HI_ORGANIC), /*Needs encyc entry*//*Needs tile*/
+FOOD(("K-ration"),                0,  MZ_SMALL,  1, 10, 0, VEGGY, 400, HI_ORGANIC),
+FOOD(("C-ration"),                0,  MZ_SMALL,  1, 10, 0, VEGGY, 300, HI_ORGANIC),
+FOOD(("tin"),                    75,   MZ_TINY,  0, 10, 1, METAL,   0, HI_METAL),
 #undef FOOD
 
 /* potions ... */
-#define POTION(name,desc,mgc,power,prob,cost,color,...) OBJECT( \
-		OBJ(name,desc), BITS(0,1,0,0,mgc,0,0,0,MZ_SMALL,0,0,P_NONE,GLASS,0), power, \
+#define POTION(names,mgc,power,prob,cost,color,...) OBJECT( \
+		DEF_BLINDNAME(names, "potion"), BITS(0,1,0,0,mgc,0,0,0,MZ_SMALL,0,0,P_NONE,GLASS,0), power, \
 		POTION_CLASS, prob, 0, 20, cost, {0}, {0}, 0, 0, 0, 10, color, __VA_ARGS__)
-POTION("gain ability", "ruby",          1, 0,          40, 300, CLR_RED),
-POTION("restore ability", "pink",       1, 0,          40, 100, CLR_BRIGHT_MAGENTA),
-POTION("confusion", "orange",           1, CONFUSION,  33, 100, CLR_ORANGE),
-POTION("blindness", "yellow",           1, BLINDED,    33, 150, CLR_YELLOW),
-POTION("paralysis", "emerald",          1, 0,          32, 300, CLR_BRIGHT_GREEN),
-POTION("speed", "dark green",           1, FAST,       40, 200, CLR_GREEN),
-POTION("levitation", "cyan",            1, LEVITATION, 40, 200, CLR_CYAN),
-POTION("hallucination", "sky blue",     1, HALLUC,     40, 100, CLR_CYAN),
-POTION("invisibility", "brilliant blue",1, INVIS,      40, 150, CLR_BRIGHT_BLUE),
-POTION("see invisible", "magenta",      1, SEE_INVIS,  40,  50, CLR_MAGENTA),
-POTION("healing", "purple-red",         1, 0,          57, 100, CLR_MAGENTA),
-POTION("extra healing", "puce",         1, 0,          47, 100, CLR_RED),
-POTION("gain level", "milky",           1, 0,          20, 300, CLR_WHITE),
-POTION("enlightenment", "swirly",       1, 0,          20, 200, CLR_BROWN),
-POTION("monster detection", "bubbly",   1, 0,          40, 150, CLR_WHITE),
-POTION("object detection", "smoky",     1, 0,          42, 150, CLR_GRAY),
-POTION("gain energy", "cloudy",         1, 0,          40, 150, CLR_WHITE),
-POTION("sleeping",  "effervescent",     1, 0,          40, 100, CLR_GRAY),
-POTION("full healing",  "black",        1, 0,          10, 200, CLR_BLACK),
-POTION("polymorph", "golden",           1, 0,          10, 200, CLR_YELLOW),
-POTION("booze", "brown",                0, 0,          42,  50, CLR_BROWN),
-POTION("sickness", "fizzy",             0, 0,          40,  50, CLR_CYAN),
-POTION("fruit juice", "dark",           0, 0,          42,  50, CLR_BLACK),
-POTION("acid", "white",                 0, 0,          32, 250, CLR_WHITE),
-POTION("oil", "murky",                  0, 0,          30, 250, CLR_BROWN),
-POTION("amnesia", "sparkling",          1, 0,          8,  100, CLR_CYAN),
-POTION("goat's milk", "black",          1, 0,          0,  900, CLR_BLACK),
-POTION("space mead", "golden",          1, 0,          0,  900, CLR_YELLOW),
-POTION("starlight", "dimly-shining",    1, 0,          4,  250, CLR_BRIGHT_CYAN),
-POTION("water", "clear",                0, 0,          80, 100, CLR_CYAN),
-POTION("blood", "blood-red",            0, 0,          18, 50,  CLR_RED, O_USKWN(1)),	/* each potion of blood must be ID-ed */
+POTION(("gain ability", "ruby"),          1, 0,          40, 300, CLR_RED),
+POTION(("restore ability", "pink"),       1, 0,          40, 100, CLR_BRIGHT_MAGENTA),
+POTION(("confusion", "orange"),           1, CONFUSION,  33, 100, CLR_ORANGE),
+POTION(("blindness", "yellow"),           1, BLINDED,    33, 150, CLR_YELLOW),
+POTION(("paralysis", "emerald"),          1, 0,          32, 300, CLR_BRIGHT_GREEN),
+POTION(("speed", "dark green"),           1, FAST,       40, 200, CLR_GREEN),
+POTION(("levitation", "cyan"),            1, LEVITATION, 40, 200, CLR_CYAN),
+POTION(("hallucination", "sky blue"),     1, HALLUC,     40, 100, CLR_CYAN),
+POTION(("invisibility", "brilliant blue"),1, INVIS,      40, 150, CLR_BRIGHT_BLUE),
+POTION(("see invisible", "magenta"),      1, SEE_INVIS,  40,  50, CLR_MAGENTA),
+POTION(("healing", "purple-red"),         1, 0,          57, 100, CLR_MAGENTA),
+POTION(("extra healing", "puce"),         1, 0,          47, 100, CLR_RED),
+POTION(("gain level", "milky"),           1, 0,          20, 300, CLR_WHITE),
+POTION(("enlightenment", "swirly"),       1, 0,          20, 200, CLR_BROWN),
+POTION(("monster detection", "bubbly"),   1, 0,          40, 150, CLR_WHITE),
+POTION(("object detection", "smoky"),     1, 0,          42, 150, CLR_GRAY),
+POTION(("gain energy", "cloudy"),         1, 0,          40, 150, CLR_WHITE),
+POTION(("sleeping",  "effervescent"),     1, 0,          40, 100, CLR_GRAY),
+POTION(("full healing",  "black"),        1, 0,          10, 200, CLR_BLACK),
+POTION(("polymorph", "golden"),           1, 0,          10, 200, CLR_YELLOW),
+POTION(("booze", "brown"),                0, 0,          42,  50, CLR_BROWN),
+POTION(("sickness", "fizzy"),             0, 0,          40,  50, CLR_CYAN),
+POTION(("fruit juice", "dark"),           0, 0,          42,  50, CLR_BLACK),
+POTION(("acid", "white"),                 0, 0,          32, 250, CLR_WHITE),
+POTION(("oil", "murky"),                  0, 0,          30, 250, CLR_BROWN),
+POTION(("amnesia", "sparkling"),          1, 0,          8,  100, CLR_CYAN),
+POTION(("goat's milk", "black"),          1, 0,          0,  900, CLR_BLACK),
+POTION(("space mead", "golden"),          1, 0,          0,  900, CLR_YELLOW),
+POTION(("starlight", "dimly-shining"),    1, 0,          4,  250, CLR_BRIGHT_CYAN),
+POTION(("water", "clear"),                0, 0,          80, 100, CLR_CYAN),
+POTION(("blood", "blood-red"),            0, 0,          18, 50,  CLR_RED, O_USKWN(1)),	/* each potion of blood must be ID-ed */
 #undef POTION
 
 /* scrolls ... */
-#define SCROLL(name,text,mgc,prob,cost,...) OBJECT( \
-		OBJ(name,text), BITS(0,1,0,0,mgc,0,0,0,MZ_SMALL,0,0,P_NONE,PAPER,0), 0, \
+#define SCROLL(names,mgc,prob,cost,...) OBJECT( \
+		DEF_BLINDNAME(names, "scroll"), BITS(0,1,0,0,mgc,0,0,0,MZ_SMALL,0,0,P_NONE,PAPER,0), 0, \
 		SCROLL_CLASS, prob, 0, 5, cost, {0}, {0}, 0, 0, 0, 6, HI_PAPER, __VA_ARGS__)
-	SCROLL("enchant armor",         "ZELGO MER",            1,  59,  80),
-	SCROLL("destroy armor",         "JUYED AWK YACC",       1,  35, 100),
-	SCROLL("confuse monster",       "NR 9",                 1,  41, 100),
-	SCROLL("scare monster",         "XIXAXA XOXAXA XUXAXA", 1,  32, 100),
-	SCROLL("remove curse",          "PRATYAVAYAH",          1,  60,  80),
-	SCROLL("enchant weapon",        "DAIYEN FOOELS",        1,  74,  60),
-	SCROLL("create monster",        "LEP GEX VEN ZEA",      1,  41, 200),
-	SCROLL("taming",                "PRIRUTSENIE",          1,  14, 200),
-	SCROLL("genocide",              "ELBIB YLOH",           1,  13, 300),
-	SCROLL("light",                 "VERR YED HORRE",       1,  71,  50),
-	SCROLL("teleportation",         "VENZAR BORGAVVE",      1,  51, 100),
-	SCROLL("gold detection",        "THARR",                1,  30, 100),
-	SCROLL("food detection",        "YUM YUM",              1,  23, 100),
-	SCROLL("identify",              "KERNOD WEL",           1, 169,  20),
-	SCROLL("magic mapping",         "ELAM EBOW",            1,  41, 100),
-	SCROLL("amnesia",               "DUAM XNAHT",           1,  27, 200),
-	SCROLL("fire",                  "ANDOVA BEGARIN",       1,  23, 100),
-	SCROLL("earth",                 "KIRJE",                1,  16, 200),
-	SCROLL("punishment",            "VE FORBRYDERNE",       1,  12, 300),
-	SCROLL("charging",              "HACKEM MUCHE",         1,  14, 300),
-	SCROLL("stinking cloud",		"VELOX NEB",            1,  13, 300),
-	SCROLL("ward",					"TLASFO SENIL",         1,  55, 300),
-	SCROLL("warding",				"RW NW PRT M HRW",      1,  13, 300),
-	SCROLL("antimagic",				"KARSUS",     		    1,  18, 250),
-	SCROLL("resistance",			"DESREVER TSEPMET",		1,  34, 250),
-	SCROLL("consecration",			"HLY HLS",      		1,   0,3000, O_NOWISH(1)),	/* unwishable/unwritable */
-	SCROLL((char *)0,		"FOOBIE BLETCH",        1,   0, 100),
-	SCROLL((char *)0,		"TEMOV",                1,   0, 100),
-	SCROLL((char *)0,		"GARVEN DEH",           1,   0, 100),
-	SCROLL((char *)0,		"READ ME",              1,   0, 100),
+	SCROLL(("enchant armor",         "ZELGO MER"),            1,  59,  80),
+	SCROLL(("destroy armor",         "JUYED AWK YACC"),       1,  35, 100),
+	SCROLL(("confuse monster",       "NR 9"),                 1,  41, 100),
+	SCROLL(("scare monster",         "XIXAXA XOXAXA XUXAXA"), 1,  32, 100),
+	SCROLL(("remove curse",          "PRATYAVAYAH"),          1,  60,  80),
+	SCROLL(("enchant weapon",        "DAIYEN FOOELS"),        1,  74,  60),
+	SCROLL(("create monster",        "LEP GEX VEN ZEA"),      1,  41, 200),
+	SCROLL(("taming",                "PRIRUTSENIE"),          1,  14, 200),
+	SCROLL(("genocide",              "ELBIB YLOH"),           1,  13, 300),
+	SCROLL(("light",                 "VERR YED HORRE"),       1,  71,  50),
+	SCROLL(("teleportation",         "VENZAR BORGAVVE"),      1,  51, 100),
+	SCROLL(("gold detection",        "THARR"),                1,  30, 100),
+	SCROLL(("food detection",        "YUM YUM"),              1,  23, 100),
+	SCROLL(("identify",              "KERNOD WEL"),           1, 169,  20),
+	SCROLL(("magic mapping",         "ELAM EBOW"),            1,  41, 100),
+	SCROLL(("amnesia",               "DUAM XNAHT"),           1,  27, 200),
+	SCROLL(("fire",                  "ANDOVA BEGARIN"),       1,  23, 100),
+	SCROLL(("earth",                 "KIRJE"),                1,  16, 200),
+	SCROLL(("punishment",            "VE FORBRYDERNE"),       1,  12, 300),
+	SCROLL(("charging",              "HACKEM MUCHE"),         1,  14, 300),
+	SCROLL(("stinking cloud",        "VELOX NEB"),            1,  13, 300),
+	SCROLL(("ward",                  "TLASFO SENIL"),         1,  55, 300),
+	SCROLL(("warding",               "RW NW PRT M HRW"),      1,  13, 300),
+	SCROLL(("antimagic",             "KARSUS"),               1,  18, 250),
+	SCROLL(("resistance",            "DESREVER TSEPMET"),     1,  34, 250),
+	SCROLL(("consecration",          "HLY HLS"),              1,   0,3000, O_NOWISH(1)),	/* unwishable/unwritable */
+	SCROLL(((char *)0,               "FOOBIE BLETCH"),        1,   0, 100),
+	SCROLL(((char *)0,               "TEMOV"),                1,   0, 100),
+	SCROLL(((char *)0,               "GARVEN DEH"),           1,   0, 100),
+	SCROLL(((char *)0,               "READ ME"),              1,   0, 100),
 	/* these must come last because they have special descriptions */
 #ifdef MAIL
-	SCROLL("mail",                  "stamped",          0,   0,   0),
+	SCROLL(("mail",                  "stamped"),          0,   0,   0),
 #endif
-	SCROLL("blank paper",           "unlabeled",        0,  21,  60),
+	SCROLL(("blank paper",           "unlabeled"),        0,  21,  60),
 
-	SCROLL("Gold Scroll of Law",    "golden",           0,   0,  10,
+	SCROLL(("Gold Scroll of Law",    "golden"),           0,   0,  10,
 		O_MAT(GOLD), O_COLOR(HI_GOLD), O_WT(50)), /* Shopkeepers aren't interested in these */
 #undef SCROLL
 
-#define CERAMIC_TILE(name,text,prob,...) OBJECT( \
-		OBJ(name,text), BITS(0,1,0,0,1,0,0,0,MZ_TINY,0,0,P_NONE,MINERAL, IDED|UNIDED), 0, \
+#define CERAMIC_TILE(names,prob,...) OBJECT( \
+		DEF_BLINDNAME(names, "shard"), BITS(0,1,0,0,1,0,0,0,MZ_TINY,0,0,P_NONE,MINERAL, IDED|UNIDED), 0, \
 		TILE_CLASS, prob, 0, 3, 300, {0}, {0}, 0, 0, 0, 6, CLR_WHITE, __VA_ARGS__)
 	/* Randomized descriptions */
-	CERAMIC_TILE("syllable of strength: Aesh","bipartite glyph", 167),
-	CERAMIC_TILE("syllable of power: Krau",   "crossed glyph",   166),
-	CERAMIC_TILE("syllable of life: Hoon",    "knotted glyph",   167),
-	CERAMIC_TILE("syllable of grace: Uur",    "multilinear glyph", 167),
-	CERAMIC_TILE("syllable of thought: Naen", "dotted glyph",    167),
-	CERAMIC_TILE("syllable of spirit: Vaul",  "hanging glyph",   166),
+	CERAMIC_TILE(("syllable of strength: Aesh","bipartite glyph"), 167),
+	CERAMIC_TILE(("syllable of power: Krau",   "crossed glyph"),   166),
+	CERAMIC_TILE(("syllable of life: Hoon",    "knotted glyph"),   167),
+	CERAMIC_TILE(("syllable of grace: Uur",    "multilinear glyph"), 167),
+	CERAMIC_TILE(("syllable of thought: Naen", "dotted glyph"),    167),
+	CERAMIC_TILE(("syllable of spirit: Vaul",  "hanging glyph"),   166),
 #undef CERAMIC_TILE
-#define BONE_TILE(name,text,prob,...) OBJECT( \
-		OBJ(name,text), BITS(0,1,0,0,0,0,0,0,MZ_TINY,0,0,P_NONE,BONE, IDED|UNIDED), 0, \
+#define BONE_TILE(names,prob,...) OBJECT( \
+		DEF_BLINDNAME(names, "shard"), BITS(0,1,0,0,0,0,0,0,MZ_TINY,0,0,P_NONE,BONE, IDED|UNIDED), 0, \
 		TILE_CLASS, prob, 0, 3, 300, {0}, {0}, 0, 0, 0, 6, CLR_GRAY, __VA_ARGS__)
-	BONE_TILE("anti-clockwise metamorphosis glyph",  "counterclockwise-rotated cross",   0),	// ANTI_CLOCKWISE_METAMORPHOSIS
-	BONE_TILE("clockwise metamorphosis glyph",  "clockwise-rotated cross",   0),				// CLOCKWISE_METAMORPHOSIS
-	BONE_TILE("sparkling lake glyph",  "sparkling horizontal line",   0),	// ARCANE_BULWARK
-	BONE_TILE("fading lake glyph",  "fading horizontal line",   0),			// DISSIPATING_BULWARK
-	BONE_TILE("smoking lake glyph",  "smoking horizontal line",   0),		// SMOLDERING_BULWARK
-	BONE_TILE("frosted lake glyph",  "frosted horizontal line",   0),		// FROSTED_BULWARK
-	BONE_TILE("rapturous eye glyph",  "long-lashed eye",   0),				// BLOOD_RAPTURE
-	BONE_TILE("clawmark glyph",  "set of many vertical lines",   0),				// CLAWMARK
-	BONE_TILE("clear sea glyph",  "set of coalescing vertical lines",   0),		// CLEAR_DEEPS
-	BONE_TILE("deep sea glyph",  "set of coalescing vertical marks",   0),			// DEEP_SEA
-	BONE_TILE("communion glyph",  "weeping-eyed leaf",   0),				// COMMUNION
-	BONE_TILE("corruption glyph",  "bleeding caduceus",   0),				// CORRUPTION
-	BONE_TILE("eye glyph",  "pentagonal eye",   0),							// EYE_THOUGHT
-	BONE_TILE("formless voice glyph",  "thrice-sealed eye",   0),			// FORMLESS_VOICE
-	BONE_TILE("guidance glyph",  "long-tailed watcher",   0),					// GUIDANCE
-	BONE_TILE("impurity glyph",  "once-sealed six-sworn eye",   0),			// IMPURITY
-	BONE_TILE("moon glyph",  "sword-crossed eye",   0),						// MOON
-	BONE_TILE("writhe glyph",  "writhing vesica piscis",   0),				// WRITHE
-	BONE_TILE("radiance glyph",  "eyed triangle",   0),						// RADIANCE
-	BONE_TILE("beast's embrace glyph",  "curling beast's claw",   0),		// BEASTS_EMBRACE
+	BONE_TILE(("anti-clockwise metamorphosis glyph",  "counterclockwise-rotated cross"),   0),	// ANTI_CLOCKWISE_METAMORPHOSIS
+	BONE_TILE(("clockwise metamorphosis glyph",  "clockwise-rotated cross"),   0),				// CLOCKWISE_METAMORPHOSIS
+	BONE_TILE(("sparkling lake glyph",  "sparkling horizontal line"),   0),	// ARCANE_BULWARK
+	BONE_TILE(("fading lake glyph",  "fading horizontal line"),   0),			// DISSIPATING_BULWARK
+	BONE_TILE(("smoking lake glyph",  "smoking horizontal line"),   0),		// SMOLDERING_BULWARK
+	BONE_TILE(("frosted lake glyph",  "frosted horizontal line"),   0),		// FROSTED_BULWARK
+	BONE_TILE(("rapturous eye glyph",  "long-lashed eye"),   0),				// BLOOD_RAPTURE
+	BONE_TILE(("clawmark glyph",  "set of many vertical lines"),   0),				// CLAWMARK
+	BONE_TILE(("clear sea glyph",  "set of coalescing vertical lines"),   0),		// CLEAR_DEEPS
+	BONE_TILE(("deep sea glyph",  "set of coalescing vertical marks"),   0),			// DEEP_SEA
+	BONE_TILE(("communion glyph",  "weeping-eyed leaf"),   0),				// COMMUNION
+	BONE_TILE(("corruption glyph",  "bleeding caduceus"),   0),				// CORRUPTION
+	BONE_TILE(("eye glyph",  "pentagonal eye"),   0),							// EYE_THOUGHT
+	BONE_TILE(("formless voice glyph",  "thrice-sealed eye"),   0),			// FORMLESS_VOICE
+	BONE_TILE(("guidance glyph",  "long-tailed watcher"),   0),					// GUIDANCE
+	BONE_TILE(("impurity glyph",  "once-sealed six-sworn eye"),   0),			// IMPURITY
+	BONE_TILE(("moon glyph",  "sword-crossed eye"),   0),						// MOON
+	BONE_TILE(("writhe glyph",  "writhing vesica piscis"),   0),				// WRITHE
+	BONE_TILE(("radiance glyph",  "eyed triangle"),   0),						// RADIANCE
+	BONE_TILE(("beast's embrace glyph",  "curling beast's claw"),   0),		// BEASTS_EMBRACE
 #undef BONE_TILE
-#define METALIC_SLAB(name,text, clr,...) OBJECT( \
-		OBJ(name,text), BITS(0,0,0,0,1,0,1,1,MZ_TINY,0,0,P_NONE,METAL, IDED|UNIDED), 0, \
+#define METALIC_SLAB(names, clr,...) OBJECT( \
+		DEF_BLINDNAME(names, "slab"), BITS(0,0,0,0,1,0,1,1,MZ_TINY,0,0,P_NONE,METAL, IDED|UNIDED), 0, \
 		TILE_CLASS, 0, 0, 3, 3000, {0}, {0}, 0, 0, 0, 6, clr, __VA_ARGS__)
 	/* Fixed descriptions (also, artifact base-items only) */
-	METALIC_SLAB("First Word",  "blinding glyph", CLR_YELLOW),
-	METALIC_SLAB("Dividing Word",  "cerulean glyph", HI_ZAP),
-	METALIC_SLAB("Nurturing Word",  "verdant glyph", CLR_GREEN),
-	METALIC_SLAB("Word of Knowledge",  "crimson glyph", CLR_RED),
+	METALIC_SLAB(("First Word",  "blinding glyph"), CLR_YELLOW),
+	METALIC_SLAB(("Dividing Word",  "cerulean glyph"), HI_ZAP),
+	METALIC_SLAB(("Nurturing Word",  "verdant glyph"), CLR_GREEN),
+	METALIC_SLAB(("Word of Knowledge",  "crimson glyph"), CLR_RED),
 #undef METALIC_SLAB
 
 /* spellbooks ... */
-#define SPELL(name,desc,sub,prob,level,mgc,dir,color,...) OBJECT( \
-		OBJ(name,desc), BITS(0,0,0,0,mgc,0,0,0,MZ_LARGE,0,dir,sub,PAPER,0), 0, \
+#define SPELL(names,sub,prob,level,mgc,dir,color,...) OBJECT( \
+		DEF_BLINDNAME(names, "spellbook"), BITS(0,0,0,0,mgc,0,0,0,MZ_LARGE,0,dir,sub,PAPER,0), 0, \
 		SPBOOK_CLASS, prob, level, \
 		50, level * 100, {0}, {0}, 0, level, 0, 20, color, __VA_ARGS__)
-SPELL("dig",             "parchment",   P_MATTER_SPELL,			20, 5, 1, RAY,       HI_PAPER),
-SPELL("magic missile",   "vellum",      P_ATTACK_SPELL, 		45, 2, 1, RAY,       HI_PAPER),
-SPELL("fireball",        "ragged",      P_ATTACK_SPELL, 		20, 4, 1, RAY,       HI_PAPER),
-SPELL("cone of cold",    "dog eared",   P_ATTACK_SPELL, 		20, 4, 1, RAY,       HI_PAPER),
-SPELL("sleep",           "mottled",     P_ENCHANTMENT_SPELL,	50, 1, 1, RAY,       HI_PAPER),
-SPELL("finger of death", "stained",     P_ATTACK_SPELL,  		 5, 7, 1, RAY,       HI_PAPER),
-SPELL("lightning bolt",  "storm-hued",  P_ATTACK_SPELL,  		 0, 5, 1, RAY,       CLR_BLUE, O_NOWISH(1)), /* unwishable */
-SPELL("poison spray",    "snakeskin",  	P_MATTER_SPELL,  		 0, 4, 1, RAY,       CLR_GREEN, O_NOWISH(1)), /* unwishable *//*Needs tile*/
-SPELL("acid splash",     "acid green", 	P_MATTER_SPELL,  		 0, 4, 1, RAY,       CLR_BRIGHT_GREEN),/*Needs tile*/
-SPELL("light",           "cloth",       P_DIVINATION_SPELL,  	45, 1, 1, NODIR,     HI_CLOTH),
-SPELL("fire storm",		 "flame-red",   P_ATTACK_SPELL,  		 0, 6, 1, NODIR,     CLR_RED),
-SPELL("blizzard",        "snow white",  P_ATTACK_SPELL,  		 0, 6, 1, NODIR,     CLR_WHITE),
-SPELL("detect monsters", "leather",     P_DIVINATION_SPELL,	 	43, 2, 1, NODIR,     HI_LEATHER),
-SPELL("healing",         "white",       P_HEALING_SPELL,  		40, 1, 1, IMMEDIATE, CLR_WHITE),
-SPELL("lightning storm", "ocean blue",  P_ATTACK_SPELL,  		 0, 7, 1, NODIR,     CLR_BLUE, O_NOWISH(1)), /* unwishable */
-SPELL("knock",           "pink",        P_MATTER_SPELL,  		30, 1, 1, IMMEDIATE, CLR_BRIGHT_MAGENTA),
-SPELL("force bolt",      "red",         P_ATTACK_SPELL,  		35, 1, 1, IMMEDIATE, CLR_RED),
-SPELL("confuse monster", "orange",      P_ENCHANTMENT_SPELL,	30, 2, 1, IMMEDIATE, CLR_ORANGE),
-SPELL("cure blindness",  "yellow",      P_HEALING_SPELL,  		25, 2, 1, IMMEDIATE, CLR_YELLOW),
-SPELL("drain life",      "velvet",      P_ATTACK_SPELL,  		10, 2, 1, IMMEDIATE, CLR_MAGENTA),
-SPELL("slow monster",    "light green", P_ENCHANTMENT_SPELL,	30, 2, 1, IMMEDIATE, CLR_BRIGHT_GREEN),
-SPELL("wizard lock",     "dark green",  P_MATTER_SPELL,  		25, 2, 1, IMMEDIATE, CLR_GREEN),
-// SPELL("create monster",  "turquoise",   P_CLERIC_SPELL,  	35, 2, 1, NODIR,     CLR_BRIGHT_CYAN),
-SPELL("turn undead",     "copper",      P_CLERIC_SPELL,  		25, 2, 1, IMMEDIATE, HI_COPPER),
-SPELL("detect food",     "cyan",        P_DIVINATION_SPELL,  	30, 2, 1, NODIR,     CLR_CYAN),
-SPELL("cause fear",      "light blue",  P_ENCHANTMENT_SPELL,  	25, 3, 1, NODIR,     CLR_BRIGHT_BLUE),
-SPELL("clairvoyance",    "dark blue",   P_DIVINATION_SPELL,  	15, 3, 1, NODIR,     CLR_BLUE),
-SPELL("cure sickness",   "indigo",      P_HEALING_SPELL,		32, 3, 1, NODIR,     CLR_BLUE),
-SPELL("pacify monster",  "fuchsia",		P_ENCHANTMENT_SPELL,  	10, 3, 1, IMMEDIATE, CLR_MAGENTA),
-SPELL("charm monster",   "magenta",     P_ENCHANTMENT_SPELL,  	10, 5, 1, IMMEDIATE, CLR_MAGENTA),
-SPELL("haste self",      "purple",      P_ESCAPE_SPELL,			33, 3, 1, NODIR,     CLR_MAGENTA),
-SPELL("detect unseen",   "violet",      P_DIVINATION_SPELL,  	20, 3, 1, NODIR,     CLR_MAGENTA),
-SPELL("levitation",      "tan",         P_ESCAPE_SPELL,			20, 4, 1, NODIR,     CLR_BROWN),
-SPELL("extra healing",   "plaid",       P_HEALING_SPELL,		27, 3, 1, IMMEDIATE, CLR_GREEN),
-SPELL("restore ability", "light brown", P_HEALING_SPELL,		25, 4, 1, NODIR,     CLR_BROWN),
-SPELL("invisibility",    "dark brown",  P_ESCAPE_SPELL,			25, 4, 1, NODIR,     CLR_BROWN),
-SPELL("detect treasure", "gray",        P_DIVINATION_SPELL,  	20, 4, 1, NODIR,     CLR_GRAY),
-SPELL("remove curse",    "wrinkled",    P_CLERIC_SPELL,			25, 3, 1, NODIR,     HI_PAPER),
-SPELL("magic mapping",   "dusty",       P_DIVINATION_SPELL,  	18, 5, 1, NODIR,     HI_PAPER),
-SPELL("identify",        "bronze",      P_DIVINATION_SPELL,  	20, 3, 1, NODIR,     HI_COPPER),
-// SPELL("turn undead",     "copper",      P_CLERIC_SPELL,		16, 6, 1, IMMEDIATE, HI_COPPER),
-SPELL("create monster",  "turquoise",   P_CLERIC_SPELL,			16, 6, 1, NODIR,     CLR_BRIGHT_CYAN),
-SPELL("polymorph",       "silver",      P_MATTER_SPELL,			10, 7, 1, IMMEDIATE, HI_SILVER),
-SPELL("teleport away",   "gold",        P_ESCAPE_SPELL,			15, 6, 1, IMMEDIATE, HI_GOLD),
-SPELL("create familiar", "glittering",  P_CLERIC_SPELL,			10, 6, 1, NODIR,     CLR_WHITE),
-SPELL("cancellation",    "shining",     P_MATTER_SPELL,			15, 6, 1, IMMEDIATE, CLR_WHITE),
-SPELL("protection",	     "dull",        P_CLERIC_SPELL,			18, 1, 1, NODIR,     HI_PAPER),
-SPELL("antimagic shield","ebony",		P_CLERIC_SPELL,			10, 5, 1, IMMEDIATE, CLR_BLACK),
-SPELL("jumping",	     "thin",        P_ESCAPE_SPELL,			20, 1, 1, IMMEDIATE, HI_PAPER),
-SPELL("stone to flesh",	 "thick",       P_HEALING_SPELL,		15, 3, 1, IMMEDIATE, HI_PAPER),
+SPELL(("dig",             "parchment"),   P_MATTER_SPELL,			20, 5, 1, RAY,       HI_PAPER),
+SPELL(("magic missile",   "vellum"),      P_ATTACK_SPELL, 		45, 2, 1, RAY,       HI_PAPER),
+SPELL(("fireball",        "ragged"),      P_ATTACK_SPELL, 		20, 4, 1, RAY,       HI_PAPER),
+SPELL(("cone of cold",    "dog eared"),   P_ATTACK_SPELL, 		20, 4, 1, RAY,       HI_PAPER),
+SPELL(("sleep",           "mottled"),     P_ENCHANTMENT_SPELL,	50, 1, 1, RAY,       HI_PAPER),
+SPELL(("finger of death", "stained"),     P_ATTACK_SPELL,  		 5, 7, 1, RAY,       HI_PAPER),
+SPELL(("lightning bolt",  "storm-hued"),  P_ATTACK_SPELL,  		 0, 5, 1, RAY,       CLR_BLUE, O_NOWISH(1)), /* unwishable */
+SPELL(("poison spray",    "snakeskin"),  	P_MATTER_SPELL,  		 0, 4, 1, RAY,       CLR_GREEN, O_NOWISH(1)), /* unwishable *//*Needs tile*/
+SPELL(("acid splash",     "acid green"), 	P_MATTER_SPELL,  		 0, 4, 1, RAY,       CLR_BRIGHT_GREEN),/*Needs tile*/
+SPELL(("light",           "cloth"),       P_DIVINATION_SPELL,  	45, 1, 1, NODIR,     HI_CLOTH),
+SPELL(("fire storm",		 "flame-red"),   P_ATTACK_SPELL,  		 0, 6, 1, NODIR,     CLR_RED),
+SPELL(("blizzard",        "snow white"),  P_ATTACK_SPELL,  		 0, 6, 1, NODIR,     CLR_WHITE),
+SPELL(("detect monsters", "leather"),     P_DIVINATION_SPELL,	 	43, 2, 1, NODIR,     HI_LEATHER),
+SPELL(("healing",         "white"),       P_HEALING_SPELL,  		40, 1, 1, IMMEDIATE, CLR_WHITE),
+SPELL(("lightning storm", "ocean blue"),  P_ATTACK_SPELL,  		 0, 7, 1, NODIR,     CLR_BLUE, O_NOWISH(1)), /* unwishable */
+SPELL(("knock",           "pink"),        P_MATTER_SPELL,  		30, 1, 1, IMMEDIATE, CLR_BRIGHT_MAGENTA),
+SPELL(("force bolt",      "red"),         P_ATTACK_SPELL,  		35, 1, 1, IMMEDIATE, CLR_RED),
+SPELL(("confuse monster", "orange"),      P_ENCHANTMENT_SPELL,	30, 2, 1, IMMEDIATE, CLR_ORANGE),
+SPELL(("cure blindness",  "yellow"),      P_HEALING_SPELL,  		25, 2, 1, IMMEDIATE, CLR_YELLOW),
+SPELL(("drain life",      "velvet"),      P_ATTACK_SPELL,  		10, 2, 1, IMMEDIATE, CLR_MAGENTA),
+SPELL(("slow monster",    "light green"), P_ENCHANTMENT_SPELL,	30, 2, 1, IMMEDIATE, CLR_BRIGHT_GREEN),
+SPELL(("wizard lock",     "dark green"),  P_MATTER_SPELL,  		25, 2, 1, IMMEDIATE, CLR_GREEN),
+// SPELL(("create monster",  "turquoise"),   P_CLERIC_SPELL,  	35, 2, 1, NODIR,     CLR_BRIGHT_CYAN),
+SPELL(("turn undead",     "copper"),      P_CLERIC_SPELL,  		25, 2, 1, IMMEDIATE, HI_COPPER),
+SPELL(("detect food",     "cyan"),        P_DIVINATION_SPELL,  	30, 2, 1, NODIR,     CLR_CYAN),
+SPELL(("cause fear",      "light blue"),  P_ENCHANTMENT_SPELL,  	25, 3, 1, NODIR,     CLR_BRIGHT_BLUE),
+SPELL(("clairvoyance",    "dark blue"),   P_DIVINATION_SPELL,  	15, 3, 1, NODIR,     CLR_BLUE),
+SPELL(("cure sickness",   "indigo"),      P_HEALING_SPELL,		32, 3, 1, NODIR,     CLR_BLUE),
+SPELL(("pacify monster",  "fuchsia"),		P_ENCHANTMENT_SPELL,  	10, 3, 1, IMMEDIATE, CLR_MAGENTA),
+SPELL(("charm monster",   "magenta"),     P_ENCHANTMENT_SPELL,  	10, 5, 1, IMMEDIATE, CLR_MAGENTA),
+SPELL(("haste self",      "purple"),      P_ESCAPE_SPELL,			33, 3, 1, NODIR,     CLR_MAGENTA),
+SPELL(("detect unseen",   "violet"),      P_DIVINATION_SPELL,  	20, 3, 1, NODIR,     CLR_MAGENTA),
+SPELL(("levitation",      "tan"),         P_ESCAPE_SPELL,			20, 4, 1, NODIR,     CLR_BROWN),
+SPELL(("extra healing",   "plaid"),       P_HEALING_SPELL,		27, 3, 1, IMMEDIATE, CLR_GREEN),
+SPELL(("restore ability", "light brown"), P_HEALING_SPELL,		25, 4, 1, NODIR,     CLR_BROWN),
+SPELL(("invisibility",    "dark brown"),  P_ESCAPE_SPELL,			25, 4, 1, NODIR,     CLR_BROWN),
+SPELL(("detect treasure", "gray"),        P_DIVINATION_SPELL,  	20, 4, 1, NODIR,     CLR_GRAY),
+SPELL(("remove curse",    "wrinkled"),    P_CLERIC_SPELL,			25, 3, 1, NODIR,     HI_PAPER),
+SPELL(("magic mapping",   "dusty"),       P_DIVINATION_SPELL,  	18, 5, 1, NODIR,     HI_PAPER),
+SPELL(("identify",        "bronze"),      P_DIVINATION_SPELL,  	20, 3, 1, NODIR,     HI_COPPER),
+// SPELL(("turn undead",     "copper"),      P_CLERIC_SPELL,		16, 6, 1, IMMEDIATE, HI_COPPER),
+SPELL(("create monster",  "turquoise"),   P_CLERIC_SPELL,			16, 6, 1, NODIR,     CLR_BRIGHT_CYAN),
+SPELL(("polymorph",       "silver"),      P_MATTER_SPELL,			10, 7, 1, IMMEDIATE, HI_SILVER),
+SPELL(("teleport away",   "gold"),        P_ESCAPE_SPELL,			15, 6, 1, IMMEDIATE, HI_GOLD),
+SPELL(("create familiar", "glittering"),  P_CLERIC_SPELL,			10, 6, 1, NODIR,     CLR_WHITE),
+SPELL(("cancellation",    "shining"),     P_MATTER_SPELL,			15, 6, 1, IMMEDIATE, CLR_WHITE),
+SPELL(("protection",	     "dull"),        P_CLERIC_SPELL,			18, 1, 1, NODIR,     HI_PAPER),
+SPELL(("antimagic shield","ebony"),		P_CLERIC_SPELL,			10, 5, 1, IMMEDIATE, CLR_BLACK),
+SPELL(("jumping",	     "thin"),        P_ESCAPE_SPELL,			20, 1, 1, IMMEDIATE, HI_PAPER),
+SPELL(("stone to flesh",	 "thick"),       P_HEALING_SPELL,		15, 3, 1, IMMEDIATE, HI_PAPER),
 #if 0	/* DEFERRED */
-SPELL("flame sphere",    "canvas",      P_MATTER_SPELL,			20, 1, 1, NODIR, CLR_BROWN),
-SPELL("freeze sphere",   "hardcover",   P_MATTER_SPELL,			20, 1, 1, NODIR, CLR_BROWN),
+SPELL(("flame sphere",    "canvas"),      P_MATTER_SPELL,			20, 1, 1, NODIR, CLR_BROWN),
+SPELL(("freeze sphere",   "hardcover"),   P_MATTER_SPELL,			20, 1, 1, NODIR, CLR_BROWN),
 #endif
 /* blank spellbook must come last because it retains its description */
-SPELL("blank paper",     "plain",       P_NONE,					18, 0, 0, 0,         HI_PAPER),
+SPELL(("blank paper",     "plain"),       P_NONE,					18, 0, 0, 0,         HI_PAPER),
 
 /* a special, one of a kind, spellbook */
-SPELL("Book of the Dead","papyrus",     P_NONE,                  0, 7, 1, 0,         HI_PAPER,
+SPELL(("Book of the Dead","papyrus"),     P_NONE,                  0, 7, 1, 0,         HI_PAPER,
 	O_USKWN(1), O_DELAY(0), O_WT(20), O_COST(10000), O_UNIQ(1), O_NOWISH(1)),
 /* base item for many artifact spellbooks */
-SPELL("secrets", "ragged leather",      P_NONE,                  0, 7, 1, 0,         CLR_BROWN,
+SPELL(("secrets", "ragged leather"),      P_NONE,                  0, 7, 1, 0,         CLR_BROWN,
 	O_USKWN(1), O_DELAY(0), O_WT(20), O_COST(10000), O_NOWISH(1)),
 
 #undef SPELL
 
 /* wands ... */
-#define WAND(name,typ,prob,cost,mgc,dir,metal,color,...) OBJECT( \
-		OBJ(name,typ), BITS(0,0,1,0,mgc,1,0,0,MZ_TINY,0,dir,P_NONE,metal,0), 0, \
+#define WAND(names,prob,cost,mgc,dir,metal,color,...) OBJECT( \
+		DEF_BLINDNAME(names, "wand"), BITS(0,0,1,0,mgc,1,0,0,MZ_TINY,0,dir,P_NONE,metal,0), 0, \
 		WAND_CLASS, prob, 0, 7, cost, {0}, {0}, 0, 0, 0, 30, color, __VA_ARGS__)
-WAND("light",          "glass",         90, 100, 1, NODIR,     GLASS,       CLR_WHITE),/*Needs tile?*/
-WAND("darkness",       "obsidian",      10, 100, 1, NODIR,     OBSIDIAN_MT, CLR_BLACK),/*Needs tile*/
-WAND("wishing",        "dragon-bone",    0, 500, 1, NODIR,     DRAGON_HIDE, CLR_WHITE, O_NOWISH(1)),	/* wizmode only */
-WAND("secret door detection", "balsa",  50, 150, 1, NODIR,	   WOOD,        HI_WOOD),
-WAND("enlightenment",  "crystal",       18, 150, 1, NODIR,     GLASS,       HI_GLASS),
-WAND("create monster", "maple",         42, 200, 1, NODIR,     WOOD,        HI_WOOD),
-WAND("nothing",        "oak",           25, 100, 0, IMMEDIATE, WOOD,        HI_WOOD),
-WAND("striking",       "ebony",         75, 150, 1, IMMEDIATE, WOOD,        HI_WOOD),
-WAND("draining",       "ceramic",        5, 175, 1, IMMEDIATE, MINERAL,     HI_MINERAL),
-WAND("make invisible", "marble",        42, 150, 1, IMMEDIATE, MINERAL,     HI_MINERAL),
-WAND("slow monster",   "tin",           46, 150, 1, IMMEDIATE, METAL,       HI_METAL),
-WAND("speed monster",  "brass",         50, 150, 1, IMMEDIATE, COPPER,      HI_COPPER),
-WAND("undead turning", "copper",        50, 150, 1, IMMEDIATE, COPPER,      HI_COPPER),
-WAND("polymorph",      "silver",        45, 200, 1, IMMEDIATE, SILVER,      HI_SILVER),
-WAND("cancellation",   "platinum",      42, 200, 1, IMMEDIATE, PLATINUM,    CLR_WHITE),
-WAND("teleportation",  "iridium",       45, 200, 1, IMMEDIATE, METAL,       CLR_BRIGHT_CYAN),
-WAND("opening",        "zinc",          30, 150, 1, IMMEDIATE, METAL,       HI_METAL),
-WAND("locking",        "aluminum",      25, 150, 1, IMMEDIATE, METAL,       HI_METAL),
-WAND("probing",        "uranium",       30, 150, 1, IMMEDIATE, METAL,       HI_METAL),
-WAND("digging",        "iron",          55, 150, 1, RAY,       IRON,        HI_METAL),
-WAND("magic missile",  "steel",         50, 150, 1, RAY,       IRON,        HI_METAL),
-WAND("fire",           "hexagonal",     40, 175, 1, RAY,       IRON,        HI_METAL),
-WAND("cold",           "short",         40, 175, 1, RAY,       IRON,        HI_METAL),
-WAND("sleep",          "runed",         50, 175, 1, RAY,       IRON,        HI_METAL),
-WAND("death",          "long",           5, 500, 1, RAY,       IRON,        HI_METAL),
-WAND("lightning",      "curved",        40, 175, 1, RAY,       IRON,        HI_METAL),
-WAND((char *)0,        "pine",           0, 150, 1, 0,         WOOD,        HI_WOOD),
-WAND((char *)0,        "forked",         0, 150, 1, 0,         WOOD,        HI_WOOD),
-WAND((char *)0,        "spiked",         0, 150, 1, 0,         IRON,        HI_METAL),
-WAND((char *)0,        "jeweled",        0, 150, 1, 0,         IRON,        HI_MINERAL),
+WAND(("light",          "glass"),         90, 100, 1, NODIR,     GLASS,       CLR_WHITE),/*Needs tile?*/
+WAND(("darkness",       "obsidian"),      10, 100, 1, NODIR,     OBSIDIAN_MT, CLR_BLACK),/*Needs tile*/
+WAND(("wishing",        "dragon-bone"),    0, 500, 1, NODIR,     DRAGON_HIDE, CLR_WHITE, O_NOWISH(1)),	/* wizmode only */
+WAND(("secret door detection", "balsa"),  50, 150, 1, NODIR,	   WOOD,        HI_WOOD),
+WAND(("enlightenment",  "crystal"),       18, 150, 1, NODIR,     GLASS,       HI_GLASS),
+WAND(("create monster", "maple"),         42, 200, 1, NODIR,     WOOD,        HI_WOOD),
+WAND(("nothing",        "oak"),           25, 100, 0, IMMEDIATE, WOOD,        HI_WOOD),
+WAND(("striking",       "ebony"),         75, 150, 1, IMMEDIATE, WOOD,        HI_WOOD),
+WAND(("draining",       "ceramic"),        5, 175, 1, IMMEDIATE, MINERAL,     HI_MINERAL),
+WAND(("make invisible", "marble"),        42, 150, 1, IMMEDIATE, MINERAL,     HI_MINERAL),
+WAND(("slow monster",   "tin"),           46, 150, 1, IMMEDIATE, METAL,       HI_METAL),
+WAND(("speed monster",  "brass"),         50, 150, 1, IMMEDIATE, COPPER,      HI_COPPER),
+WAND(("undead turning", "copper"),        50, 150, 1, IMMEDIATE, COPPER,      HI_COPPER),
+WAND(("polymorph",      "silver"),        45, 200, 1, IMMEDIATE, SILVER,      HI_SILVER),
+WAND(("cancellation",   "platinum"),      42, 200, 1, IMMEDIATE, PLATINUM,    CLR_WHITE),
+WAND(("teleportation",  "iridium"),       45, 200, 1, IMMEDIATE, METAL,       CLR_BRIGHT_CYAN),
+WAND(("opening",        "zinc"),          30, 150, 1, IMMEDIATE, METAL,       HI_METAL),
+WAND(("locking",        "aluminum"),      25, 150, 1, IMMEDIATE, METAL,       HI_METAL),
+WAND(("probing",        "uranium"),       30, 150, 1, IMMEDIATE, METAL,       HI_METAL),
+WAND(("digging",        "iron"),          55, 150, 1, RAY,       IRON,        HI_METAL),
+WAND(("magic missile",  "steel"),         50, 150, 1, RAY,       IRON,        HI_METAL),
+WAND(("fire",           "hexagonal"),     40, 175, 1, RAY,       IRON,        HI_METAL),
+WAND(("cold",           "short"),         40, 175, 1, RAY,       IRON,        HI_METAL),
+WAND(("sleep",          "runed"),         50, 175, 1, RAY,       IRON,        HI_METAL),
+WAND(("death",          "long"),           5, 500, 1, RAY,       IRON,        HI_METAL),
+WAND(("lightning",      "curved"),        40, 175, 1, RAY,       IRON,        HI_METAL),
+WAND(((char *)0,        "pine"),           0, 150, 1, 0,         WOOD,        HI_WOOD),
+WAND(((char *)0,        "forked"),         0, 150, 1, 0,         WOOD,        HI_WOOD),
+WAND(((char *)0,        "spiked"),         0, 150, 1, 0,         IRON,        HI_METAL),
+WAND(((char *)0,        "jeweled"),        0, 150, 1, 0,         IRON,        HI_MINERAL),
 #undef WAND
 
 /* coins ... - so far, gold is all there is */
-#define COIN(name,prob,metal,worth,...) OBJECT( \
-		OBJ(name,(char *)0), BITS(0,1,0,0,0,0,0,0,MZ_TINY,0,0,P_NONE,metal,0), 0, \
+#define COIN(names,prob,metal,worth,...) OBJECT( \
+		names, BITS(0,1,0,0,0,0,0,0,MZ_TINY,0,0,P_NONE,metal,0), 0, \
 		COIN_CLASS, prob, 0, 1, worth, {0}, {0}, 0, 0, 0, 0, HI_GOLD, __VA_ARGS__)
-	COIN("gold piece",      1000, GOLD,1),
+	COIN(("gold piece"),      1000, GOLD,1),
 #undef COIN
 
 /* gems ... - includes stones and rocks but not boulders */
-#define GEM(name,desc,prob,wt,gval,nutr,mohs,glass,color,...) OBJECT( \
-	    OBJ(name,desc), \
+#define GEM(names,prob,wt,gval,nutr,mohs,glass,color,...) OBJECT( \
+	    DEF_BLINDNAME(names, "gem"), \
 	    BITS(0,1,0,0,0,0,0,0,MZ_TINY,HARDGEM(mohs),PIERCE,-P_SLING,glass,0), 0, \
 		GEM_CLASS, prob, 0, 1, gval, DMG(D(3)), DMG(D(3)), 0, WP_GENERIC, 0, nutr, color, __VA_ARGS__)
-#define ROCK(name,desc,kn,prob,wt,gval,sdam,ldam,hitbon,mgc,nutr,mohs,glass,color,...) OBJECT( \
-	    OBJ(name,desc), \
+#define ROCK(names,kn,prob,wt,gval,sdam,ldam,hitbon,mgc,nutr,mohs,glass,color,...) OBJECT( \
+	    DEF_BLINDNAME(names, "stone"), \
 	    BITS(kn,1,0,0,mgc,0,0,0,MZ_TINY,HARDGEM(mohs),WHACK,-P_SLING,glass,0), 0, \
 		GEM_CLASS, prob, 0, wt, gval, DMG(D(sdam)), DMG(D(ldam)), hitbon, WP_GENERIC, 0, nutr, color, __VA_ARGS__)
-GEM("magicite crystal","brilliant blue",1, 1, 9999, 15, 11, GEMSTONE, CLR_BRIGHT_BLUE),/*Needs tile*/
-GEM("dilithium crystal", "white",      2,  1, 4500, 15,  5, GEMSTONE, CLR_WHITE),
-GEM("diamond", "white",                3,  1, 4000, 15, 10, GEMSTONE, CLR_WHITE),
+GEM(("magicite crystal","brilliant blue"),1, 1, 9999, 15, 11, GEMSTONE, CLR_BRIGHT_BLUE),/*Needs tile*/
+GEM(("dilithium crystal", "white"),      2,  1, 4500, 15,  5, GEMSTONE, CLR_WHITE),
+GEM(("diamond", "white"),                3,  1, 4000, 15, 10, GEMSTONE, CLR_WHITE),
 //3
-GEM("star sapphire", "blue",           2,  1, 3750, 15,  9, GEMSTONE, CLR_BLUE),/*Needs tile*/
-GEM("ruby", "red",                     4,  1, 3500, 15,  9, GEMSTONE, CLR_RED),
-GEM("jacinth", "orange",               3,  1, 3250, 15,  9, GEMSTONE, CLR_ORANGE),
+GEM(("star sapphire", "blue"),           2,  1, 3750, 15,  9, GEMSTONE, CLR_BLUE),/*Needs tile*/
+GEM(("ruby", "red"),                     4,  1, 3500, 15,  9, GEMSTONE, CLR_RED),
+GEM(("jacinth", "orange"),               3,  1, 3250, 15,  9, GEMSTONE, CLR_ORANGE),
 //6
-GEM("sapphire", "blue",                4,  1, 3000, 15,  9, GEMSTONE, CLR_BLUE),
-GEM("black opal", "black",             3,  1, 2500, 15,  8, GEMSTONE, CLR_BLACK),
-GEM("emerald", "green",                3,  1, 2500, 15,  8, GEMSTONE, CLR_GREEN),
+GEM(("sapphire", "blue"),                4,  1, 3000, 15,  9, GEMSTONE, CLR_BLUE),
+GEM(("black opal", "black"),             3,  1, 2500, 15,  8, GEMSTONE, CLR_BLACK),
+GEM(("emerald", "green"),                3,  1, 2500, 15,  8, GEMSTONE, CLR_GREEN),
 //9
-GEM("turquoise", "green",              4,  1, 2000, 15,  6, GEMSTONE, CLR_GREEN),
-GEM("morganite", "pink",               4,  1, 2000, 15,  6, GEMSTONE, CLR_ORANGE),
+GEM(("turquoise", "green"),              4,  1, 2000, 15,  6, GEMSTONE, CLR_GREEN),
+GEM(("morganite", "pink"),               4,  1, 2000, 15,  6, GEMSTONE, CLR_ORANGE),
 //11 Note: Only first 11 gems are affected by dungeon level
-GEM("citrine", "yellow",               4,  1, 1500, 15,  6, GEMSTONE, CLR_YELLOW),
-GEM("aquamarine", "green",             6,  1, 1500, 15,  8, GEMSTONE, CLR_GREEN),
-GEM("amber", "yellowish brown",        8,  1, 1000, 15,  2, GEMSTONE, CLR_BROWN),
-GEM("topaz", "yellowish brown",       10,  1,  900, 15,  8, GEMSTONE, CLR_BROWN),
-GEM("jet", "black",                    6,  1,  850, 15,  7, GEMSTONE, CLR_BLACK),
-GEM("opal", "white",                  12,  1,  800, 15,  6, GEMSTONE, CLR_WHITE),
-GEM("chrysoberyl", "yellow",           8,  1,  700, 15,  5, GEMSTONE, CLR_YELLOW),
-GEM("garnet", "red",                  12,  1,  700, 15,  7, GEMSTONE, CLR_RED),
-GEM("amethyst", "violet",             14,  1,  600, 15,  7, GEMSTONE, CLR_MAGENTA),
-GEM("jasper", "red",                  15,  1,  500, 15,  7, GEMSTONE, CLR_RED),
-GEM("violet fluorite", "violet",       4,  1,  400, 15,  4, GEMSTONE, CLR_MAGENTA),/*Needs tile*/
-GEM("blue fluorite", "blue",           4,  1,  400, 15,  4, GEMSTONE, CLR_BLUE),/*Needs tile*/
-GEM("white fluorite", "white",         4,  1,  400, 15,  4, GEMSTONE, CLR_WHITE),/*Needs tile*/
-GEM("green fluorite", "green",         4,  1,  400, 15,  4, GEMSTONE, CLR_GREEN),/*Needs tile*/
-GEM("obsidian", "black",               9,  1,  200, 15,  6, GEMSTONE, CLR_BLACK),
-GEM("agate", "orange",                12,  1,  200, 15,  6, GEMSTONE, CLR_ORANGE),
-GEM("jade", "green",                  10,  1,  300, 15,  6, GEMSTONE, CLR_GREEN),
-GEM("worthless piece of white glass", "white",   76, 1, 0, 6, 5, GLASS, CLR_WHITE),
-GEM("worthless piece of blue glass", "blue",     76, 1, 0, 6, 5, GLASS, CLR_BLUE),
-GEM("worthless piece of red glass", "red",       76, 1, 0, 6, 5, GLASS, CLR_RED),
-GEM("worthless piece of yellowish brown glass", "yellowish brown",
+GEM(("citrine", "yellow"),               4,  1, 1500, 15,  6, GEMSTONE, CLR_YELLOW),
+GEM(("aquamarine", "green"),             6,  1, 1500, 15,  8, GEMSTONE, CLR_GREEN),
+GEM(("amber", "yellowish brown"),        8,  1, 1000, 15,  2, GEMSTONE, CLR_BROWN),
+GEM(("topaz", "yellowish brown"),       10,  1,  900, 15,  8, GEMSTONE, CLR_BROWN),
+GEM(("jet", "black"),                    6,  1,  850, 15,  7, GEMSTONE, CLR_BLACK),
+GEM(("opal", "white"),                  12,  1,  800, 15,  6, GEMSTONE, CLR_WHITE),
+GEM(("chrysoberyl", "yellow"),           8,  1,  700, 15,  5, GEMSTONE, CLR_YELLOW),
+GEM(("garnet", "red"),                  12,  1,  700, 15,  7, GEMSTONE, CLR_RED),
+GEM(("amethyst", "violet"),             14,  1,  600, 15,  7, GEMSTONE, CLR_MAGENTA),
+GEM(("jasper", "red"),                  15,  1,  500, 15,  7, GEMSTONE, CLR_RED),
+GEM(("violet fluorite", "violet"),       4,  1,  400, 15,  4, GEMSTONE, CLR_MAGENTA),/*Needs tile*/
+GEM(("blue fluorite", "blue"),           4,  1,  400, 15,  4, GEMSTONE, CLR_BLUE),/*Needs tile*/
+GEM(("white fluorite", "white"),         4,  1,  400, 15,  4, GEMSTONE, CLR_WHITE),/*Needs tile*/
+GEM(("green fluorite", "green"),         4,  1,  400, 15,  4, GEMSTONE, CLR_GREEN),/*Needs tile*/
+GEM(("obsidian", "black"),               9,  1,  200, 15,  6, GEMSTONE, CLR_BLACK),
+GEM(("agate", "orange"),                12,  1,  200, 15,  6, GEMSTONE, CLR_ORANGE),
+GEM(("jade", "green"),                  10,  1,  300, 15,  6, GEMSTONE, CLR_GREEN),
+GEM(("worthless piece of white glass", "white"),   76, 1, 0, 6, 5, GLASS, CLR_WHITE),
+GEM(("worthless piece of blue glass", "blue"),     76, 1, 0, 6, 5, GLASS, CLR_BLUE),
+GEM(("worthless piece of red glass", "red"),       76, 1, 0, 6, 5, GLASS, CLR_RED),
+GEM(("worthless piece of yellowish brown glass", "yellowish brown"),
 						 77, 1, 0, 6, 5, GLASS, CLR_BROWN),
-GEM("worthless piece of orange glass", "orange", 76, 1, 0, 6, 5, GLASS, CLR_ORANGE),
-GEM("worthless piece of yellow glass", "yellow", 76, 1, 0, 6, 5, GLASS, CLR_YELLOW),
-GEM("worthless piece of black glass",  "black",  76, 1, 0, 6, 5, GLASS, CLR_BLACK),
-GEM("worthless piece of green glass", "green",   77, 1, 0, 6, 5, GLASS, CLR_GREEN),
-GEM("worthless piece of violet glass", "violet", 77, 1, 0, 6, 5, GLASS, CLR_MAGENTA),
+GEM(("worthless piece of orange glass", "orange"), 76, 1, 0, 6, 5, GLASS, CLR_ORANGE),
+GEM(("worthless piece of yellow glass", "yellow"), 76, 1, 0, 6, 5, GLASS, CLR_YELLOW),
+GEM(("worthless piece of black glass",  "black"),  76, 1, 0, 6, 5, GLASS, CLR_BLACK),
+GEM(("worthless piece of green glass", "green"),   77, 1, 0, 6, 5, GLASS, CLR_GREEN),
+GEM(("worthless piece of violet glass", "violet"), 77, 1, 0, 6, 5, GLASS, CLR_MAGENTA),
 
 /* Placement note: there is a wishable subrange for
  * "gray stones" in the o_ranges[] array in objnam.c
  * that is currently everything between luckstones and flint (inclusive).
  */
-ROCK("luckstone", "gray",	0, 10,   1, 60, 6, 6, 20, 1, 10, 7, MINERAL, CLR_GRAY),
-ROCK("loadstone", "gray",	0, 10, 500,  1,30,30, -5, 1, 10, 6, MINERAL, CLR_GRAY),
-ROCK("touchstone", "gray",	0,  8,   1, 45, 6, 6,  0, 1, 10, 6, MINERAL, CLR_GRAY),
-ROCK("flint", "gray",		0, 10,   1,  1, 6, 6,  2, 0, 10, 7, MINERAL, CLR_GRAY, O_DTYPE(SLASH)),	/* does slashing damage, not blunt */
-ROCK("chunk of unrefined mithril", "silvery metal", 
+ROCK(("luckstone", "gray"),	0, 10,   1, 60, 6, 6, 20, 1, 10, 7, MINERAL, CLR_GRAY),
+ROCK(("loadstone", "gray"),	0, 10, 500,  1,30,30, -5, 1, 10, 6, MINERAL, CLR_GRAY),
+ROCK(("touchstone", "gray"),	0,  8,   1, 45, 6, 6,  0, 1, 10, 6, MINERAL, CLR_GRAY),
+ROCK(("flint", "gray"),		0, 10,   1,  1, 6, 6,  2, 0, 10, 7, MINERAL, CLR_GRAY, O_DTYPE(SLASH)),	/* does slashing damage, not blunt */
+ROCK(("chunk of unrefined mithril", "silvery metal"), 
 							0,  0,   1, 10000,3,3, 3, 0, 0, 10, MITHRIL, HI_MITHRIL),/*Needs tile*/
-ROCK("chunk of fossil dark", "black",
+ROCK(("chunk of fossil dark", "black"),
 							0,  0,  25, 	500, 8, 8, 4, 1, 0, 1, MINERAL, CLR_BLACK),/*Needs tile*/
-ROCK("chunk of salt", "white",		
+ROCK(("chunk of salt", "white"),		
 							0,  0,   1,  1, 3, 3,  0, 0, 10, 2, SALT, CLR_GRAY), /*Needs tile*/
-ROCK("silver slingstone", "silver", 
+ROCK(("silver slingstone", "silver"), 
 							0,  0,   1, 10, 6, 6, 2, 0,  0, 5, SILVER, HI_SILVER),/*Needs tile*/
-ROCK("rock", (char *)0,		1,100,   1,  0, 6, 6, 0, 0, 10, 7, MINERAL, CLR_GRAY),
+ROCK(("rock"),		1,100,   1,  0, 6, 6, 0, 0, 10, 7, MINERAL, CLR_GRAY),
 #undef GEM
 #undef ROCK
 
@@ -1649,90 +1650,90 @@ ROCK("rock", (char *)0,		1,100,   1,  0, 6, 6, 0, 0, 10, 7, MINERAL, CLR_GRAY),
  * on a specific type and may act as containers (both affect weight).
  */
 								//BITS(nmkn,mrg,uskn,ctnr,mgc,chrg,uniq,nwsh,big,tuf,dir,sub,mtrl,shwmat)
-OBJECT(OBJ("boulder",(char *)0), BITS(1,0,0,0,0,0,0,0,MZ_GIGANTIC,0,0,P_NONE,MINERAL,0), 0,
+OBJECT(("boulder",(char *)0), BITS(1,0,0,0,0,0,0,0,MZ_GIGANTIC,0,0,P_NONE,MINERAL,0), 0,
 		ROCK_CLASS,   100, 0, 6000,  0, DMG(D(20)), DMG(D(20)), 0, 0, 0, 2000, HI_MINERAL),
-OBJECT(OBJ("statue", (char *)0), BITS(1,0,0,1,0,0,0,0,    MZ_HUGE,0,0,P_NONE,MINERAL,0), 0,
+OBJECT(("statue"), BITS(1,0,0,1,0,0,0,0,    MZ_HUGE,0,0,P_NONE,MINERAL,0), 0,
 		ROCK_CLASS,   800, 0, 2500,  0, DMG(D(20)), DMG(D(20)), 0, 0, 0, 2500, CLR_WHITE),
-OBJECT(OBJ("fossil", (char *)0), BITS(1,0,0,0,0,0,0,0,    MZ_HUGE,0,0,P_NONE,MINERAL,0), 0,
+OBJECT(("fossil"), BITS(1,0,0,0,0,0,0,0,    MZ_HUGE,0,0,P_NONE,MINERAL,0), 0,
 		ROCK_CLASS,   100, 0, 2500,  0, DMG(D(20)), DMG(D(20)), 0, 0, 0, 2500, CLR_BROWN),
 /*
-OBJECT(OBJ("bed",(char *)0), BITS(1,0,0,0,0,0,0,0,1,0,0,P_NONE,WOOD,0), 0,
+OBJECT(("bed",(char *)0), BITS(1,0,0,0,0,0,0,0,1,0,0,P_NONE,WOOD,0), 0,
 		BED_CLASS,   900, 0, 2000,  1000, 20, 20, 0, 0, 0, 2000, HI_WOOD),
-OBJECT(OBJ("knapsack",(char *)0), BITS(1,0,0,0,0,0,0,0,1,0,0,P_NONE,PLASTIC,0), 0,
+OBJECT(("knapsack",(char *)0), BITS(1,0,0,0,0,0,0,0,1,0,0,P_NONE,PLASTIC,0), 0,
 		BED_CLASS,   100, 0, 60,  100, 20, 20, 0, 0, 0, 2000, CLR_GREEN),
-OBJECT(OBJ("gurney",(char *)0), BITS(1,0,0,0,0,0,0,0,1,0,0,P_NONE,METAL,0), 0,
+OBJECT(("gurney",(char *)0), BITS(1,0,0,0,0,0,0,0,1,0,0,P_NONE,METAL,0), 0,
 		BED_CLASS,     0, 0, 60,  100, 20, 20, 0, 0, 0, 2000, CLR_WHITE),
 */
 #ifdef CONVICT
-OBJECT(OBJ("heavy iron ball", (char *)0), BITS(1,0,0,0,0,0,0,0,MZ_LARGE,0,WHACK,P_FLAIL,IRON,0), 0,
+OBJECT(("heavy iron ball"), BITS(1,0,0,0,0,0,0,0,MZ_LARGE,0,WHACK,P_FLAIL,IRON,0), 0,
 #else
-OBJECT(OBJ("heavy iron ball", (char *)0), BITS(1,0,0,0,0,0,0,0,MZ_LARGE,0,WHACK,P_NONE,IRON,0), 0,
+OBJECT(("heavy iron ball"), BITS(1,0,0,0,0,0,0,0,MZ_LARGE,0,WHACK,P_NONE,IRON,0), 0,
 #endif /* CONVICT */
 		BALL_CLASS,  1000, 0,  480, 10, DMG(D(25)), DMG(D(25)), 0, 0,  0, 200, HI_METAL),
 						/* +d4 when "very heavy" */
 
-#define CHAIN(name,desc,sdam,ldam,nutr,wt,cost,hitbon,dtyp,mat,color,...) OBJECT( \
-	    OBJ(name,desc), \
+#define CHAIN(names,sdam,ldam,nutr,wt,cost,hitbon,dtyp,mat,color,...) OBJECT( \
+	    names, \
 	    BITS(1,1,0,0,0,0,0,0,MZ_MEDIUM,0,dtyp,P_NONE,mat,0), 0, \
 		CHAIN_CLASS, 0, 0, wt, cost, sdam, ldam, hitbon, WP_GENERIC, 0, nutr, color, __VA_ARGS__)
 					
-CHAIN("chain", (char *)0,
+CHAIN(("chain"),
 	DMG(D(4), F(1)), DMG(D(4), F(1)),
 	200, 120, 0, 4, B, IRON, HI_METAL,
 	O_MATSPEC(IDED|UNIDED), O_MERGE(0), O_SKILL(P_FLAIL), O_PROB(1000)),
-CHAIN("sheaf of hay", (char *)0,
+CHAIN(("sheaf of hay"),
 	DMG(D(1)), DMG(D(1)),
 	100,  20, 2, 0, 0, VEGGY, CLR_YELLOW),
-CHAIN("clockwork component", (char *)0,
+CHAIN(("clockwork component"),
 	DMG(D(1)), DMG(D(1)),
 	 20,   1, 0, 0, B, COPPER, HI_COPPER),
-CHAIN("subethaic component", (char *)0,
+CHAIN(("subethaic component"),
 	DMG(D(1)), DMG(D(1)),
 	 20,   1, 0, 0, B, GLASS, HI_GLASS),
-CHAIN("scrap", (char *)0,
+CHAIN(("scrap"),
 	DMG(D(1)), DMG(D(1)),
 	 20,   1, 0, 0, B, IRON, CLR_BROWN),
-CHAIN("hellfire component", (char *)0,
+CHAIN(("hellfire component"),
 	DMG(D(1)), DMG(D(1)),
 	 20,   1, 0, 0, B, METAL, CLR_ORANGE),
 
-#define CHAINCORPSE(name,desc,wt,mat,color,...)\
-	CHAIN(name,desc,{0},{0},20,wt,0,0,0,mat,color,O_MERGE(0),O_SIZE(MZ_HUGE),__VA_ARGS__)
+#define CHAINCORPSE(names,wt,mat,color,...)\
+	CHAIN(names,{0},{0},20,wt,0,0,0,mat,color,O_MERGE(0),O_SIZE(MZ_HUGE),__VA_ARGS__)
 
-CHAINCORPSE("broken android", (char *)0, 3000, METAL, CLR_WHITE), /*Needs encyc entry*//*Needs tile*/
-CHAINCORPSE("broken gynoid", (char *)0,  3000, METAL, CLR_WHITE), /*Needs encyc entry*//*Needs tile*/
-CHAINCORPSE("lifeless doll", (char *)0,   750, PLASTIC, CLR_BRIGHT_MAGENTA), /*Needs encyc entry*//*Needs tile*/
+CHAINCORPSE(("broken android"), 3000, METAL, CLR_WHITE), /*Needs encyc entry*//*Needs tile*/
+CHAINCORPSE(("broken gynoid"),  3000, METAL, CLR_WHITE), /*Needs encyc entry*//*Needs tile*/
+CHAINCORPSE(("lifeless doll"),   750, PLASTIC, CLR_BRIGHT_MAGENTA), /*Needs encyc entry*//*Needs tile*/
 
 #undef CHAINCORPSE
 
-#define CHAINROPE(name,desc,dtyp,mat,color,...)\
-	CHAIN(name,desc,DMG(D(4)),DMG(D(4)),200,120,0,0,dtyp,mat,color,O_MERGE(0),__VA_ARGS__)
+#define CHAINROPE(names,dtyp,mat,color,...)\
+	CHAIN(names,DMG(D(4)),DMG(D(4)),200,120,0,0,dtyp,mat,color,O_MERGE(0),__VA_ARGS__)
 
-CHAINROPE("rope of entangling", (char *)0,   B, VEGGY, CLR_BROWN),
-CHAINROPE("iron bands", (char *)0,           B, IRON,  HI_METAL),
-CHAINROPE("razor wire", (char *)0,           S, METAL, HI_METAL),
-CHAINROPE("shackles", (char *)0,             S, IRON,  HI_METAL),
+CHAINROPE(("rope of entangling"),   B, VEGGY, CLR_BROWN),
+CHAINROPE(("iron bands"),           B, IRON,  HI_METAL),
+CHAINROPE(("razor wire"),           S, METAL, HI_METAL),
+CHAINROPE(("shackles"),             S, IRON,  HI_METAL),
 
 #undef CHAINROPE
 
 #undef CHAIN
 
-OBJECT(OBJ("blinding venom", "splash of venom"),
+OBJECT(("blinding venom", "splash of venom"),
 		BITS(0,1,0,0,0,0,0,1,MZ_TINY,0,0,P_NONE,LIQUID,0), 0,
 		VENOM_CLASS,  500, 0,	 1,  0,  {0},  {0}, 0, 0,	 0, 0, CLR_BLACK),
-OBJECT(OBJ("acid venom", "splash of venom"),
+OBJECT(("acid venom", "splash of venom"),
 		BITS(0,1,0,0,0,0,0,1,MZ_TINY,0,0,P_NONE,LIQUID,0), 0,
 		VENOM_CLASS,  500, 0,	 1,  0,  DMG(D(6)),  DMG(D(6)), 0, 0,	 0, 0, CLR_BRIGHT_GREEN),
-OBJECT(OBJ("ball of webbing", (char *)0),/*Needs tile*/
+OBJECT(("ball of webbing"),/*Needs tile*/
 		BITS(1,1,0,0,0,0,0,1,MZ_TINY,0,0,P_NONE,LIQUID,0), 0,
 		VENOM_CLASS,  0, 0,	 1,  0,  DMG(D(6)),  DMG(D(6)), 0, 0,	 0, 0, CLR_WHITE),
-//OBJECT(OBJ("shoggoth venom", "splash of venom"),
+//OBJECT(("shoggoth venom", "splash of venom"),
 //		BITS(0,1,0,0,0,0,0,1,MZ_TINY,0,0,P_NONE,LIQUID,0), 0,
 //		VENOM_CLASS,  500, 0,	 1,  0,  {0},  {0}, 0, 0,	 0, 0, HI_ORGANIC),
 		/* +d6 small or large */
 
 /* fencepost, the deadly Array Terminator -- name [1st arg] *must* be NULL */
-	OBJECT(OBJ((char *)0,(char *)0), BITS(0,0,0,0,0,0,0,0,0,0,0,P_NONE,0,0), 0,
+	OBJECT(((char *)0,(char *)0), BITS(0,0,0,0,0,0,0,0,0,0,0,P_NONE,0,0), 0,
 		ILLOBJ_CLASS, 0, 0, 0, 0, {0}, {0}, 0, 0, 0, 0, 0)
 }; /* objects[] */
 

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1413,7 +1413,9 @@ boolean with_price;
 	register int nn = ocl->oc_name_known;			/* you know the oc name of the otyp*/
 	register const char *actualn = OBJ_NAME(*ocl);	/* the identified name of the otyp */
 	register const char *dn = OBJ_DESCR(*ocl);		/* the unidentified name of the otyp */
+	register const char *bn = OBJ_BLINDNAME(*ocl);	/* the blind name of the otyp */
 	register const char *un = ocl->oc_uname;		/* what you have named the otyp */
+	char tbuf[BUFSZ];
 	const struct artifact *oart = 0;
 	static int getting_obj_base_desc = 0;
 	if (obj && obj->oartifact) oart = &artilist[(obj)->oartifact];
@@ -1459,7 +1461,7 @@ boolean with_price;
 		add_poison_words(obj, buf);
 		add_insight_words(obj, buf);
 		add_colours_words(obj, buf);
-		add_material_words(obj, buf);	// TODO - show some artifact's materials, currently hides all
+		add_material_words(obj, buf);
 		if (dofull) add_type_words(obj, buf);
 	}
 
@@ -1480,367 +1482,212 @@ boolean with_price;
 	}
 	else if (!obj_is_pname(obj))
 	{
-		switch (obj->oclass) {
-		case AMULET_CLASS:
-			if (!obj->dknown)
-				Strcat(buf, "amulet");
-			else if (typ == AMULET_OF_YENDOR ||
-				typ == FAKE_AMULET_OF_YENDOR)
-				/* each must be identified individually */
-				Strcat(buf, obj->known ? actualn : dn);
-			else if (nn)
-				Strcat(buf, actualn);
-			else if (un)
-				Sprintf(eos(buf), "amulet called %s", un);
-			else
-				Sprintf(eos(buf), "%s amulet", dn);
-			break;
-		case WEAPON_CLASS:
-		case VENOM_CLASS:
-		case TOOL_CLASS:
-			if (typ == LENSES)
-				Strcat(buf, "pair of ");
-			if (typ == HYPOSPRAY_AMPULE){
-				int ptyp = (int)(obj->ovar1);
-				struct objclass *pcl = &objects[ptyp];
-				// register int pnn = ocl->oc_name_known;
-				register const char *pactualn = OBJ_NAME(*pcl);
-				// register const char *pdn = OBJ_DESCR(*pcl);
-				// register const char *pun = pcl->oc_uname;
-				if (!obj->dknown); //add "ampule" below and finish
-				else if (nn) {
-					if (ptyp == POT_WATER &&
-							obj->bknown && (obj->blessed || obj->cursed)
-						) {
-						Strcat(buf, obj->blessed ? "holy " : "unholy ");
-					}
-					Strcat(buf, pactualn);
-					Strcat(buf, " ");
-				}
-				else if (un) {
-					Strcat(buf, "ampule called ");
-					Strcat(buf, un);
-					break;
+		char * restart = eos(buf);
+
+		/* some item classes follow very similar naming structures */
+		static const char standardized[] = { RING_CLASS, AMULET_CLASS, POTION_CLASS, SCROLL_CLASS,
+									SPBOOK_CLASS, WAND_CLASS, GEM_CLASS, TILE_CLASS, 0 };
+
+		if (index(standardized, (char)obj->oclass)) {
+			if (!bn)
+				impossible("otyp %d doesn't have a when-blind name, and is assumed to!", typ);
+			if (!obj->dknown) {
+				/* <blind> */
+				Strcat(buf, bn);
+			}
+			else if (nn) {
+				/* you know the object type */
+				if (obj->oclass == AMULET_CLASS ||
+					obj->oclass == GEM_CLASS ||
+					typ == SCR_GOLD_SCROLL_OF_LAW ||
+					typ == SPE_BOOK_OF_THE_DEAD
+					){
+					/* <real> */
+					Strcat(buf, actualn);
+
+					/* gemstones get "stone" appended */
+					if (obj->oclass == GEM_CLASS && GemStone(typ))
+						Strcat(buf, " stone");
+					/* kludge: the real and fake amulets of yendor must be fully id-ed */
+					if (!obj->known && (typ == AMULET_OF_YENDOR || typ == FAKE_AMULET_OF_YENDOR))
+						Strcat(restart, dn); /* overwrite! */
 				}
 				else {
-					Strcat(buf, dn);
-					break;
-				}
-				Strcat(buf, "ampule");
-				Sprintf(eos(buf), " (%d doses)", (int)(obj->spe));
-				break;
-			}
-			else if (!obj->dknown)
-				Strcat(buf, dn ? dn : actualn);
-			else if (nn)
-				Strcat(buf, actualn);
-			else if (un) {
-				Strcat(buf, dn ? dn : actualn);
-				Strcat(buf, " called ");
-				Strcat(buf, un);
-			}
-			else Strcat(buf, dn ? dn : actualn);
-			/* If we use an() here we'd have to remember never to use */
-			/* it whenever calling doname() or xname(). */
-			if (typ == FIGURINE)
-				Sprintf(eos(buf), " of a%s %s",
-				index(vowels, *(mons[obj->corpsenm].mname)) ? "n" : "",
-				mons[obj->corpsenm].mname);
-			else if (is_blaster(obj) && (obj->known || uandroid))
-				Sprintf(eos(buf), " (%d:%d)", (int)obj->recharged, (int)obj->ovar1);
-			else if (is_vibroweapon(obj) && (obj->known || uandroid))
-				Sprintf(eos(buf), " (%d:%d)", (int)obj->recharged, (int)obj->ovar1);
-			else if (obj->otyp == SEISMIC_HAMMER && (obj->known || uandroid))
-				Sprintf(eos(buf), " (%d:%d)", (int)obj->recharged, (int)obj->ovar1);
-			break;
-		case ARMOR_CLASS:
-			/* depends on order of the dragon scales objects */
-			if (typ >= GRAY_DRAGON_SCALES && typ <= YELLOW_DRAGON_SCALES) {
-				Sprintf(eos(buf), "set of %s", actualn);
-				break;
-			}
-			if (typ == VICTORIAN_UNDERWEAR && nn) {
-				Sprintf(eos(buf), "set of %s", actualn);
-				break;
-			}
-			if ((typ == JUMPSUIT && !nn) || (typ == BODYGLOVE && !nn)) {
-				Sprintf(eos(buf), "set of %s", dn);
-				break;
-			}
-			if (is_boots(obj) || is_gloves(obj)) Strcat(buf, "pair of ");
+					/* <blind> of <real> */
+					Strcat(buf, bn);
 
-			if (obj->otyp >= ELVEN_SHIELD && obj->otyp <= ORCISH_SHIELD
-				&& !obj->dknown) {
-				Strcat(buf, "shield");
-				break;
-			}
-			if (obj->otyp == SHIELD_OF_REFLECTION && !obj->dknown) {
-				Strcat(buf, "smooth shield");
-				break;
-			}
-
-			if (nn)	Strcat(buf, actualn);
-			else if (un) {
-				if (is_boots(obj))
-					Strcat(buf, "boots");
-				else if (is_gloves(obj))
-					Strcat(buf, "gloves");
-				else if (is_cloak(obj))
-					Strcat(buf, "cloak");
-				else if (is_helmet(obj))
-					Strcat(buf, "helmet");
-				else if (is_shield(obj))
-					Strcat(buf, "shield");
-				else
-					Strcat(buf, "armor");
-				Strcat(buf, " called ");
-				Strcat(buf, un);
-			}
-			else	Strcat(buf, dn);
-			break;
-		case FOOD_CLASS:
-			if (typ == SLIME_MOLD) {
-				register struct fruit *f;
-
-				for (f = ffruit; f; f = f->nextf) {
-					if (f->fid == obj->spe) {
-						Strcat(buf, f->fname);
-						break;
+					if (obj->oclass == TILE_CLASS) {
+						Sprintf(eos(buf), " %s the ", obj->obj_material == BONE ? "scrimshawed with" : "bearing");
 					}
-				}
-				if (!f) impossible("Bad fruit #%d?", obj->spe);
-				break;
-			}
+					else {
+						Strcat(buf, " of ");
+					}
 
-			if (typ == EYEBALL && obj->known) {
+					/* modified actualn */
+					if (typ == POT_WATER && obj->bknown && (obj->blessed || obj->cursed))
+						Sprintf(eos(buf), "%s %s", obj->blessed ? "holy" : "unholy", actualn);
+					else if (typ == POT_BLOOD && (obj->known || is_vampire(youracedata)))
+						Sprintf(eos(buf), "%s %s", mons[obj->corpsenm].mname, actualn);
+					else if (typ == SCR_WARD) {
+						if (u.wardsknown & obj->oward) Strcat(buf, wardDecode[obj->oward]);
+						else                           Strcat(buf, "an unknown ward");
+					}
+					else
+						Strcat(buf, actualn);
+				}
+			}
+			else if (!un) {
+				/* you don't know this object */
+				if (obj->oclass == TILE_CLASS ||
+#ifdef MAIL
+					(obj->oclass == SCROLL_CLASS && obj->otyp < SCR_MAIL)
+#else
+					(obj->oclass == SCROLL_CLASS && obj->otyp < SCR_BLANK_PAPER)
+#endif
+					)
+				{
+					/* <blind> <verb> <desc> */
+					if (obj->oclass == TILE_CLASS && obj->obj_material == BONE)
+						Strcpy(tbuf, "scrimshawed with a");
+					else if (obj->oclass == TILE_CLASS)
+						Strcpy(tbuf, "bearing a");
+					else if (obj->oclass == SCROLL_CLASS && ocl->oc_magic)
+						Strcpy(tbuf, "labeled");
+					else
+						Strcpy(tbuf, "titled");	/* should not be reached */
+
+					Sprintf(eos(buf), "%s %s %s", OBJ_BLINDNAME(*ocl), tbuf, dn);
+				}
+				else
+				{
+					/* <desc> <blind> */
+					Sprintf(eos(buf), "%s %s", dn, bn);
+
+					/* kludge: the real and fake amulets of yendor are just their description */
+					if (typ == AMULET_OF_YENDOR || typ == FAKE_AMULET_OF_YENDOR)
+						Strcat(restart, dn); /* overwrite! */
+				}
+			}
+			else {
+				/* you've called this object type something */
+				Sprintf(eos(buf), "%s called %s", bn, un);
+			}
+		}
+		else {
+			/* prefixes */
+			if (typ == LENSES ||
+				is_boots(obj) ||
+				is_gloves(obj)
+				) {
+				Strcat(buf, "pair of ");
+			}
+			if ((typ == VICTORIAN_UNDERWEAR && nn) ||
+				(typ == JUMPSUIT && !nn) ||
+				(typ == BODYGLOVE && !nn) ||
+				/* depends on order of dragon scales */
+				(typ >= GRAY_DRAGON_SCALES && typ <= YELLOW_DRAGON_SCALES) ||
+				(typ == IRON_BANDS)
+				) {
+				Strcat(buf, "set of ");
+			}
+			if ((typ == FOSSIL) ||
+				(typ == EYEBALL && obj->known)
+				){
 				if (obj->corpsenm != NON_PM)
 					Sprintf(eos(buf), "%s ", mons[obj->corpsenm].mname);
 			}
+			if (typ == HYPOSPRAY_AMPULE && nn && obj->dknown){
+				int ptyp = (int)(obj->ovar1);
+				if (ptyp == POT_WATER && obj->bknown && (obj->blessed || obj->cursed)) {
+					Strcat(buf, obj->blessed ? "holy " : "unholy ");
+				}
+				Strcat(buf, OBJ_NAME(objects[ptyp]));
+				Strcat(buf, " ");
+			}
+			if (obj->oclass == BALL_CLASS && (obj->owt > ocl->oc_weight)) {
+				Strcat(buf, "very ");
+			}
+			if (typ == STATUE) {
+				if (Role_if(PM_ARCHEOLOGIST) && (obj->spe & STATUE_HISTORIC))
+					Strcat(buf, "historic ");
+				if (obj->spe & STATUE_FACELESS)
+					Strcat(buf, "faceless ");
+			}
 
-			Strcat(buf, actualn);
+			/* blind desc, or desc, or name */
+			if ((obj->dknown) ||
+				(typ == SLIME_MOLD) ||
+				(typ == HYPOSPRAY_AMPULE && nn) ||
+				(is_firearm(obj) && nn)
+				) {
+				/* we can see it */
+				if (typ == SLIME_MOLD) {
+					register struct fruit *f;
+
+					for (f = ffruit; f; f = f->nextf) {
+						if (f->fid == obj->spe) {
+							Strcat(buf, f->fname);
+							break;
+						}
+					}
+					if (!f) impossible("Bad fruit #%d?", obj->spe);
+				}
+				else if (nn) {
+					/* actual name */
+					Strcat(buf, actualn);
+				}
+				else if (un) {
+					/* called */
+					/* perhaps use a simpler form instead of dn */
+					if (is_boots(obj))
+						Strcat(buf, "boots");
+					else if (is_gloves(obj))
+						Strcat(buf, "gloves");
+					else if (is_cloak(obj))
+						Strcat(buf, "cloak");
+					else if (is_helmet(obj))
+						Strcat(buf, "helmet");
+					else if (is_shield(obj))
+						Strcat(buf, "shield");
+					else if (obj->oclass == ARMOR_CLASS)
+						Strcat(buf, "armor");
+					else
+						Strcat(buf, dn ? dn : actualn);
+
+					Strcat(buf, " called ");
+					Strcat(buf, un);
+				}
+				else {
+					Strcat(buf, dn ? dn : actualn);
+				}
+			}
+			else {
+				/* we can't see it, describe it as best we can  */
+				Strcat(buf, bn ? bn : dn ? dn : actualn);
+			}
+
+			/* suffixes */
+			/* note: most suffixes belong in the dofull-only section */
+
 			if (typ == TIN && obj->known) {
 				if (obj->spe > 0)
 					Strcat(buf, " of spinach");
 				else if (obj->corpsenm == NON_PM)
-					Strcpy(buf, "empty tin");
+					Strcat(buf, " (empty)");
 				else if (vegetarian(&mons[obj->corpsenm]))
 					Sprintf(eos(buf), " of %s", mons[obj->corpsenm].mname);
 				else
 					Sprintf(eos(buf), " of %s meat", mons[obj->corpsenm].mname);
 			}
-			break;
-		case COIN_CLASS:
-		case CHAIN_CLASS:
-			if (typ == IRON_BANDS) {
-				Sprintf(eos(buf), "set of %s", actualn);
-			} else {
-				Strcat(buf, actualn);
-			}
-			if (obj->owornmask & W_ARM)
-				Strcat(eos(buf), " (wrapped around chest)");
-			else if (obj->owornmask & W_ARMC)
-				Strcat(eos(buf), " (draped over shoulders)");
-			else if (obj->owornmask & W_ARMH)
-				Strcat(eos(buf), " (wrapped around head)");
-			else if (obj->owornmask & W_ARMG)
-				Strcat(eos(buf), " (wrapped around arms)");
-			else if (obj->owornmask & W_ARMF)
-				Strcat(eos(buf), " (wrapped around legs)");
-			break;
-		case ROCK_CLASS:
-			if (typ == STATUE)
-		    Sprintf(eos(buf), "%s%s%s of %s%s",
-				(Role_if(PM_ARCHEOLOGIST) && (obj->spe & STATUE_HISTORIC)) ? "historic " : "",
-				((obj->spe & STATUE_FACELESS)) ? "faceless " : "",
-				actualn,
-				type_is_pname(&mons[obj->corpsenm]) ? "" :
-				((mons[obj->corpsenm].geno & G_UNIQ) && obj->corpsenm != PM_GOD) ? "the " :
-				(index(vowels, *(mons[obj->corpsenm].mname)) ?
-				"an " : "a "),
-				mons[obj->corpsenm].mname);
-			else if (typ == FOSSIL)
-				Sprintf(eos(buf), "%s %s",
-				mons[obj->corpsenm].mname,
-				actualn);
-			else Strcat(buf, actualn);
-			break;
-		case BALL_CLASS:
-			Sprintf(eos(buf), "%sheavy iron ball",
-				(obj->owt > ocl->oc_weight) ? "very " : "");
-			break;
-		case POTION_CLASS:
-			if (typ == POT_BLOOD && (obj->known || is_vampire(youracedata))) {
-				Strcat(buf, "potion");
-				Sprintf(eos(buf), " of %s blood", mons[obj->corpsenm].mname);
-			}
-			else if (nn || un || !obj->dknown) {
-				Strcat(buf, "potion");
-				if (!obj->dknown) break;
-				if (nn) {
-					Strcat(buf, " of ");
-					if (typ == POT_WATER &&
-						obj->bknown && (obj->blessed || obj->cursed)) {
-						Strcat(buf, obj->blessed ? "holy " : "unholy ");
-					}
-					Strcat(buf, actualn);
-				}
-				else {
-					Strcat(buf, " called ");
-					Strcat(buf, un);
-				}
-			}
-			else {
-				Strcat(buf, dn);
-				Strcat(buf, " potion");
-			}
-			break;
-		case SCROLL_CLASS:
-		/* special-case scrolls */
-#ifdef MAIL
-		if (obj->otyp >= SCR_MAIL) {
-#else
-		if (obj->otyp >= SCR_BLANK_PAPER) {
-#endif
-			if (!obj->dknown) {
-				Strcat(buf, "scroll");
-				break;
-			}
-			if (!nn)
-			{
-				/* unknown otyp */
-				/* reverse order -- "stamped"/"unlabelled"/"golden" scroll */
-				Strcat(buf, dn);
-				Strcat(buf, " ");
-				Strcat(buf, "scroll");
-				if (un){
-					Strcat(buf, " called ");
-					Strcat(buf, un);
-				}
-			}
-			else {
-				/* known otyp */
-				if (obj->otyp == SCR_GOLD_SCROLL_OF_LAW) {
-					Strcat(buf, actualn);
-				}
-				else {
-					Strcat(buf, "scroll of ");
-					Strcat(buf, actualn);
-				}
-			}
-		}
-		/* standard magic scrolls */
-		else {
-			Strcat(buf, "scroll");
-			if (!obj->dknown) break;
 
-			if (nn) {
-				/* you have identified otyp */
-				Strcat(buf, " of ");
-				if (obj->otyp == SCR_WARD) Strcat(buf, wardDecode[obj->oward]);
-				else Strcat(buf, actualn);
+			if (typ == STATUE || typ == FIGURINE) {
+				Sprintf(eos(buf), " of %s%s",
+					type_is_pname(&mons[obj->corpsenm]) ? "" :
+					((mons[obj->corpsenm].geno & G_UNIQ) && obj->corpsenm != PM_GOD) ? "the " :
+					(index(vowels, *(mons[obj->corpsenm].mname)) ? "an " : "a "),
+					mons[obj->corpsenm].mname
+					);
 			}
-			else if (un) {
-				/* you have called otyp */
-				Strcat(buf, " called ");
-				Strcat(buf, un);
-			}
-			else if (ocl->oc_magic) {
-				/* unknown magic scroll */
-				Strcat(buf, " labeled ");
-				Strcat(buf, dn);
-			}
-			else {
-				/* non-magic scroll ??? */
-				Strcat(buf, " titled ");
-				Strcat(buf, dn);
-			}
-		}
-	break;
-	case TILE_CLASS:
-		if(ocl->oc_unique)
-			Strcat(buf, "slab");
-		else
-			Strcat(buf, "shard");
-		if (!obj->dknown) break;
-		if (nn) {
-			if(obj->obj_material == BONE){
-				Strcat(buf, " scrimshawed with the ");
-			} else {
-				Strcat(buf, " bearing the ");
-			}
-			Strcat(buf, actualn);
-		}
-		else if (un){
-			Strcat(buf, " called ");
-			Strcat(buf, un);
-		}
-		else {
-			if(obj->obj_material == BONE){
-				Strcat(buf, " scrimshawed with a ");
-			} else {
-				Strcat(buf, " with a ");
-			}
-			Strcat(buf, dn);
-		}
-			break;
-		case WAND_CLASS:
-			if (!obj->dknown)
-				Strcat(buf, "wand");
-			else if (nn)
-				Sprintf(eos(buf), "wand of %s", actualn);
-			else if (un)
-				Sprintf(eos(buf), "wand called %s", un);
-			else
-				Sprintf(eos(buf), "%s wand", dn);
-			break;
-		case SPBOOK_CLASS:
-			if (!obj->dknown) {
-				Strcat(buf, "spellbook");
-			}
-			else if (nn) {
-				if (typ != SPE_BOOK_OF_THE_DEAD)
-					Strcat(buf, "spellbook of ");
-				Strcat(buf, actualn);
-			}
-			else if (un) {
-				Sprintf(eos(buf), "spellbook called %s", un);
-			}
-			else
-				Sprintf(eos(buf), "%s spellbook", dn);
-			break;
-		case RING_CLASS:
-			if (!obj->dknown)
-				Strcat(buf, "ring");
-			else if (nn)
-				Sprintf(eos(buf), "ring of %s", actualn);
-			else if (un)
-				Sprintf(eos(buf), "ring called %s", un);
-			else
-				Sprintf(eos(buf), "%s ring", dn);
-			break;
-		case GEM_CLASS:
-		{
-						  const char *rock =
-							  (ocl->oc_material == MINERAL ||
-			     ocl->oc_material == SALT ||
-							  ocl->oc_material == MITHRIL ||
-							  ocl->oc_material == SILVER
-							  ) ? "stone" : "gem";
-						  if (!obj->dknown) {
-							  Strcat(buf, rock);
-						  }
-						  else if (!nn) {
-							  if (un) Sprintf(eos(buf), "%s called %s", rock, un);
-							  else Sprintf(eos(buf), "%s %s", dn, rock);
-						  }
-						  else {
-							  Strcat(buf, actualn);
-							  if (GemStone(typ)) Strcat(buf, " stone");
-						  }
-						  break;
-		}
-		default:
-			Sprintf(eos(buf), "glorkum %d %d %d", obj->oclass, typ, obj->spe);
 		}
 #ifdef SORTLOOT
 		if (!ignore_oquan)
@@ -1876,6 +1723,9 @@ boolean with_price;
 			break;
 		case WEAPON_CLASS:
 weapon:
+			if ((is_blaster(obj) || is_vibroweapon(obj) || typ == SEISMIC_HAMMER) && (obj->known || uandroid)) {
+				Sprintf(eos(buf), " (%d:%d)", (int)obj->recharged, (int)obj->ovar1);
+			}
 			if (obj->known && obj->oartifact &&
 				(oart->inv_prop == LORDLY || oart->inv_prop == ANNUL)
 				){
@@ -2089,6 +1939,9 @@ weapon:
 					Strcat(buf, " (lit)");
 				break;
 			}
+			else if (typ == HYPOSPRAY_AMPULE && nn && obj->dknown) {
+				Sprintf(eos(buf), " (%d doses)", (int)(obj->spe));
+			}
 			if (objects[obj->otyp].oc_charged && !is_weptool(obj))
 				goto charges;
 		if(is_weptool(obj))
@@ -2152,6 +2005,16 @@ weapon:
 		case CHAIN_CLASS:
 			if (obj->owornmask & W_BALL)
 				Strcat(buf, " (chained to you)");
+			else if (obj->owornmask & W_ARM)
+				Strcat(eos(buf), " (wrapped around chest)");
+			else if (obj->owornmask & W_ARMC)
+				Strcat(eos(buf), " (draped over shoulders)");
+			else if (obj->owornmask & W_ARMH)
+				Strcat(eos(buf), " (wrapped around head)");
+			else if (obj->owornmask & W_ARMG)
+				Strcat(eos(buf), " (wrapped around arms)");
+			else if (obj->owornmask & W_ARMF)
+				Strcat(eos(buf), " (wrapped around legs)");
 			break;
 		}//end switch(oclass)
 

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1680,12 +1680,13 @@ boolean with_price;
 					Sprintf(eos(buf), " of %s meat", mons[obj->corpsenm].mname);
 			}
 
+			
+			/* Reminder: Don't use an() on anything that could call xname/doname inside xname/doname */
+			/* it is okay to call an() on mons[].mname, since that is a string constant */
 			if (typ == STATUE || typ == FIGURINE) {
-				Sprintf(eos(buf), " of %s%s",
-					type_is_pname(&mons[obj->corpsenm]) ? "" :
-					((mons[obj->corpsenm].geno & G_UNIQ) && obj->corpsenm != PM_GOD) ? "the " :
-					(index(vowels, *(mons[obj->corpsenm].mname)) ? "an " : "a "),
-					mons[obj->corpsenm].mname
+				Sprintf(eos(buf), " of %s",
+					((mons[obj->corpsenm].geno & G_UNIQ) && obj->corpsenm != PM_GOD && !type_is_pname(&mons[obj->corpsenm])) ? "the " :
+					an(mons[obj->corpsenm].mname)
 					);
 			}
 		}


### PR DESCRIPTION
NOTE: based on #996 to avoid merge conflicts (first 5 commits)

Example, a "white headscarf" is shown as a "headscarf" when you don't know the objects `dknown`.
View f493537 to see all special cases made.

Does not touch lightsaber blade colors, because Chris said he was poking at them.

Blind names are not valid to use to wish for an object. This should probably change in the future.