### PR TITLE
Nerf Jester's Mirth duration

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -2111,7 +2111,14 @@ spiriteffects(power, atme)
 					break;
 				}
 				mon->mnotlaugh = 0;
-				mon->mlaughing = d(1,5)+u.ulevel/10;
+				if (resist(mon, 0, 0, FALSE))
+					mon->mlaughing = 1;
+				else
+					mon->mlaughing = d(1, spiritDsize());
+				
+				// considered a save at the end of every turn to break out, but that's not
+				// a huge difference for high-MR targets, the only ones who really matter.
+				
 				pline("%s collapses in a fit of laughter.", Monnam(mon));
 			} else{
 				pline("There is no target there.");


### PR DESCRIPTION
Reduces from 1d5 + lvl/10 (3-8 at xp 30) to 1d(dice) (1-9 at xp 30?). However, if a monster passes a resist check, then it will only be frozen for 1 turn.

Thought process behind this was the removal of the ability annihilate demon lords. An average of 5-6 turns of free attacks, each getting +15 damage from sneak attacks? That's busted. Ideally an MR check would only really penalize the use on high-level monsters, so it's still a useful tool vs random things that pop up, and 1 turn should work as an escape item as well.