### PR TITLE
Add Dirge

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -453,7 +453,7 @@ extern struct artinstance artinstance[];
 				)\
 			)
 /* artifact has no specific material or size, eg "silver Grimtooth" */
-#define is_malleable_artifact(a) (is_nameable_artifact((a)) || (a) == &artilist[ART_EXCALIBUR])
+#define is_malleable_artifact(a) (is_nameable_artifact((a)) || (a) == &artilist[ART_EXCALIBUR] || (a) == &artilist[ART_DIRGE])
 
 #define is_living_artifact(obj) ((obj)->oartifact == ART_TENTACLE_ROD || (obj)->oartifact == ART_DRAGONHEAD_SHIELD || (obj)->oartifact == ART_CRUCIFIX_OF_THE_MAD_KING || (obj)->oartifact == ART_RITUAL_RINGED_SPEAR)
 

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -77,6 +77,16 @@ A("Excalibur",			LONG_SWORD,						(const char *)0,
 	NOINVOKE, NOFLAG
 	),
 
+A("Dirge",			LONG_SWORD,						"half-melted %s",
+	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	A_CHAOTIC, PM_KNIGHT, NON_PM, TIER_A, (ARTG_NOGEN|ARTG_NOWISH|ARTG_INHER|ARTG_MAJOR|ARTG_FXALGN),
+	NO_MONS(),
+	ATTK(AD_ACID, 5, 10), NOFLAG,
+	PROPS(ACID_RES), NOFLAG,
+	PROPS(), NOFLAG,
+	NOINVOKE, NOFLAG
+	),
+
 /*
  *	Stormbringer only has a 2 because it can drain a level,
  *	providing 8 more.

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1553,6 +1553,10 @@ touch_artifact(obj, mon, hypothetical)
 		forceEvade = TRUE;
 	}
 	
+	if(obj->oartifact == ART_DIRGE && (badalign || badclass)){
+		forceEvade = TRUE;
+	}
+	
 	if (((badclass || badalign) && self_willed) ||
        (badalign && (!yours || !rn2(4)))
 	   )  {

--- a/src/invent.c
+++ b/src/invent.c
@@ -2951,8 +2951,8 @@ winid *datawin;
 				poisons |= OPOISON_FILTH;
 			if (oartifact == ART_MOONBEAM)
 				poisons |= OPOISON_SLEEP;
-			
-			
+			if (oartifact == ART_DIRGE)
+				poisons |= OPOISON_ACID;
 			
 			if (poisons) {
 				/* special cases */

--- a/src/pray.c
+++ b/src/pray.c
@@ -2745,52 +2745,76 @@ dosacrifice()
 			}
 
 			if (altaralign != A_CHAOTIC && altaralign != A_NONE) {
-			/* curse the lawful/neutral altar */
-			if(Race_if(PM_INCANTIFIER)) pline_The("altar is stained with human blood, the blood of your birth race.");
-			else pline_The("altar is stained with %s blood.", urace.adj);
-			if(!Is_astralevel(&u.uz))
-				levl[u.ux][u.uy].altarmask = AM_CHAOTIC;
-			angry_priest();
-			} else {
-			struct monst *dmon;
-			const char *demonless_msg;
-
-			/* Human sacrifice on a chaotic or unaligned altar */
-			/* is equivalent to demon summoning */
-			if (altaralign == A_CHAOTIC && u.ualign.type != A_CHAOTIC) {
-				pline(
-				 "The blood floods the altar, which vanishes in %s cloud!",
-				  an(hcolor(NH_BLACK)));
-				levl[u.ux][u.uy].typ = ROOM;
-				levl[u.ux][u.uy].altarmask = 0;
-				newsym(u.ux, u.uy);
+				/* curse the lawful/neutral altar */
+				if(Race_if(PM_INCANTIFIER)) pline_The("altar is stained with human blood, the blood of your birth race.");
+				else pline_The("altar is stained with %s blood.", urace.adj);
+				if(!Is_astralevel(&u.uz))
+					levl[u.ux][u.uy].altarmask = AM_CHAOTIC;
 				angry_priest();
-				demonless_msg = "cloud dissipates";
 			} else {
-				/* either you're chaotic or altar is Moloch's or both */
-				pline_The("blood covers the altar!");
-				change_luck(altaralign == A_NONE ? -2 : 2);
-				demonless_msg = "blood coagulates";
-			}
-			if ((pm = dlord((struct permonst *) 0, altaralign)) != NON_PM &&
-				(dmon = makemon(&mons[pm], u.ux, u.uy, NO_MM_FLAGS))) {
-				You("have summoned %s!", a_monnam(dmon));
-				if (sgn(u.ualign.type) == sgn(dmon->data->maligntyp))
-				dmon->mpeaceful = TRUE;
-				You("are terrified, and unable to move.");
-				nomul(-3, "being terrified of a demon");
-			} else pline_The("%s.", demonless_msg);
+				struct monst *dmon;
+				const char *demonless_msg;
+
+				/* Human sacrifice on a chaotic or unaligned altar */
+				/* is equivalent to demon summoning */
+				if (altaralign == A_CHAOTIC && u.ualign.type != A_CHAOTIC) {
+					pline(
+					 "The blood floods the altar, which vanishes in %s cloud!",
+					  an(hcolor(NH_BLACK)));
+					levl[u.ux][u.uy].typ = ROOM;
+					levl[u.ux][u.uy].altarmask = 0;
+					newsym(u.ux, u.uy);
+					angry_priest();
+					demonless_msg = "cloud dissipates";
+				} else {
+					/* either you're chaotic or altar is Moloch's or both */
+					pline_The("blood covers the altar!");
+					change_luck(altaralign == A_NONE ? -2 : 2);
+					demonless_msg = "blood coagulates";
+				}
+				if ((pm = dlord((struct permonst *) 0, altaralign)) != NON_PM &&
+					(dmon = makemon(&mons[pm], u.ux, u.uy, NO_MM_FLAGS))) {
+					You("have summoned %s!", a_monnam(dmon));
+					if (sgn(u.ualign.type) == sgn(dmon->data->maligntyp))
+					dmon->mpeaceful = TRUE;
+					You("are terrified, and unable to move.");
+					nomul(-3, "being terrified of a demon");
+				} else pline_The("%s.", demonless_msg);
 			}
 
 			if (u.ualign.type != A_CHAOTIC) {
-			adjalign(-5);
-			u.ugangr[Align2gangr(u.ualign.type)] += 3;
-			(void) adjattrib(A_WIS, -1, TRUE);
-			if (!Inhell) angrygods(Align2gangr(u.ualign.type));
-			change_luck(-5);
-			} else adjalign(5);
+				adjalign(-5);
+				u.ugangr[Align2gangr(u.ualign.type)] += 3;
+				(void) adjattrib(A_WIS, -1, TRUE);
+				if (!Inhell) angrygods(Align2gangr(u.ualign.type));
+				change_luck(-5);
+			} else {
+				adjalign(5);
+				/* create Dirge from player's longsword here if possible */
+				if (Role_if(PM_KNIGHT) && u.ugangr[Align2gangr(u.ualign.type)] == 0 && u.ualign.record > 0
+					&& uwep && uwep->otyp == LONG_SWORD
+					&& !uwep->oartifact && !(uarmh && uarmh->otyp == HELM_OF_OPPOSITE_ALIGNMENT)
+					&& !exist_artifact(LONG_SWORD, artiname(ART_DIRGE))
+				) {
+					pline("Your sword melts in your hand and transforms into something new!");
+					uwep = oname(uwep, artiname(ART_DIRGE));
+					discover_artifact(ART_DIRGE);
+
+					if (uwep->spe < 0)
+						uwep->spe = 0;
+					uwep->oeroded = uwep->oeroded2 = 0;
+					uwep->oerodeproof = TRUE;
+
+					exercise(A_WIS, TRUE);
+
+					char llog[BUFSZ+22];
+					Sprintf(llog, "was given %s", the(artilist[uwep->oartifact].name));
+					livelog_write_string(llog);
+				}
+			}	
 			if (carried(otmp)) useup(otmp);
 			else useupf(otmp, 1L);
+	
 			return(1);
 		} else if (otmp->oxlth && otmp->oattached == OATTACHED_MONST
 				&& ((mtmp = get_mtraits(otmp, FALSE)) != (struct monst *)0)

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -11908,6 +11908,8 @@ boolean * wepgone;				/* used to return an additional result: was [weapon] destr
 			poisons |= OPOISON_FILTH;
 		if (poisonedobj->oartifact == ART_MOONBEAM)
 			poisons |= OPOISON_SLEEP;
+		if (poisonedobj->oartifact == ART_DIRGE)
+			poisons |= OPOISON_ACID;
 		/* Plague adds poisons to its launched ammo */
 		if (launcher && launcher->oartifact == ART_PLAGUE) {
 			if (monstermoves < launcher->ovar1)

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1429,6 +1429,8 @@ struct obj * otmp;
 			ndice = 4; //Extra unholy (4d9 vs excal's 3d7)
 		else if (otmp->oartifact == ART_GODHANDS)
 			dmg += 9;
+		else if (otmp->oartifact == ART_DIRGE)
+			dmg += 6;
 		else if (otmp->oartifact == ART_LANCE_OF_LONGINUS)
 			ndice = 3;
 		else if (otmp->oartifact == ART_SCEPTRE_OF_THE_FROZEN_FLOO)


### PR DESCRIPTION
~~Stolen~~ Inspired by EvilHack Dirge.

* chaotic intelligent knight-favoring malleable long sword
  * Will always evade the grasp of non-chaotics and non-knights, you must be a chaotic knight to wield. Helms of opposite alignment are accepted for wielding purposes.
* Can only be obtained by same-race sacrifice on a chaotic altar, while a permanently chaotic knight wielding a long sword. This will convert the long sword into Dirge, rustproofing it, clearing erosion, and setting enchantment to 0 if it was previously lower. This will not uncurse it.
* Has +5 to hit and +1d10 acid damage
* Has +6 unholy damage when cursed
* Permanently coated in acid poison
* Grants acid resistance when wielded

This is mostly just a feature suggestion I wanted to get out there. It seems like fun, if not particularly balanced, and shouldn't be too busted since it requires a permanent conversion to chaotic to get. Should be only marginally stronger than Excalibur in general, and much less useful in the late game considering the extra d10 acid vs 3d7 holy. Thoughts?