### PR TITLE
Add paranoid_self_cast as an option that prevents self-cancellation and more

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2542,7 +2542,7 @@ E int FDECL(spiriteffects, (int,BOOLEAN_P));
 E int FDECL(nudzirath_hit_pile, (struct obj *, struct obj *));
 E int FDECL(nudzirath_hit_mon, (struct monst *, struct obj *));
 E void FDECL(nudzirath_shatter, (struct obj *, int, int));
-E int FDECL(spelleffects, (int,BOOLEAN_P,int));
+E int FDECL(spelleffects, (int,boolean,int));
 E int FDECL(wordeffects, (int));
 E void FDECL(losespells, (int));
 E int NDECL(throwgaze);

--- a/include/flag.h
+++ b/include/flag.h
@@ -310,6 +310,7 @@ struct instance_flags {
 	char sortloot;          /* sort items to loot alphabetically */
 #endif
 #ifdef PARANOID
+	boolean  paranoid_self_cast; /* Ask for 'yes' when casting certain spells at yourself (using . ) */
 	boolean  paranoid_hit;  /* Ask for 'yes' when hitting peacefuls */
 	boolean  paranoid_quit; /* Ask for 'yes' when quitting */
 	boolean  paranoid_remove; /* Always show menu for 'T' and 'R' */

--- a/src/options.c
+++ b/src/options.c
@@ -207,6 +207,7 @@ static struct Bool_Opt
 	{"page_wait", (boolean *)0, FALSE, SET_IN_FILE},
 #endif
 #ifdef PARANOID
+	{"paranoid_self_cast", &iflags.paranoid_self_cast, FALSE, SET_IN_GAME},
 	{"paranoid_hit", &iflags.paranoid_hit, FALSE, SET_IN_GAME},
 	{"paranoid_quit", &iflags.paranoid_quit, FALSE, SET_IN_GAME},
 	{"paranoid_remove", &iflags.paranoid_remove, FALSE, SET_IN_GAME},

--- a/src/spell.c
+++ b/src/spell.c
@@ -4558,8 +4558,7 @@ dothrowspell:
 				if (iflags.paranoid_self_cast &&
 						pseudo->otyp != SPE_HEALING &&
 						pseudo->otyp != SPE_EXTRA_HEALING &&
-						pseudo->otyp != SPE_TELEPORT_AWAY &&
-						pseudo->otyp != SPE_STONE_TO_FLESH)
+						pseudo->otyp != SPE_TELEPORT_AWAY
 				{
 					char buf[BUFSZ];
 					getlin ("Are you sure you want to cast that spell at yourself? [yes/no]?",buf);

--- a/src/spell.c
+++ b/src/spell.c
@@ -4555,7 +4555,12 @@ dothrowspell:
 			if(!u.dx && !u.dy && !u.dz) {
 
 #ifdef PARANOID
-				if (iflags.paranoid_self_cast && pseudo->otyp != SPE_HEALING && pseudo->otyp != SPE_EXTRA_HEALING && pseudo->otyp != SPE_TELEPORT_AWAY) {
+				if (iflags.paranoid_self_cast &&
+						pseudo->otyp != SPE_HEALING &&
+						pseudo->otyp != SPE_EXTRA_HEALING &&
+						pseudo->otyp != SPE_TELEPORT_AWAY &&
+						pseudo->otyp != SPE_STONE_TO_FLESH)
+				{
 					char buf[BUFSZ];
 					getlin ("Are you sure you want to cast that spell at yourself? [yes/no]?",buf);
 					if ((strcmp (buf, "yes")))

--- a/src/spell.c
+++ b/src/spell.c
@@ -4336,9 +4336,7 @@ int spell;
 	}
 }
 int
-spelleffects(spell, atme, spelltyp)
-int spell, spelltyp;
-boolean atme;
+spelleffects(int spell, boolean atme, int spelltyp)
 {
 	int energy, damage, chance, n, intell;
 	int skill, role_skill;
@@ -4555,6 +4553,19 @@ dothrowspell:
 			    pline_The("magical energy is released!");
 			}
 			if(!u.dx && !u.dy && !u.dz) {
+
+#ifdef PARANOID
+				if (iflags.paranoid_self_cast && pseudo->otyp != SPE_HEALING && pseudo->otyp != SPE_EXTRA_HEALING && pseudo->otyp != SPE_TELEPORT_AWAY) {
+					char buf[BUFSZ];
+					getlin ("Are you sure you want to cast that spell at yourself? [yes/no]?",buf);
+					if ((strcmp (buf, "yes")))
+					{
+						pline_The("spell fizzles and dissipates");
+						break;
+					}
+				}
+#endif
+
 			    if ((damage = zapyourself(pseudo, TRUE)) != 0) {
 				char buf[BUFSZ];
 				Sprintf(buf, "zapped %sself with a spell", uhim());


### PR DESCRIPTION
Currently hard coded to allow heal/extraheal/tp as the only spells that it won't confirm, but can make an option but not sure it's really worth it.