### PR TITLE
Minor horror improvements

### DIFF
--- a/include/ehor.h
+++ b/include/ehor.h
@@ -49,14 +49,16 @@ static int randMeleeAttackTypes[] =
 
 static int randRangedAttackTypes[] =
 					{
+						/* 4x */
+						AT_BREA, AT_BREA, AT_BREA, AT_BREA,
+						AT_GAZE, AT_GAZE, AT_GAZE, AT_GAZE,
+						AT_MAGC, AT_MAGC, AT_MAGC, AT_MAGC,
 						/* 2x */
-						AT_BREA, AT_BREA,
 						AT_SPIT, AT_SPIT,
-						AT_GAZE, AT_GAZE,
-						AT_MAGC, AT_MAGC,
+						AT_ARRW, AT_ARRW,
+						AT_BEAM, AT_BEAM,
 						/* 1x */
-						AT_ARRW,
-						AT_BEAM
+						AT_WDGZ
 					};
 
 static int randSpecialAttackTypes[] =
@@ -294,20 +296,19 @@ static int randArrowDamageTypes[] =
 						AD_BLDR
 					};
 
- // AT_MAGC }
 static int randMagicDamageTypes[] =
 					{
-						AD_SPEL,
-						AD_SPEL,
-						AD_SPEL,
+						/* 6/10 standard spellcasting */
+						AD_SPEL, AD_SPEL, AD_SPEL,
+						AD_CLRC, AD_CLRC, AD_CLRC,
+						/* 4/10 elemental spellcasting */
 						AD_MAGM,
 						AD_FIRE,
 						AD_COLD,
-						AD_ELEC,
-						AD_CLRC,
-						AD_CLRC,
-						AD_CLRC
+						AD_ELEC
 					};
+
+/* corresponds to MZ sizes */
 static int randCorpseWeights[] = 
 						{WT_TINY,
 						 WT_SMALL,
@@ -317,6 +318,7 @@ static int randCorpseWeights[] =
 						 0,
 						 0,
 						 WT_GIGANTIC };
+/* corresponds to MZ sizes */
 static int randCorpseNut[] = 
 						{CN_TINY,
 						 CN_SMALL,

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -697,6 +697,11 @@ int level_bonus;
 
 		/* attacks...?  */
 		horrorattacks = 0;
+		extern struct attack noattack;
+		for (i = 0; i < NATTK; i++) {
+			horror->mattk[i] = noattack;
+		}
+
 		/* always start with weapon attacks... if it gets any */
 		if (!rn2(4)) {
 			attkptr = &horror->mattk[horrorattacks];
@@ -737,7 +742,7 @@ int level_bonus;
 			}
 		}
 		/* get some more melee attacks in here (this will bring it up to at least 2, with 2/3 odds of at least 3) */
-		while ((!rn2(horrorattacks) || !rn2(3)) && horrorattacks<6) {
+		while ((!rn2(horrorattacks) || !rn2(3)) && horrorattacks<NATTK) {
 			attkptr = &horror->mattk[horrorattacks];
 			if (rn2(7)) {
 				attkptr->aatyp = get_random_of(randMeleeAttackTypes);
@@ -760,7 +765,7 @@ int level_bonus;
 			horrorattacks++;
 		}
 		/* chance of getting special, hard-hitting melee attacks */
-		if (horrorattacks <= 2 || (!rn2(8) && horrorattacks < 5)) {
+		if (horrorattacks <= 2 || (!rn2(8) && horrorattacks < NATTK-1)) {
 			attkptr = &horror->mattk[horrorattacks];
 
 			attkptr->aatyp = get_random_of(randSpecialAttackTypes);
@@ -786,10 +791,14 @@ int level_bonus;
 			horrorattacks++;
 		}
 		/* chance of getting ranged attacks */
-		while (!rn2(horrorattacks / 2) && horrorattacks < 6) {
+		while (!rn2(horrorattacks / 2) && horrorattacks < NATTK) {
 			attkptr = &horror->mattk[horrorattacks];
 
-			attkptr->aatyp = get_random_of(randRangedAttackTypes);
+			do {
+				i = get_random_of(randRangedAttackTypes);
+			} while (attacktype(horror, i) && rn2(40));
+			attkptr->aatyp = i;
+
 			attkptr->damn = d(2, 3);			/*  2 -  6 */
 			attkptr->damd = rn2(3) * 2 + 6;		/*  6 - 10, by 2s */
 
@@ -813,11 +822,11 @@ int level_bonus;
 				break;
 			case AT_GAZE:
 				attkptr->adtyp = get_random_of(randGazeDamageTypes);
-				if (!rn2(4)) {
-					attkptr->aatyp = AT_WDGZ;	/* hahahaha */
-					attkptr->damn = rnd(3);			/* reduce to 1-3 */
-					attkptr->damd = rn2(3) * 2 + 4;	/* reduce to 4-8 by 2s */
-				}
+				break;
+			case AT_WDGZ:
+				attkptr->adtyp = get_random_of(randGazeDamageTypes);
+				attkptr->damn = rnd(3);			/* reduce to 1-3 */
+				attkptr->damd = rn2(3) * 2 + 4;	/* reduce to 4-8 by 2s */
 				break;
 			case AT_MAGC:
 				attkptr->adtyp = get_random_of(randMagicDamageTypes);
@@ -919,6 +928,12 @@ int level_bonus;
 				else
 					Strcat(nameless_horror_name, get_random_of(Vowels));
 			}
+			/* names cannot start with apostrophes */
+			while(nameless_horror_name[0] == '\'')
+				nameless_horror_name[0] = (get_random_of(Consonants))[0];
+			/* names cannot end with apostrophes */
+			while (eos(nameless_horror_name)[-1] == '\'')
+				eos(nameless_horror_name)[-1] = (get_random_of(Vowels))[0];
 			(void)upstart(nameless_horror_name);
 			horror->mname = nameless_horror_name;
 			horror->mflagsg |= MG_PRINCE;


### PR DESCRIPTION
No longer limited to 6 attacks, can use the full 10.

Nameless horrors' names cannot start or end with an apostrophe.

Tweak ranged attack type proportions.

Horrors try not to have multiple similar ranged attacks.