### PR TITLE
Blaster ammo inherits some things

### DIFF
--- a/src/projectile.c
+++ b/src/projectile.c
@@ -2231,9 +2231,10 @@ struct obj * blaster;
 		ammo = mksobj(HEAVY_BLASTER_BOLT, FALSE, FALSE);
 		break;
 	case MASS_SHADOW_PISTOL:
-		/* note: does not copy cobj->oartifact */
-		if (blaster->cobj)
+		if (blaster->cobj) {
 			ammo = mksobj(blaster->cobj->otyp, FALSE, FALSE);
+			ammo->oartifact = blaster->cobj->oartifact;
+		}
 		else
 			ammo = mksobj(ROCK, FALSE, FALSE);
 		break;
@@ -2245,6 +2246,10 @@ struct obj * blaster;
 		impossible("Unhandled blaster %d!", blaster->otyp);
 		break;
 	}
+
+	ammo->blessed = blaster->blessed;
+	ammo->cursed = blaster->cursed;
+	ammo->spe = blaster->spe;
 
 	return ammo;
 }


### PR DESCRIPTION
Blaster's BUC status
Blaster's enchantment
Mass-shadow-pistol only: contained ammo's artifactness

This is not new mechanics, it was lost during the creation of projectile.c.