### PR TITLE
Dropping a bag on an altar will BUC-id its contents

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -276,6 +276,50 @@ doaltarobj(obj)  /* obj is an object dropped on an altar */
 			otense(obj, "land"));
 		obj->bknown = 1;
 	}
+
+	/* From NetHack4: colored flashes one level deep inside containers. */
+	if (Has_contents(obj) && !obj->olocked) { /* && obj->cknown */
+		int blessed = 0;
+		int cursed = 0;
+		struct obj * otmp;
+		for (otmp = obj->cobj; otmp; otmp = otmp->nobj) {
+			if (otmp->blessed)
+				blessed++;
+			if (otmp->cursed)
+				cursed++;
+			if (!Hallucination) {
+				otmp->bknown = 1;
+			}
+		}
+		/* even when hallucinating, if you get no flashes at all, you know
+		* everything's uncursed, so save the player the trouble of manually
+		* naming them all */
+		if (Hallucination && blessed + cursed == 0) {
+			for (otmp = obj->cobj; otmp; otmp = otmp->nobj) {
+				otmp->bknown = 1;
+			}
+		}
+		if (blessed + cursed > 0) {
+			const char* color;
+			if (Hallucination) {
+				color = "pretty multichromatic";
+			}
+			else if (blessed == 0) {
+				color = hcolor(NH_BLACK);
+			}
+			else if (cursed == 0) {
+				color = hcolor(NH_AMBER);
+			}
+			else {
+				color = "colored";
+			}
+
+			pline("From inside %s, you see %s flash%s.",
+				the(xname(obj)),
+				(blessed + cursed == 1 ? an(color) : color),
+				(blessed + cursed == 1 ? "" : "es"));
+		}
+	}
 }
 
 #ifdef SINKS


### PR DESCRIPTION
Note: does not merge contents of the bag.

I think the correct thing to do is to merge bag contents when you open a bag to look at it, as that would also cover the contents of the bag being modified by other things (like water damage).