### PR TITLE
A little more misc property work

### DIFF
--- a/include/prop.h
+++ b/include/prop.h
@@ -155,11 +155,13 @@ struct prop {
 	long intrinsic;
 	/* Timed properties */
 #	define TIMEOUT	    0x00ffffffL /* Up to 16 million turns */
+#	define TIMEOUT_INF	0x00800000L	/* If you get this much, it won't decrement. should be a subset of TIMEOUT */
 	/* Permanent properties */
 #	define FROMEXPER    0x01000000L /* Gain/lose with experience, for role */
 #	define FROMRACE     0x02000000L /* Gain/lose with experience, for race */
-#	define FROMOUTSIDE  0x04000000L /* By prayer, thrones, etc. */
-#	define INTRINSIC    (FROMOUTSIDE|FROMRACE|FROMEXPER)
+#	define FROMPOLY		0x04000000L	/* Gain/lose with polyform */
+#	define FROMOUTSIDE  0x08000000L /* Should generally not be lost. */
+#	define INTRINSIC    (FROMOUTSIDE|FROMRACE|FROMPOLY|FROMEXPER|TIMEOUT_INF)
 	/* Control flags */
 #	define I_SPECIAL    0x10000000L /* Property is controllable */
 };

--- a/include/you.h
+++ b/include/you.h
@@ -342,8 +342,8 @@ struct you {
 	int bc_order;	/* ball & chain order [see bc_order() in ball.c] */
 	int bc_felt;	/* mask for ball/chain being felt */
 
-	int umonster;			/* hero's "real" monster num */
-	int umonnum;			/* current monster number */
+	int umonster;			/* hero's role's monster num */
+	int umonnum;			/* current monster number (either your role's or a polyform) */
 
 	int mh, mhmax, mhrolled, mtimedone;	/* for polymorph-self */
 #define MATTK_DSCALE         1

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -162,7 +162,7 @@
 /* Those implemented solely as timeouts (we use just intrinsic) */
 #define HStun			u.uprops[STUNNED].intrinsic
 #define Stunned			((HStun || u.umonnum == PM_STALKER || \
-				 youmonst.data->mlet == S_BAT) && !(u.specialSealsActive&SEAL_NUMINA))
+						(Upolyd && youmonst.data->mlet == S_BAT)) && !(u.specialSealsActive&SEAL_NUMINA))
 		/* Note: birds will also be stunned */
 
 #define HConfusion		u.uprops[CONFUSION].intrinsic

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -29,14 +29,13 @@
 #define HFire_resistance	u.uprops[FIRE_RES].intrinsic
 #define EFire_resistance	u.uprops[FIRE_RES].extrinsic
 #define Fire_resistance		(HFire_resistance || EFire_resistance || \
-				 species_resists_fire(&youmonst) || (Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_FIRE) ||\
+				 species_resists_fire(&youmonst) || \
 				 ward_at(u.ux,u.uy) == SIGIL_OF_CTHUGHA )
 #define InvFire_resistance	(EFire_resistance || Preservation || ward_at(u.ux,u.uy) == SIGIL_OF_CTHUGHA)
 
 #define HCold_resistance	u.uprops[COLD_RES].intrinsic
 #define ECold_resistance	u.uprops[COLD_RES].extrinsic
-#define NCold_resistance		((Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_COLD) ||\
-				 species_resists_cold(&youmonst) || \
+#define NCold_resistance		(species_resists_cold(&youmonst) || \
 				 ward_at(u.ux,u.uy) == BRAND_OF_ITHAQUA)
 #define Cold_resistance		(HCold_resistance || ECold_resistance || NCold_resistance)
 #define InvCold_resistance	(ECold_resistance || Preservation || ward_at(u.ux,u.uy) == BRAND_OF_ITHAQUA)
@@ -44,7 +43,6 @@
 #define HSleep_resistance	u.uprops[SLEEP_RES].intrinsic
 #define ESleep_resistance	u.uprops[SLEEP_RES].extrinsic
 #define Sleep_resistance	(HSleep_resistance || ESleep_resistance || \
-				 (Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_SLEE) || \
 				 species_resists_sleep(&youmonst))
 
 #define HDisint_resistance	u.uprops[DISINT_RES].intrinsic
@@ -55,19 +53,19 @@
 #define HShock_resistance	u.uprops[SHOCK_RES].intrinsic
 #define EShock_resistance	u.uprops[SHOCK_RES].extrinsic
 #define Shock_resistance	(HShock_resistance || EShock_resistance || \
-				 species_resists_elec(&youmonst) || (Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_ELEC) ||\
+				 species_resists_elec(&youmonst) || \
 				 ward_at(u.ux,u.uy) == TRACERY_OF_KARAKAL )
 #define InvShock_resistance	(EShock_resistance || Preservation || ward_at(u.ux,u.uy) == TRACERY_OF_KARAKAL || (HShock_resistance&FROMRACE && Race_if(PM_ANDROID)))
 
 #define HPoison_resistance	u.uprops[POISON_RES].intrinsic
 #define EPoison_resistance	u.uprops[POISON_RES].extrinsic
 #define Poison_resistance	(HPoison_resistance || EPoison_resistance || GoodHealth || \
-				 species_resists_poison(&youmonst) || (Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_DRST) ||\
+				 species_resists_poison(&youmonst) || \
 				 (ward_at(u.ux,u.uy) == WINGS_OF_GARUDA && num_wards_at(u.ux, u.uy) > rn2(7)))
 
 #define HAcid_resistance	u.uprops[ACID_RES].intrinsic
 #define EAcid_resistance	u.uprops[ACID_RES].extrinsic
-#define Acid_resistance		(HAcid_resistance || EAcid_resistance || (Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_ACID) ||\
+#define Acid_resistance		(HAcid_resistance || EAcid_resistance ||\
 							 species_resists_acid(&youmonst))
 #define InvAcid_resistance	(EAcid_resistance || Preservation)
 
@@ -84,7 +82,7 @@
 
 #define HAntimagic		u.uprops[ANTIMAGIC].intrinsic
 #define EAntimagic		u.uprops[ANTIMAGIC].extrinsic
-#define Antimagic		(EAntimagic || HAntimagic || (Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_MAGM) ||\
+#define Antimagic		(EAntimagic || HAntimagic || \
 						(u.usteed && u.usteed->misc_worn_check & W_SADDLE \
 						&& which_armor(u.usteed, W_SADDLE)->oartifact == ART_HELLRIDER_S_SADDLE) || \
 						Nullmagic ||\

--- a/src/apply.c
+++ b/src/apply.c
@@ -3140,7 +3140,7 @@ struct obj *hypo;
 				if (!(HFast & INTRINSIC)) {
 					if (!Fast) You("speed up.");
 					else Your("quickness feels more natural.");
-					HFast |= FROMOUTSIDE;
+					HFast |= TIMEOUT_INF;
 				} else nothing++;
 				exercise(A_DEX, TRUE);
 			break;

--- a/src/eat.c
+++ b/src/eat.c
@@ -669,7 +669,7 @@ boolean allowmsg;
 					You("have a bad feeling deep inside.");
 				You("cannibal!  You will regret this!");
 			}
-			HAggravate_monster |= FROMOUTSIDE;
+			HAggravate_monster |= TIMEOUT_INF;
 			change_luck(-rn1(4,2));		/* -5..-2 */
 		} else if (Role_if(PM_CAVEMAN)) {
 			adjalign(sgn(u.ualign.type));
@@ -715,7 +715,7 @@ BOOLEAN_P bld, nobadeffects;
 		      victual.eating ? "eating" : bld ? "drinking" : "biting",
 		      occupation == opentin ? "tinned " : "", mons[pm].mname,
 			  bld ? " blood" : "");
-		    HAggravate_monster |= FROMOUTSIDE;
+			HAggravate_monster |= TIMEOUT_INF;
 		}
 		break;
 	    case PM_LIZARD:
@@ -929,7 +929,7 @@ give_intrinsic(int type, long duration){
 	boolean nullify = (duration == -2);
 	
 	if (permanent){
-		u.uprops[type].intrinsic |= FROMOUTSIDE;
+		u.uprops[type].intrinsic |= TIMEOUT_INF;
 		return;
 	}
 	
@@ -1034,7 +1034,7 @@ boolean drained;
 		break;
 	    case DISINT_RES:
 			debugpline("Trying to give disintegration resistance");
-			if (!(HDisint_resistance & FROMOUTSIDE)) {
+			if (!(HDisint_resistance & (TIMEOUT_INF | FROMOUTSIDE))) {
 				You_feel(Hallucination ? "totally together, man." : "very firm.");
 				give_intrinsic(DISINT_RES, -1);
 			}
@@ -1059,7 +1059,7 @@ boolean drained;
 		break;
 	    case POISON_RES:
 			debugpline("Trying to give poison resistance");
-			if (!(HPoison_resistance & FROMOUTSIDE)) {
+			if (!(HPoison_resistance & (TIMEOUT_INF | FROMOUTSIDE))) {
 				You_feel(Poison_resistance ? "especially healthy." : "healthy.");
 				give_intrinsic(POISON_RES, -1);
 			}
@@ -1075,21 +1075,21 @@ boolean drained;
 		break;
 	    case TELEPORT:
 			debugpline("Trying to give teleport");
-			if(!(HTeleportation & FROMOUTSIDE)) {
+			if (!(HTeleportation & (TIMEOUT_INF | FROMOUTSIDE))) {
 				You_feel(Hallucination ? "diffuse." : "very jumpy.");
 				give_intrinsic(TELEPORT, -1);
 			}
 		break;
 	    case TELEPORT_CONTROL:
 			debugpline("Trying to give teleport control");
-			if(!(HTeleport_control & FROMOUTSIDE)) {
+			if (!(HTeleport_control & (TIMEOUT_INF | FROMOUTSIDE))) {
 				You_feel(Hallucination ? "centered in your personal space." : "in control of yourself.");
 				give_intrinsic(TELEPORT_CONTROL, -1);
 			}
 		break;
 	    case TELEPAT:
 			debugpline("Trying to give telepathy");
-			if(!(HTelepat & FROMOUTSIDE)) {
+			if (!(HTelepat & (TIMEOUT_INF | FROMOUTSIDE))) {
 				You_feel(Hallucination ? "in touch with the cosmos." : "a strange mental acuity.");
 				give_intrinsic(TELEPAT, -1);
 				if(Hallucination) change_uinsight(1);
@@ -1238,8 +1238,8 @@ BOOLEAN_P tin, nobadeffects, drained;
 					if (!Blind && !BInvis) self_invis_message();
 				} else {
 					if (!(HInvis & INTRINSIC)) You_feel("hidden!");
-					HInvis |= FROMOUTSIDE;
-					HSee_invisible |= FROMOUTSIDE;
+					HInvis |= TIMEOUT_INF;
+					HSee_invisible |= TIMEOUT_INF;
 				}
 				newsym(u.ux, u.uy);
 			}
@@ -2175,7 +2175,7 @@ struct obj *otmp;
 		if (!(u.uprops[objects[typ].oc_oprop].intrinsic & FROMOUTSIDE))
 		    accessory_has_effect(otmp);
 
-		u.uprops[objects[typ].oc_oprop].intrinsic |= FROMOUTSIDE;
+		u.uprops[objects[typ].oc_oprop].intrinsic |= TIMEOUT_INF;
 
 		switch (typ) {
 		  case RIN_SEE_INVISIBLE:
@@ -2205,7 +2205,7 @@ struct obj *otmp;
 		    rescham();
 		    break;
 		  case RIN_LEVITATION:
-		    /* undo the `.intrinsic |= FROMOUTSIDE' done above */
+		    /* undo the `.intrinsic |= TIMEOUT_INF' done above */
 		    u.uprops[LEVITATION].intrinsic = oldprop;
 		    if (!Levitation) {
 			float_up();
@@ -2240,17 +2240,17 @@ struct obj *otmp;
 		break;
 	    case RIN_PROTECTION:
 		accessory_has_effect(otmp);
-		HProtection |= FROMOUTSIDE;
+		HProtection |= TIMEOUT_INF;
 		u.ublessed += otmp->spe;
 		flags.botl = 1;
 		break;
 	    case RIN_FREE_ACTION:
 		/* Give sleep resistance instead */
-		if (!(HSleep_resistance & FROMOUTSIDE))
+		if (!(HSleep_resistance & (FROMOUTSIDE | TIMEOUT_INF)))
 		    accessory_has_effect(otmp);
 		if (!Sleep_resistance)
 		    You_feel("wide awake.");
-		HSleep_resistance |= FROMOUTSIDE;
+		HSleep_resistance |= TIMEOUT_INF;
 		break;
 	    case AMULET_OF_CHANGE:
 		accessory_has_effect(otmp);
@@ -2474,14 +2474,14 @@ register struct obj *otmp;
 		/* This stuff seems to be VERY healthy! */
 		adjattrib(A_DEX, 1, 0);
 		if(!otmp->cursed){
-			if (!(HFast & INTRINSIC)) {
+			if (!(HFast & (INTRINSIC))) {
 				if (!Fast) You("speed up.");
 				else Your("quickness feels more natural.");
-				HFast |= FROMOUTSIDE;
+				HFast |= TIMEOUT_INF;
 			}
 		} else {
-			if ((HFast & FROMOUTSIDE)) {
-				HFast &= ~FROMOUTSIDE;
+			if ((HFast & TIMEOUT_INF)) {
+				HFast &= ~TIMEOUT_INF;
 				if (!Fast) You("slow down.");
 				else Your("quickness feels less natural.");
 			}

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -307,7 +307,7 @@ drinkfountain()
 			   You("see an image of someone stalking you.");
 			   pline("But it disappears.");
 			}
-			HSee_invisible |= FROMOUTSIDE;
+			HSee_invisible |= TIMEOUT_INF;
 			newsym(u.ux,u.uy);
 			exercise(A_WIS, TRUE);
 			break;

--- a/src/hack.c
+++ b/src/hack.c
@@ -1029,13 +1029,10 @@ domove()
 			    || is_whirly(youracedata))
 			on_ice = FALSE;
 		    else if (!rn2(Cold_resistance ? 3 : 2)) {
-			HFumbling |= FROMOUTSIDE;
 			HFumbling &= ~TIMEOUT;
 			HFumbling += 1;  /* slip on next move */
 		    }
 		}
-		if (!on_ice && (HFumbling & FROMOUTSIDE))
-		    HFumbling &= ~FROMOUTSIDE;
 
 		x = u.ux + u.dx;
 		y = u.uy + u.dy;

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -3590,8 +3590,8 @@ int tary;
 
 	case DISAPPEAR:
 		if (youagr) {
-			if (!(HInvis & INTRINSIC)) {
-				HInvis |= FROMOUTSIDE;
+			if (!(HInvis & (INTRINSIC))) {
+				HInvis |= TIMEOUT_INF;
 				if (!Blind && !BInvis) self_invis_message();
 			}
 		}
@@ -4606,7 +4606,7 @@ int tary;
 		if (youdef && !HSterile && !Drain_resistance) {
 			/* only works vs player, and should fall through to drain life */
 			You_feel("old!");
-			HSterile |= FROMOUTSIDE;
+			HSterile |= TIMEOUT_INF;
 		}
 		else {
 			return cast_spell(magr, mdef, attk, DRAIN_LIFE, tarx, tary);
@@ -4954,12 +4954,12 @@ int tary;
 
 	/* don't cast haste self when already fast */
 	if (spellnum == HASTE_SELF
-		&& (youagr ? (HFast&FROMOUTSIDE) : (magr->permspeed == MFAST)))
+		&& (youagr ? (HFast&(INTRINSIC)) : (magr->permspeed == MFAST)))
 		return TRUE;
 
 	/* don't cast invisibility when already invisible */
 	if (spellnum == DISAPPEAR
-		&& (youagr ? (HInvis&FROMOUTSIDE) : (magr->minvis || magr->invis_blkd)))
+		&& (youagr ? (HInvis&(INTRINSIC)) : (magr->minvis || magr->invis_blkd)))
 		return TRUE;
 	/* peaceful monsters won't cast invisibility if you can't see invisible,
 	 * same as when monsters drink potions of invisibility.  This doesn't

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -291,7 +291,7 @@ boolean forcecontrol;
 				uskin = uarm;
 				uarm = (struct obj *)0;
 				/* save/restore hack */
-				uskin->owornmask |= I_SPECIAL;
+				uskin->owornmask |= W_SKIN;
 			}
 		}
 		else if(leonine) {
@@ -303,7 +303,7 @@ boolean forcecontrol;
 				uskin = uarmc;
 				uarmc = (struct obj *)0;
 				/* save/restore hack */
-				uskin->owornmask |= I_SPECIAL;
+				uskin->owornmask |= W_SKIN;
 			}
 		} else if (hasmask) {
 			if ((youmonst.data) == &mons[ublindf->corpsenm])
@@ -1947,17 +1947,17 @@ boolean silently;
 		if(uskin->otyp == LEO_NEMAEUS_HIDE){
 			uarmc = uskin;
 			/* undo save/restore hack */
-			uskin->owornmask &= ~I_SPECIAL;
+			uskin->owornmask &= ~W_SKIN;
 			uskin = (struct obj *)0;
 			/* undo save/restore hack */
-			uarmc->owornmask &= ~I_SPECIAL;
+			uarmc->owornmask &= ~W_SKIN;
 		} else {
 			uarm = uskin;
 			/* undo save/restore hack */
-			uskin->owornmask &= ~I_SPECIAL;
+			uskin->owornmask &= ~W_SKIN;
 			uskin = (struct obj *)0;
 			/* undo save/restore hack */
-			uarm->owornmask &= ~I_SPECIAL;
+			uarm->owornmask &= ~W_SKIN;
 		}
 	}
 }

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -23,44 +23,11 @@ STATIC_DCL short NDECL(doclockmenu);
 STATIC_DCL short NDECL(dodroidmenu);
 STATIC_DCL void FDECL(worddescriptions, (int));
 
-/* Assumes u.umonster is set up already */
-/* Use u.umonster since we might be restoring and you may be polymorphed */
+/* assumes u.umonnum is set already */
 void
 init_uasmon()
 {
-	int i;
-
-	upermonst = mons[u.umonster];
-
-	/* Fix up the flags */
-	/* Default flags assume human,  so replace with your race's flags */
-
-	upermonst.mflagsm &= ~(mons[PM_HUMAN].mflagsm);
-	upermonst.mflagsm |= (mons[urace.malenum].mflagsm);
-
-	upermonst.mflagst &= ~(mons[PM_HUMAN].mflagst);
-	upermonst.mflagst |= (mons[urace.malenum].mflagst);
-
-	upermonst.mflagsb &= ~(mons[PM_HUMAN].mflagsb);
-	upermonst.mflagsb |= (mons[urace.malenum].mflagsb);
-	
-	upermonst.mflagsg &= ~(mons[PM_HUMAN].mflagsg);
-	upermonst.mflagsg |= (mons[urace.malenum].mflagsg);
-
-	upermonst.mflagsa &= ~(mons[PM_HUMAN].mflagsa);
-	upermonst.mflagsa |= (mons[urace.malenum].mflagsa);
-
-	upermonst.mflagsv &= ~(mons[PM_HUMAN].mflagsv);
-	upermonst.mflagsv |= (mons[urace.malenum].mflagsv);
-	
-	/* Fix up the attacks */
-	/* crude workaround, needs better general solution */
-	if (Race_if(PM_VAMPIRE)) {
-	  for(i = 0; i < NATTK; i++) {
-	    upermonst.mattk[i] = mons[urace.malenum].mattk[i];
-	  }
-	}
-	
+	upermonst = mons[(flags.female && urace.femalenum != NON_PM) ? urace.femalenum : urace.malenum];
 	set_uasmon();
 }
 

--- a/src/potion.c
+++ b/src/potion.c
@@ -748,7 +748,7 @@ peffects(otmp)
 		} else {
 		    self_invis_message();
 		}
-		if (otmp->blessed) HInvis |= FROMOUTSIDE;
+		if (otmp->blessed) HInvis |= TIMEOUT_INF;
 		else incr_itimeout(&HInvis, rn1(15,31));
 		newsym(u.ux,u.uy);	/* update position */
 		if(otmp->cursed) {
@@ -789,7 +789,7 @@ peffects(otmp)
 				change_uinsight(1);
 		}
 		if (otmp->blessed)
-			HSee_invisible |= FROMOUTSIDE;
+			HSee_invisible |= TIMEOUT_INF;
 		else
 			incr_itimeout(&HSee_invisible, rn1(100,750));
 		set_mimic_blocking(); /* do special mimic handling */
@@ -954,7 +954,7 @@ peffects(otmp)
 				Your("quickness feels more natural.");
 				unkn++;
 			}
-			HFast |= FROMOUTSIDE;
+			HFast |= TIMEOUT_INF;
 	    } else nothing++;
 		exercise(A_DEX, TRUE);
 	break;

--- a/src/pray.c
+++ b/src/pray.c
@@ -2854,7 +2854,7 @@ dosacrifice()
 			pline("So this is how you repay loyalty?");
 			adjalign(-3);
 			value = -1;
-			HAggravate_monster |= FROMOUTSIDE;
+			HAggravate_monster |= TIMEOUT_INF;
 		} else if (is_undead(ptr)) { /* Not demons--no demon corpses */
 			if (u.ualign.type != A_CHAOTIC)
 			value += 1;
@@ -4072,7 +4072,7 @@ aligntyp alignment;
 			case 3: // give an intrinsic for 500-1500 turns, first of pois/slee/fire/cold/shock
 				timeout = rn1(1000, 500);
 
-				if(!(HPoison_resistance & FROMOUTSIDE)) {
+				if(!(HPoison_resistance & INTRINSIC)) {
 					You_feel(Poison_resistance ? "especially healthy." : "healthy.");
 					HPoison_resistance |= FROMOUTSIDE;
 					break;

--- a/src/seduce.c
+++ b/src/seduce.c
@@ -2258,25 +2258,25 @@ int effect_num;
 			break;
 
 		case SEDU_POISRES:
-			if (!(HPoison_resistance & FROMOUTSIDE)) {
+			if (!(HPoison_resistance & INTRINSIC)) {
 				You_feel("healthy.");
-				HPoison_resistance |= FROMOUTSIDE;
+				HPoison_resistance |= TIMEOUT_INF;
 			}
 			else pline("but that's about it.");
 			break;
 		case SEDU_ACIDRES:
-			if (!(HAcid_resistance & FROMOUTSIDE)) {
+			if (!(HAcid_resistance & INTRINSIC)) {
 				if (Hallucination) You("like you've gone back to the basics.");
 				else Your("health seems insoluble.");
-				HAcid_resistance |= FROMOUTSIDE;
+				HAcid_resistance |= TIMEOUT_INF;
 			}
 			else pline("but that's about it.");
 			break;
 		case SEDU_SICKRES:
-			if (!(HSick_resistance & FROMOUTSIDE) && !rn2(4)) {
+			if (!(HSick_resistance & INTRINSIC) && !rn2(4)) {
 				You(Hallucination ? "feel alright." :
 					"feel healthier than you ever have before.");
-				HSick_resistance |= FROMOUTSIDE;
+				HSick_resistance |= TIMEOUT_INF;
 			}
 			else pline("but that's about it.");
 			break;

--- a/src/sit.c
+++ b/src/sit.c
@@ -382,7 +382,7 @@ dosit()
 					}
 				} else  {
 					Your("vision becomes clear.");
-					HSee_invisible |= FROMOUTSIDE;
+					HSee_invisible |= TIMEOUT_INF;
 					newsym(u.ux, u.uy);
 				}
 				break;
@@ -683,66 +683,63 @@ register struct monst *mtmp;
 	return FALSE;
 }
 
+/* remove a random INTRINSIC ability
+ * that was gained via eating corpses
+ * or some other re-appliable source */
 void
-attrcurse()			/* remove a random INTRINSIC ability */
+attrcurse()
 {
-	switch(rnd(11)) {
-	case 1 : if (HFire_resistance & INTRINSIC) {
-			HFire_resistance &= ~INTRINSIC;
+	switch(rnd(10)) {
+	case 1 : if (HFire_resistance & TIMEOUT) {
+			HFire_resistance &= ~TIMEOUT;
 			You_feel("warmer.");
 			break;
 		}
-	case 2 : if (HTeleportation & INTRINSIC) {
-			HTeleportation &= ~INTRINSIC;
+	case 2 : if (HTeleportation & TIMEOUT) {
+			HTeleportation &= ~TIMEOUT;
 			You_feel("less jumpy.");
 			break;
 		}
-	case 3 : if (HPoison_resistance & INTRINSIC) {
-			HPoison_resistance &= ~INTRINSIC;
+	case 3 : if (HPoison_resistance & TIMEOUT) {
+			HPoison_resistance &= ~TIMEOUT;
 			You_feel("a little sick!");
 			break;
 		}
-	case 4 : if (HTelepat & INTRINSIC) {
-			HTelepat &= ~INTRINSIC;
+	case 4 : if (HTelepat & TIMEOUT) {
+			HTelepat &= ~TIMEOUT;
 			if (Blind && !Blind_telepat)
 			    see_monsters();	/* Can't sense mons anymore! */
 			Your("senses fail!");
 			break;
 		}
-	case 5 : if (HCold_resistance & INTRINSIC) {
-			HCold_resistance &= ~INTRINSIC;
+	case 5 : if (HCold_resistance & TIMEOUT) {
+			HCold_resistance &= ~TIMEOUT;
 			You_feel("cooler.");
 			break;
 		}
-	case 6 : if (HInvis & INTRINSIC) {
-			HInvis &= ~INTRINSIC;
+	case 6 : if (HInvis & TIMEOUT) {
+			HInvis &= ~TIMEOUT;
 			You_feel("paranoid.");
 			break;
 		}
-	case 7 : if (HSee_invisible & INTRINSIC) {
-			HSee_invisible &= ~INTRINSIC;
+	case 7 : if (HSee_invisible & TIMEOUT) {
+			HSee_invisible &= ~TIMEOUT;
 			You("%s!", Hallucination ? "tawt you taw a puttie tat"
 						: "thought you saw something");
 			break;
 		}
-	case 8 : if (HFast & INTRINSIC) {
-			HFast &= ~INTRINSIC;
+	case 8 : if (HFast & TIMEOUT) {
+			HFast &= ~TIMEOUT;
 			You_feel("slower.");
 			break;
 		}
-	case 9 : if (HStealth & INTRINSIC) {
-			HStealth &= ~INTRINSIC;
+	case 9 : if (HStealth & TIMEOUT) {
+			HStealth &= ~TIMEOUT;
 			You_feel("clumsy.");
 			break;
 		}
-	case 10: if (HProtection & INTRINSIC) {
-			HProtection &= ~INTRINSIC;
-			u.ublessed = 0; /* fix for C343-189 */
-			You_feel("vulnerable.");
-			break;
-		}
-	case 11: if (HAggravate_monster & INTRINSIC) {
-			HAggravate_monster &= ~INTRINSIC;
+	case 10: if (HAggravate_monster & TIMEOUT) {
+			HAggravate_monster &= ~TIMEOUT;
 			You_feel("less attractive.");
 			break;
 		}

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -1482,7 +1482,7 @@ asGuardian:
 						if (!(HFast & INTRINSIC)) {
 							if (!Fast) You("speed up.");
 							else Your("quickness feels more natural.");
-							HFast |= FROMOUTSIDE;
+							HFast |= TIMEOUT_INF;
 						}
 					}
 					if(distmin(mtmp->mx,mtmp->my,u.ux,u.uy) < 5 && uwep && uwep->oartifact == ART_SINGING_SWORD){
@@ -1668,8 +1668,8 @@ asGuardian:
 					if(!mtmp->mpeaceful && distmin(mtmp->mx,mtmp->my,u.ux,u.uy) < 4 && !u.uinvulnerable){
 						pline("Your body feels leaden!");
 						youmonst.movement -= 12;
-						if ((HFast & FROMOUTSIDE)) {
-							HFast &= ~FROMOUTSIDE;
+						if ((HFast & TIMEOUT_INF)) {
+							HFast &= ~TIMEOUT_INF;
 							if (!Fast) You("slow down.");
 							else Your("quickness feels less natural.");
 						}
@@ -4094,7 +4094,7 @@ int tx,ty;
 					 * not a real monster */
 					pline("So this is how you repay loyalty?");
 					adjalign(-3);
-					HAggravate_monster |= FROMOUTSIDE;
+					HAggravate_monster |= TIMEOUT_INF;
 				} else if (is_unicorn(&mons[otmp->corpsenm])) {
 					int unicalign = sgn((&mons[otmp->corpsenm])->maligntyp);
 

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -675,7 +675,10 @@ nh_timeout()
 			upp->intrinsic++;
 			You("form new eyes.");
 		}
-	    if((upp->intrinsic & TIMEOUT) && !(--upp->intrinsic & TIMEOUT)) {
+		if (!(upp->intrinsic & TIMEOUT_INF)
+			&& (upp->intrinsic & TIMEOUT)
+			&& !(--upp->intrinsic & TIMEOUT)	/* decremented here */
+			){
 		switch(upp - u.uprops){
 		case FIRE_RES:
 			You_feel("warmer!");
@@ -859,9 +862,6 @@ nh_timeout()
 				wake_nearby();
 			    }
 			}
-			/* from outside means slippery ice; don't reset
-			   counter if that's the only fumble reason */
-			HFumbling &= ~FROMOUTSIDE;
 			if (Fumbling)
 			    HFumbling += rnd(20);
 			break;
@@ -2634,12 +2634,16 @@ wiz_timeout_queue()
         for (i = 0; (propname = propertynames[i].prop_name) != 0; ++i) {
             p = propertynames[i].prop_num;
             intrinsic = u.uprops[p].intrinsic;
-            if (intrinsic & TIMEOUT) {
+			if (intrinsic & TIMEOUT_INF) {
+				Sprintf(buf, " %*s    inf", -longestlen, propname);
+				putstr(win, 0, buf);
+			}
+            else if (intrinsic & TIMEOUT) {
                 /* timeout value can be up to 16777215 (0x00ffffff) but
-                   width of 4 digits should result in values lining up
+                   width of 6 digits should result in values lining up
                    almost all the time (if/when they don't, it won't
                    look nice but the information will still be accurate) */
-                Sprintf(buf, " %*s %4ld", -longestlen, propname,
+                Sprintf(buf, " %*s %6ld", -longestlen, propname,
                         (intrinsic & TIMEOUT));
                 putstr(win, 0, buf);
             }

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -2452,27 +2452,38 @@ u_init()
 
 	dungeon_topology.eprecursor_typ = rnd(8);
 	if(Race_if(PM_HALF_DRAGON) && Role_if(PM_NOBLEMAN) && flags.initgend){
-		if(flags.initgend)
-			flags.HDbreath = rn2(2) ? AD_MAGM : AD_COLD;
-		else flags.HDbreath = AD_FIRE;
+		if (rn2(2)) {
+			flags.HDbreath = AD_MAGM;
+			HAntimagic |= (FROMRACE|FROMOUTSIDE);
+		}
+		else {
+			flags.HDbreath = AD_COLD;
+			HCold_resistance |= (FROMRACE|FROMOUTSIDE);
+		}
 	} else switch(rnd(6)){
 		case 1:
 			flags.HDbreath = AD_COLD;
+			HCold_resistance |= (FROMRACE|FROMOUTSIDE);
 		break;
 		case 2:
 			flags.HDbreath = AD_FIRE;
+			HFire_resistance |= (FROMRACE|FROMOUTSIDE);
 		break;
 		case 3:
 			flags.HDbreath = AD_SLEE;
+			HSleep_resistance |= (FROMRACE|FROMOUTSIDE);
 		break;
 		case 4:
 			flags.HDbreath = AD_ELEC;
+			HShock_resistance |= (FROMRACE|FROMOUTSIDE);
 		break;
 		case 5:
 			flags.HDbreath = AD_DRST;
+			HPoison_resistance |= (FROMRACE|FROMOUTSIDE);
 		break;
 		case 6:
 			flags.HDbreath = AD_ACID;
+			HAcid_resistance |= (FROMRACE|FROMOUTSIDE);
 		break;
 	}
 	/* Fix up the alignment quest nemesi */

--- a/src/worn.c
+++ b/src/worn.c
@@ -251,7 +251,7 @@ long mask;
       if(P_BASIC     == OLD_P_SKILL(P_ATTACK_SPELL)) OLD_P_SKILL(P_ATTACK_SPELL) = P_SKILLED;
     }
 	
-	if ((mask & (W_ARM|I_SPECIAL)) == (W_ARM|I_SPECIAL)) {
+	if ((mask & (W_ARM | W_SKIN)) == (W_ARM | W_SKIN)) {
 	    /* restoring saved game; no properties are conferred via skin */
 	    uskin = obj;
 	 /* assert( !uarm ); */

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -5015,7 +5015,7 @@ boolean ranged;
 			) {
 			if(attk->aatyp == AT_VINE && youdef && !HSterile){
 				You_feel("old.");
-				HSterile |= FROMOUTSIDE;
+				HSterile |= TIMEOUT_INF;
 				alt_attk.adtyp = AD_PHYS;
 				/* make attack without hitmsg */
 				return xmeleehurty(magr, mdef, &alt_attk, originalattk, weapon, FALSE, dmg, dieroll, vis, ranged);

--- a/src/zap.c
+++ b/src/zap.c
@@ -2513,7 +2513,7 @@ boolean ordinary;
 		        break;
 		    }
 		    if (ordinary || !rn2(10)) {	/* permanent */
-			HInvis |= FROMOUTSIDE;
+				HInvis |= TIMEOUT_INF;
 		    } else {			/* temporary */
 		    	incr_itimeout(&HInvis, d(obj->spe, 250));
 		    }


### PR DESCRIPTION
* `FROMOUTSIDE` should now be nearly permanent, and semi-permanent 'trinsics are all that gremlins can steal
* Move halfdragon resistances to proper intrinsics, now that they can't be stolen
* Lay ground for using &youmonst more safely by making upermonst represent your race, not a weird amalgam of your race and role.