### PR TITLE
Monsters with alt spellcasting show their spellcasting at end of attack chain

### DIFF
--- a/src/monst.c
+++ b/src/monst.c
@@ -2482,7 +2482,7 @@ then fill new spaces with our spawn!
     MON("Gae Eladrin", S_CHA_ANGEL,//12 /*Needs tile*/
 	LVL(18, 14, 6, 30, -12), (G_PLANES|G_NOCORPSE|G_NOGEN),
 	A(ATTK(AT_WEAP, AD_PHYS, 2, 8), ATTK(AT_XWEP, AD_PHYS, 2, 8), /*Alt attacks: spellcasting, sterility*/
-	  ATTK(AT_VINE, AD_SESN, 4, 8), NO_ATTK, /* Spring: Growing vines, Summer: Pollen/Thorned "fruit" */
+	ATTK(AT_VINE, AD_SESN, 4, 8), ATTK(AT_MAGC, AD_SPEL, 0, 0), /* Spring: Growing vines, Summer: Pollen/Thorned "fruit" */
 	  NO_ATTK, NO_ATTK),					/* Fall: Life drain, Winter: Elemental ice */
 	SIZ(WT_MEDIUM, 350, 0, MS_HUMANOID, MZ_HUMAN), 
 		MR_FIRE|MR_ELEC|MR_COLD|MR_SLEEP|MR_POISON, MR_SLEEP,
@@ -7677,7 +7677,7 @@ is a red right hand
     MON("Lich, the Fiend of Earth", S_LICH,//14 /*Needs encyc entry*//*Needs tile*/
 	LVL_NDR(11, 6, 0, 5, 30, -9), (G_NOCORPSE|G_UNIQ),
 	A(ATTK(AT_TUCH, AD_COLD, 1,10), ATTK(AT_TUCH, AD_PLYS, 1, 10),//Attack routine sometimes replaced by ATTK(AT_MAGC, AD_SPEL, 0, 0)
-	  NO_ATTK, NO_ATTK, NO_ATTK, NO_ATTK),
+	  ATTK(AT_MAGC, AD_SPEL, 0, 0), NO_ATTK, NO_ATTK, NO_ATTK),
 	SIZ(WT_GIGANTIC, 100, 0, MS_MUMBLE, MZ_GIGANTIC),//75% Flare -> paralize -> warp -> death touch
 	MR_COLD|MR_SLEEP|MR_POISON, MR_COLD|MR_STONE,
 	MM_BREATHLESS /*MM*/, MT_HOSTILE|MT_MAGIC|MT_WAITFORU /*MT*/,
@@ -7688,7 +7688,7 @@ is a red right hand
 	A_EXPLICIT(ATTK(AT_WEAP, AD_PHYS, 2, 4), ATTK(AT_XWEP, AD_PHYS, 2, 4),//Attack routine sometimes replaced by ATTK(AT_MAGC, AD_SPEL, 0, 0)
 	  ATTK(AT_MARI, AD_PHYS, 2, 4), ATTK(AT_MARI, AD_PHYS, 2, 4),
 	  ATTK(AT_MARI, AD_PHYS, 2, 4), ATTK(AT_MARI, AD_PHYS, 2, 4),
-	  ATTK(AT_HUGS, AD_WRAP, 4, 6), NO_ATTK, NO_ATTK, NO_ATTK),
+	  ATTK(AT_HUGS, AD_WRAP, 4, 6), ATTK(AT_MAGC, AD_SPEL, 0, 0), NO_ATTK, NO_ATTK),
 	SIZ(WT_GIGANTIC, 400, 0, MS_CUSS, MZ_GIGANTIC), MR_FIRE|MR_COLD|MR_POISON|MR_STONE, 0,//37% Firaga->blind->firaga->blind->firaga->stun->firaga->stun
 	0 /*MM*/, MT_TRAITOR|MT_WAITFORU|MT_COLLECT|MT_STALK|MT_HOSTILE /*MT*/,
 	MB_HUMANOID|MB_SLITHY|MB_POIS|MB_FEMALE /*MB*/, MG_NOTAME|MG_NOPOLY|MG_NASTY|MG_PNAME|MG_INFRAVISIBLE|MG_NOSPELLCOOLDOWN /*MG*/,
@@ -7697,7 +7697,7 @@ is a red right hand
 	LVL_NDR(20, 9, 6, 4, 70, -10), (G_NOCORPSE|G_UNIQ),
 	A(ATTK(AT_TENT, AD_PHYS, 2, 4), ATTK(AT_CLAW, AD_PHYS, 2, 4),//Attack routine sometimes replaced by ATTK(AT_MAGC, AD_SPEL, 0, 0)
 	  ATTK(AT_HUGS, AD_WRAP, 2, 6), ATTK(AT_BITE, AD_PHYS, 5, 4),
-	  ATTK(AT_SPIT, AD_BLND, 0, 0), NO_ATTK),
+	  ATTK(AT_SPIT, AD_BLND, 0, 0), ATTK(AT_MAGC, AD_SPEL, 0, 0)),
 	SIZ(WT_GIGANTIC, 1000, 0, MS_SILENT, MZ_GIGANTIC), MR_POISON|MR_ELEC|MR_STONE, 0,//37% Thundara or 15% blind
 	MM_SWIM|MM_AMPHIBIOUS /*MM*/, MT_WAITFORU|MT_HOSTILE|MT_ANIMAL|MT_CARNIVORE /*MT*/,
 	MB_HUMANOID|MB_NOHANDS|MB_STRONG|MB_MALE /*MB*/, MG_VSLASH|MG_NOTAME|MG_NOPOLY|MG_INFRAVISIBLE|MG_PNAME|MG_NOSPELLCOOLDOWN /*MG*/,
@@ -7706,7 +7706,7 @@ is a red right hand
 	LVL_NDR(13, 9, -6, 5, 90, -10), (G_NOCORPSE|G_UNIQ),
 	A(ATTK(AT_BITE, AD_PHYS, 3, 8), ATTK(AT_BITE, AD_PHYS, 3, 8),//Attack routine sometimes replaced by ATTK(AT_MAGC, AD_SPEL, 0, 0)
 	  ATTK(AT_BITE, AD_PHYS, 3, 8), ATTK(AT_BITE, AD_PHYS, 3, 8),//50% Scourge->Blizzara->Thundara->Fira
-	  NO_ATTK, NO_ATTK),//25% Thunderbolt->poison gas->Ice storm->Flame strike
+	  ATTK(AT_MAGC, AD_SPEL, 0, 0), NO_ATTK),//25% Thunderbolt->poison gas->Ice storm->Flame strike
 	SIZ(WT_GIGANTIC, 1500, 0, MS_ROAR, MZ_GIGANTIC), MR_POISON|MR_ELEC|MR_FIRE|MR_COLD|MR_STONE, MR_POISON,
 	MM_FLY /*MM*/, MT_HOSTILE|MT_CARNIVORE|MT_WAITFORU|MT_GREEDY|MT_JEWELS|MT_MAGIC /*MT*/,
 	MB_ANIMAL|MB_LONGHEAD|MB_WINGS|MB_STRONG|MB_FEMALE|MB_THICK_HIDE|MB_NOHANDS|MB_POIS /*MB*/, MG_NOTAME|MG_NOPOLY|MG_NASTY|MG_PNAME|MG_NOSPELLCOOLDOWN /*MG*/,

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -1801,48 +1801,32 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 		(pa->mtyp == PM_KARY__THE_FIEND_OF_FIRE) ||
 		(pa->mtyp == PM_KRAKEN__THE_FIEND_OF_WATER) ||
 		(pa->mtyp == PM_TIAMAT__THE_FIEND_OF_WIND) ||
-		(pa->mtyp == PM_CHAOS))
-		){
-		// first index -- determine if using the alternate attack set (solo spellcasting)
+		(pa->mtyp == PM_CHAOS) ||
+		(pa->mtyp == PM_GAE_ELADRIN)
+		)){
+		// first index -- determine if only using their spellcasting
 		if (*indexnum == 0){
 			if (
 				(pa->mtyp == PM_LICH__THE_FIEND_OF_EARTH && rn2(4)) ||
 				(pa->mtyp == PM_KARY__THE_FIEND_OF_FIRE && rn2(100)<37) ||
 				(pa->mtyp == PM_KRAKEN__THE_FIEND_OF_WATER && rn2(100)<52) ||
 				(pa->mtyp == PM_TIAMAT__THE_FIEND_OF_WIND && !rn2(4)) ||
-				(pa->mtyp == PM_CHAOS && rn2(3))
+				(pa->mtyp == PM_CHAOS && rn2(3)) ||
+				(pa->mtyp == PM_GAE_ELADRIN && !magr->mcan && !magr->mspec_used && !rn2(3))
 				){
 				*subout |= SUBOUT_SPELLS;
-				attk->aatyp = AT_MAGC;
-				attk->adtyp = AD_SPEL;
-				attk->damn = 0;
-				attk->damd = 0;
 			}
 		}
-		else if (*subout&SUBOUT_SPELLS){
-			/* If spellcasting, stop after the first index */
-			return &noattack;
+		/* cast only spells if SUBOUT_SPELLS; cast no spells if !SUBOUT_SPELLS */
+		if (!is_null_attk(attk) && ((attk->aatyp == AT_MAGC) == !(*subout&SUBOUT_SPELLS))) {
+			/* just get the next attack */
+			*indexnum += 1;
+			*prev_and_buf = prev_attack;
+			fromlist = TRUE;
+			return getattk(magr, mdef, prev_res, indexnum, prev_and_buf, by_the_book, subout, tohitmod);
 		}
 	}
-	if(!by_the_book && pa->mtyp == PM_GAE_ELADRIN){
-		// first index -- determine if using the alternate attack set (solo spellcasting)
-		if (*indexnum == 0){
-			if (!magr->mcan
-				&& !magr->mspec_used
-				&& !rn2(3)
-			){
-				*subout |= SUBOUT_SPELLS;
-				attk->aatyp = AT_MAGC;
-				attk->adtyp = AD_CLRC;
-				attk->damn = 0;
-				attk->damd = 6;
-			}
-		}
-		else if (*subout&SUBOUT_SPELLS){
-			/* If spellcasting, stop after the first index */
-			return &noattack;
-		}
-	}
+	/* Nitocris uses clerical spells while wearing their Prayer-Warded Wrappings */
 	if(!by_the_book && pa->mtyp == PM_NITOCRIS){
 		if (attk->aatyp == AT_MAGC){
 			if (which_armor(magr, W_ARMC) && which_armor(magr, W_ARMC)->oartifact == ART_PRAYER_WARDED_WRAPPINGS_OF){


### PR DESCRIPTION
Instead of sometimes substituting their attacks with a single AT_MAGC, which isn't shown in the pokedex entry, put the AT_MAGC attack at the end of their chain. Then, when doing the check that previously would have done the total substitution, instead choose whether to do NO spellcasting or ONLY spellcasting.

This also gives them a reason to attempt to search for ranged targets. Previously, they were able to cast ranged magic if they had some other cause to (like Kraken's spit attack).