### PR TITLE
De-kludge "eternal" lightsources & engulfers interaction

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -426,9 +426,6 @@ struct obj *obj;
 			attach_fig_transform_timeout(obj);
 		    }
 	}
-	/* relight lightsources that should always be lit */
-	if (obj_eternal_light(obj) && !obj->lamplit)
-		begin_burn(obj);
 }
 
 #endif /* OVL1 */

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2648,9 +2648,6 @@ int x, y;
     otmp->nobj = fobj;
     fobj = otmp;
     if (otmp->timed) obj_timer_checks(otmp, x, y, 0);
-	/* relight lightsources that should always be lit */
-	if (obj_eternal_light(otmp) && !otmp->lamplit)
-		begin_burn(otmp);
 }
 
 #define ON_ICE(a) ((a)->recharged)

--- a/src/o_init.c
+++ b/src/o_init.c
@@ -1434,12 +1434,6 @@ fix_object(otmp)
 	struct obj *otmp;
 {
 	otmp->owt = weight(otmp);
-	if (obj_eternal_light(otmp) && !otmp->lamplit &&
-		/* special case where these lights should be snuffed */
-		!(mcarried(otmp) && attacktype(otmp->ocarry->data, AT_ENGL))
-		) {
-		begin_burn(otmp);
-	}
 }
 
 /*o_init.c*/

--- a/src/steal.c
+++ b/src/steal.c
@@ -473,16 +473,11 @@ register struct obj *otmp;
 		/* Must do carrying effects on object prior to add_to_minv() */
 		carry_obj_effects(otmp);
 
-		/* don't want hidden light source inside the monster; assumes that
-		engulfers won't have external inventories; whirly monsters cause
-		the light to be extinguished rather than letting it shine thru;
-		must come after carry_obj_effects because that relights always-on
-		lightsources */
-		if (obj_sheds_light(otmp))
-		{
-			if (attacktype(mtmp->data, AT_ENGL)) {
-				/* burning objects should go out; non-burning objects should just be disabled */
-				if (obj_is_burning(otmp) && u.uswallow && mtmp == u.ustuck && !Blind)
+		/* extinguish burning objects -- it isn't strictly necessary to end_burn anymore, though */
+		if (attacktype(mtmp->data, AT_ENGL)) {
+			/* burning objects should go out; */
+			if (obj_is_burning(otmp) && u.uswallow && mtmp == u.ustuck) {
+				if (!Blind)
 					pline("%s out.", Tobjnam(otmp, "go"));
 				end_burn(otmp, TRUE);
 			}


### PR DESCRIPTION
Use the same method that lightsources in containers use.

Make sunrods properly not go out (via invoke darkness nor dropping into a stomach).