### PR TITLE
Adjust artifact silvering / silvering alignment penalties

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -11834,6 +11834,8 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 		poisons |= poisonedobj->opoisoned;
 		if (arti_poisoned(poisonedobj))
 			poisons |= OPOISON_BASIC;
+		if (arti_silvered(poisonedobj))
+			poisons |= OPOISON_SILVER;
 		if (poisonedobj->oartifact == ART_WEBWEAVER_S_CROOK)
 			poisons |= (OPOISON_SLEEP | OPOISON_BLIND | OPOISON_PARAL);
 		if (poisonedobj->oartifact == ART_SUNBEAM)
@@ -11856,7 +11858,7 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 	if (poisons)
 	{
 		/* Penalties for you using a poisoned weapon */
-		if (poisons && youagr && !recursed)
+		if ((poisons & ~OPOISON_SILVER) && youagr && !recursed)
 		{
 			if Role_if(PM_SAMURAI) {
 				if (!(uarmh && uarmh->oartifact && uarmh->oartifact == ART_HELM_OF_THE_NINJA)){
@@ -11931,6 +11933,8 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 				break;
 			case OPOISON_SILVER:
 				resists = !(hates_silver(pd) && !(youdef && u.sealsActive&SEAL_EDEN));
+				if (!resists)
+					silverobj |= slot;
 				majoreff = TRUE;
 				break;
 			}

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1297,7 +1297,6 @@ struct obj * obj;
 		(obj->oclass == RING_CLASS && obj->ohaluengr
 		&& (isEngrRing(obj->otyp) || isSignetRing(obj->otyp))
 		&& obj->oward >= LOLTH_SYMBOL && obj->oward <= LOST_HOUSE) ||
-		(arti_silvered(obj)) ||
 		(obj->otyp == SHURIKEN && !flags.mon_moving && uwep && uwep->oartifact == ART_SILVER_STARLIGHT)	// THIS IS BAD AND SHOULD BE DONE DIFFERENTLY
 		)
 		return TRUE;


### PR DESCRIPTION
No more penalties for using an OPOISON_SILVER weapon, and arti_silvered now is check in poisons rather than silver_searing or whatever. Also properly makes silver poison message when it should.