### PR TITLE
Fix spell-swapping bug in tty version of spellmenu

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -4986,7 +4986,7 @@ int *spell_no;
 			any.a_int = i + 1;	/* must be non-zero */
 			add_menu(tmpwin, NO_GLYPH, &any,
 				spellet(i), 0, ATR_NONE, buf,
-				(i == splaction) ? MENU_SELECTED : MENU_UNSELECTED);
+				MENU_UNSELECTED);
 		}
 		//Other menu options
 		if (splaction != SPELLMENU_CAST && splaction != SPELLMENU_PICK && splaction < 0) {


### PR DESCRIPTION
What?  Don't preselect the spell to be swapping with.

Why?  Curses menus, if given how=PICK_ONE, take the users input over any preselected items. TTY menus don't, and instead give back all selected items (in this case, n=2).