### PR TITLE
Fix findtravelpath() going back and forth

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -410,7 +410,7 @@ struct instance_flags {
 	boolean  lootabc;	/* use "a/b/c" rather than "o/i/b" when looting */
 	boolean  showrace;	/* show hero glyph by race rather than by role */
 	boolean  travelcmd;	/* allow travel command */
-	boolean  travelplus;/* if travel command should attempt to path through the unknown */
+	int  travelplus;/* how far travel command should attempt to path through the unknown */
 	int	 runmode;	/* update screen display during run moves */
 #ifdef AUTOPICKUP_EXCEPTIONS
 	struct autopickup_exception *autopickup_exceptions[2];

--- a/include/flag.h
+++ b/include/flag.h
@@ -410,6 +410,7 @@ struct instance_flags {
 	boolean  lootabc;	/* use "a/b/c" rather than "o/i/b" when looting */
 	boolean  showrace;	/* show hero glyph by race rather than by role */
 	boolean  travelcmd;	/* allow travel command */
+	boolean  travelplus;/* if travel command should attempt to path through the unknown */
 	int	 runmode;	/* update screen display during run moves */
 #ifdef AUTOPICKUP_EXCEPTIONS
 	struct autopickup_exception *autopickup_exceptions[2];

--- a/include/you.h
+++ b/include/you.h
@@ -279,6 +279,7 @@ struct you {
 	schar dx, dy, dz;	/* direction of move (or zap or ... ) */
 	schar di;		/* direction of FF */
 	xchar tx, ty;		/* destination of travel */
+	xchar itx, ity;		/* intermediary travel destination */
 	xchar ux0, uy0;		/* initial position FF */
 	d_level uz, uz0;	/* your level on this and the previous turn */
 	d_level utolev;		/* level monster teleported you to, or uz */

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -6283,6 +6283,7 @@ register char *cmd;
 	    multi = 0;
 	} else if (*cmd == CMD_TRAVEL && iflags.travelcmd) {
 	  flags.travel = 1;
+	  u.itx = u.ity = 0;
 	  iflags.travel1 = 1;
 	  flags.run = 8;
 	  flags.nopick = 1;

--- a/src/hack.c
+++ b/src/hack.c
@@ -821,9 +821,9 @@ boolean guess;
 	int radius = 1;			/* search radius */
 	int i;
 
-	/* If guessing, first find an "obvious" goal location.  The obvious
-	 * goal is the position the player knows of, or might figure out
-	 * (couldsee) that is closest to the target on a straight path.
+	/* If guessing, first find an "obvious" goal location.
+	 * The player must be able to path there successfully
+	 * with findtravelpath(FALSE).
 	 */
 	if (guess) {
 	    tx = u.ux; ty = u.uy; ux = u.tx; uy = u.ty;
@@ -904,14 +904,14 @@ boolean guess;
 		for (ty = 0; ty < ROWNO; ++ty)
 		    if (travel[tx][ty]) {
 			nxtdist = distmin(ux, uy, tx, ty);
-			if (nxtdist == dist && couldsee(tx, ty)) {
+			if (nxtdist == dist) {
 			    nd2 = dist2(ux, uy, tx, ty);
 			    if (nd2 < d2) {
 				/* prefer non-zigzag path */
 				px = tx; py = ty;
 				d2 = nd2;
 			    }
-			} else if (nxtdist < dist && couldsee(tx, ty)) {
+			} else if (nxtdist < dist) {
 			    px = tx; py = ty;
 			    dist = nxtdist;
 			    d2 = dist2(ux, uy, tx, ty);

--- a/src/hack.c
+++ b/src/hack.c
@@ -837,7 +837,6 @@ boolean guess;
 	(void) memset((genericptr_t)travel, 0, sizeof(travel));
 	travelstepx[0][0] = tx;
 	travelstepy[0][0] = ty;
-
 	while (n != 0) {
 	    int nn = 0;
 
@@ -853,7 +852,13 @@ boolean guess;
 		    int nx = x+xdir[ordered[dir]];
 		    int ny = y+ydir[ordered[dir]];
 
+			/* don't go out of bounds */
 		    if (!isok(nx, ny)) continue;
+
+			/* don't go through places we know we can't */
+			if (!test_move(x, y, nx-x, ny-y, TEST_TRAV) && levl[nx][ny].seenv)
+				continue;
+
 		    if ((!Passes_walls && !can_ooze(&youmonst) &&
 			closed_door(x, y)) || boulder_at(x, y)) {
 			/* closed doors and boulders usually
@@ -866,8 +871,8 @@ boolean guess;
 			    continue;
 			}
 		    }
-		    if (test_move(x, y, nx-x, ny-y, TEST_TRAV) &&
-			(levl[nx][ny].seenv || (!Blind && couldsee(nx, ny)))) {
+			/* travelplus is a bit adventerous, and will hope that unseen locations are pathable */
+		    if (iflags.travelplus || levl[nx][ny].seenv) {
 			if (nx == ux && ny == uy) {
 			    if (!guess) {
 				u.dx = x-ux;
@@ -889,14 +894,13 @@ boolean guess;
 		    }
 		}
 	    }
-	    
 	    n = nn;
 	    set = 1-set;
 	    radius++;
 	}
 
 	/* if guessing, find best location in travel matrix and go there */
-	if (guess) {
+	if (guess && !iflags.travelplus) {
 	    int px = tx, py = ty;	/* pick location */
 	    int dist, idist, nxtdist, d2, id2, nd2;
 

--- a/src/hack.c
+++ b/src/hack.c
@@ -889,7 +889,7 @@ boolean guess;
 				return TRUE;
 			    }
 			}
-			else if (!suretravel[nx][ny] && levl[nx][ny].seenv && suretravel[nx-x][ny-y]) {
+			else if (!suretravel[nx][ny] && levl[nx][ny].seenv && suretravel[x][y]) {
 				/* we are now sure of this step (because the previous step was) */
 			    travelstepx[1-set][nn] = nx;
 			    travelstepy[1-set][nn] = ny;

--- a/src/hack.c
+++ b/src/hack.c
@@ -917,14 +917,14 @@ boolean guess;
 		for (ty = 0; ty < ROWNO; ++ty)
 		    if (travel[tx][ty]) {
 			nxtdist = distmin(ux, uy, tx, ty);
-			if (nxtdist == dist && couldsee(tx, ty)) {
+			if (nxtdist == dist && (couldsee(tx, ty) || iflags.travelplus)) {
 			    nd2 = dist2(ux, uy, tx, ty);
 			    if (nd2 < d2) {
 				/* prefer non-zigzag path */
 				px = tx; py = ty;
 				d2 = nd2;
 			    }
-			} else if (nxtdist < dist && couldsee(tx, ty)) {
+			} else if (nxtdist < dist && (couldsee(tx, ty) || iflags.travelplus)) {
 			    px = tx; py = ty;
 			    dist = nxtdist;
 			    d2 = dist2(ux, uy, tx, ty);

--- a/src/options.c
+++ b/src/options.c
@@ -278,7 +278,6 @@ static struct Bool_Opt
 	{"tombstone",&flags.tombstone, TRUE, SET_IN_GAME},
 	{"toptenwin",&flags.toptenwin, FALSE, SET_IN_GAME},
 	{"travel", &iflags.travelcmd, TRUE, SET_IN_GAME},
-	{"travelplus", &iflags.travelplus, FALSE, SET_IN_GAME},
 #ifdef UTF8_GLYPHS
 	{"UTF8graphics", &iflags.UTF8graphics, FALSE, SET_IN_GAME},
 #else
@@ -447,6 +446,7 @@ static struct Comp_Opt
 	{ "tile_file", "name of tile file", 70, DISP_IN_GAME},	/*WC*/
 	{ "traps",    "the symbols to use in drawing traps",
 						MAXTCHARS+1, SET_IN_FILE },
+	{ "travelplus", "maximum unknown-explore distance when traveling", 32, SET_IN_GAME},
 	{ "vary_msgcount", "show more old messages at a time", 20, DISP_IN_GAME }, /*WC*/
 #ifdef MSDOS
 	{ "video",    "method of video updating", 20, SET_IN_FILE },
@@ -637,6 +637,7 @@ initoptions()
 	flags.end_own = FALSE;
 	flags.end_top = 3;
 	flags.end_around = 2;
+	iflags.travelplus = 0;
 	iflags.runmode = RUN_LEAP;
 	iflags.pokedex = POKEDEX_SHOW_DEFAULT;
 	iflags.msg_history = 20;
@@ -2733,6 +2734,15 @@ goodfruit:
 		return;
 	}
 	
+	fullname = "travelplus";
+	if (match_optname(opts, fullname, 7, TRUE)) {
+		op = string_for_opt(opts, negated);
+		if ((negated && !op) || (!negated && op)) {
+			iflags.travelplus = negated ? 0 : atoi(op);
+		} else if (negated) bad_negation(fullname, TRUE);
+		return;
+	}
+
 #ifdef VIDEOSHADES
 	/* videocolors:string */
 	fullname = "videocolors";
@@ -4202,6 +4212,8 @@ char *buf;
 	}
 	else if (!strcmp(optname, "traps"))
 		Sprintf(buf, "%s", to_be_done);
+	else if (!strcmp(optname, "travelplus"))
+		Sprintf(buf, "%d", iflags.travelplus);
 	else if (!strcmp(optname, "vary_msgcount")) {
 		if (iflags.wc_vary_msgcount) Sprintf(buf, "%d",iflags.wc_vary_msgcount);
 		else Strcpy(buf, defopt);

--- a/src/options.c
+++ b/src/options.c
@@ -278,6 +278,7 @@ static struct Bool_Opt
 	{"tombstone",&flags.tombstone, TRUE, SET_IN_GAME},
 	{"toptenwin",&flags.toptenwin, FALSE, SET_IN_GAME},
 	{"travel", &iflags.travelcmd, TRUE, SET_IN_GAME},
+	{"travelplus", &iflags.travelplus, FALSE, SET_IN_GAME},
 #ifdef UTF8_GLYPHS
 	{"UTF8graphics", &iflags.UTF8graphics, FALSE, SET_IN_GAME},
 #else


### PR DESCRIPTION
This happened when the following occurred:
1) you tried to travel to somewhere you did not have a clear path to (blocked off, or unexplored tiles in the way)
2) there was an intermediary location, closer to your target, that *could be reached*, in LoS
3) the path to reach that intermediary location brought you further away from your original target AND broke LoS to your intermediary location

Simply dropping the LoS requirement fixes findtravelpath(), which is what this first commit does.

I am exploring the possibility of re-enforcing the LoS requirement when picking intermediary locations, but saving a single intermediary location to `u` so that it can only pick better intermediaries (because LoS changes as you move).