### PR TITLE
Use a separate list of buffers when displaying your inventory

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -141,6 +141,8 @@ struct flag {
 	boolean made_divide;		/* the dividing word slab has been created */
 	boolean made_life;			/* the nurturing word slab has been created */
 	boolean made_know;			/* the word of knowledge slab has been created */
+
+	boolean disp_inv;			/* currently displaying inventory, use separate obuf list */
 	
 	/* KMH, role patch -- Variables used during startup.
 	 *

--- a/src/invent.c
+++ b/src/invent.c
@@ -3911,11 +3911,15 @@ display_inventory(lets, want_reply)
 register const char *lets;
 boolean want_reply;
 {
-	return display_pickinv(lets, want_reply, (long *)0
+	char retval;
+	flags.disp_inv = TRUE;
+	retval = display_pickinv(lets, want_reply, (long *)0
 #ifdef DUMP_LOG
 			       , FALSE , TRUE
 #endif
 	);
+	flags.disp_inv = FALSE;
+	return retval;
 }
 
 #ifdef DUMP_LOG

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -246,10 +246,18 @@ static char *
 nextobuf()
 {
 	static char NEARDATA bufs[NUMOBUF][BUFSZ];
+	static char NEARDATA ibufs[NUMOBUF][BUFSZ];
 	static int bufidx = 0;
+	static int ibufidx = 0;
 
-	bufidx = (bufidx + 1) % NUMOBUF;
-	return bufs[bufidx];
+	if (flags.disp_inv) {
+		ibufidx = (ibufidx + 1) % NUMOBUF;
+		return ibufs[ibufidx];
+	}
+	else {
+		bufidx = (bufidx + 1) % NUMOBUF;
+		return bufs[bufidx];
+	}
 }
 
 const char *


### PR DESCRIPTION
Otherwise, perminvent() will frequently overwrite all object-name buffers, which can cause quite a number of unexpected strings.