### PR TITLE
Fix drain-pw bad seduce effect

### DIFF
--- a/src/seduce.c
+++ b/src/seduce.c
@@ -1814,7 +1814,8 @@ int effect_num;
 		{
 		case SEDU_DRAINEN:
 			You_feel("drained of energy.");
-			drain_en(u.uen * 99 / 100);
+			if (u.uen > 0)
+				losepw(u.uen * 99 / 100);
 			tmp = (greater || greatest ? 90 : 10) / (Half_physical_damage ? 2 : 1);
 			u.uenbonus -= rnd(tmp);
 			exercise(A_CON, FALSE);


### PR DESCRIPTION
Use correct function (drain_en() is for antimagic traps, losepw() is general).
Don't restore pw to fainting incantifiers.