### PR TITLE
Your marilith arms use your two-weapon combat skill to determine max wt

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -674,6 +674,7 @@ int tary;
 						&& !(otmp->oartifact && !always_twoweapable_artifact(otmp))			// ok artifact
 						&& (!bimanual(otmp, pa) || pa->mtyp == PM_GYNOID || pa->mtyp == PM_PARASITIZED_GYNOID)// not two-handed
 						&& (youagr || (otmp != MON_WEP(magr) && otmp != MON_SWEP(magr)))	// not wielded already (monster)
+						&& (!youagr || otmp->owt <= max(10, P_SKILL(P_TWO_WEAPON_COMBAT)*10))// not too heavy
 						&& (!youagr || (otmp != uwep && (!u.twoweap || otmp != uswapwep)))	// not wielded already (player)
 						&& !(is_ammo(otmp) || is_pole(otmp) || is_missile(otmp))			// not unsuitable for melee (ammo, polearm, missile)
 						&& !otmp->owornmask)												// not worn


### PR DESCRIPTION
This prevents you from finding absurd offhands that are technically one-handed, but wouldn't be offhandable normally, and brings marilith arms closer to normal twoweaponing. Ideally, this would only apply to Miska, but I don't believe there are any huge balance problems with making them apply to all AT_MARI attacks?