### PR TITLE
Give Marionette back axe skill

### DIFF
--- a/src/sounds.c
+++ b/src/sounds.c
@@ -5110,6 +5110,7 @@ int floorID;
 		skillchain[i++] = P_BEAST_MASTERY;
 		break;
 	case MARIONETTE:
+		skillchain[i++] = P_AXE;	
 		skillchain[i++] = P_MATTER_SPELL;
 		break;
 	case MOTHER:


### PR DESCRIPTION
Was lost in the switch in how skills are done.