### PR TITLE
Ludios spawns on the first possible vault

### DIFF
--- a/src/mklev.c
+++ b/src/mklev.c
@@ -2205,17 +2205,13 @@ xchar x, y;
 	    source = &br->end1;
 	}
 
-	/* Already set or 2/3 chance of deferring until a later level. */
-	if (source->dnum < n_dgns || (rn2(3)
-#ifdef WIZARD
-				      && !wizard
-#endif
-				      )) return;
+	/* Already set -> nope. */
+	if (source->dnum < n_dgns) return;
 
-	if (! (u.uz.dnum == oracle_level.dnum	    /* in main dungeon */
-		&& !at_dgn_entrance("The Quest")    /* but not Quest's entry */
-		&& (u_depth = depth(&u.uz)) > 10    /* beneath 10 */
-		&& u_depth < depth(&challenge_level))) /* and above Medusa */
+	if (u.uz.dnum != oracle_level.dnum		// not in main dungeon
+		|| (u_depth = depth(&u.uz)) < 10	// not beneath 10
+		|| u_depth > depth(&challenge_level)// not below medusa
+	)
 	    return;
 
 	/* Adjust source to be current level and re-insert branch. */


### PR DESCRIPTION
The first vault between lvl 10 and medusa will be used to spawn Ludios. Solves the minor problem of Ludios being extra rare compared to vanilla due to 3+ additional branches taking up valuable vault space.

Should be safe to remove the quest entrance check due to the above `Is_branchlev` check.