### PR TITLE
Reduce Vampire Killer's increased damage back to what was intended

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -496,11 +496,11 @@ int otyp;
 			if (large)
 			{
 				bonn = 1;
-				bond = max(12 + 2 * dmod, 2);
+				bond = max(10 + 2 * dmod, 2);
 			}
 			else
 			{
-				flat += max(12 + 2 * dmod, 2);
+				flat += max(10 + 2 * dmod, 2);
 			}
 		}
 		else if (obj->oartifact == ART_GREEN_DRAGON_CRESCENT_BLAD){


### PR DESCRIPTION
Material differences had gave it an unintentional +dmod.

Compare to https://nethackwiki.com/wiki/DNetHack_artifacts#Vampire_Killer