### PR TITLE
All (unpolyd) players can twoweapon

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -3415,14 +3415,12 @@ const struct def_skill *class_skill;
 
 	/* walk through array to set skill maximums */
 	for (; class_skill->skill != P_NONE; class_skill++) {
-		if(!(Race_if(PM_VAMPIRE) && !Role_if(PM_ANACHRONONAUT)) || class_skill->skill != P_TWO_WEAPON_COMBAT){
-			skmax = class_skill->skmax;
-			skill = class_skill->skill;
+		skmax = class_skill->skmax;
+		skill = class_skill->skill;
 
-			OLD_P_MAX_SKILL(skill) = skmax;
-			if (OLD_P_SKILL(skill) == P_ISRESTRICTED)	/* skill pre-set */
-				OLD_P_SKILL(skill) = P_UNSKILLED;
-		}
+		OLD_P_MAX_SKILL(skill) = skmax;
+		if (OLD_P_SKILL(skill) == P_ISRESTRICTED)	/* skill pre-set */
+			OLD_P_SKILL(skill) = P_UNSKILLED;
 	}
 
 	/* High potential fighters already know how to use their hands. */


### PR DESCRIPTION
If your race/role is restricted in twoweapon, you can twoweapon, just very poorly.
You will have awful to-hit and damage, especially with a heavy (>10aum) offhand weapon.

You remain unable to offhand non-weapons (notably, the Garnet Rod).

Binders, after first binding Miska, may train and use two-weapon combat like any other role, albeit limited in skill by normal binder rules.