### PR TITLE
Actually truncate initmap rooms overlapped by .des maps

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1334,7 +1334,7 @@ E void NDECL(mkinvokearea);
 /* ### mkmap.c ### */
 
 void FDECL(flood_fill_rm, (int,int,int,BOOLEAN_P,BOOLEAN_P));
-void FDECL(remove_rooms, (int,int,int,int));
+void FDECL(remove_rooms, (int,int,int,int,SCHAR_P));
 void FDECL(remove_room, (unsigned));
 
 /* ### mkmaze.c ### */

--- a/src/mkmap.c
+++ b/src/mkmap.c
@@ -371,10 +371,11 @@ finish_map(fg_typ, bg_typ, lit, walled)
  * region are all set.
  */
 void
-remove_rooms(lx, ly, hx, hy)
-    int lx, ly, hx, hy;
+remove_rooms(lx, ly, hx, hy, bg_typ)
+int lx, ly, hx, hy;
+schar bg_typ;
 {
-    int i;
+	int i;
     struct mkroom *croom;
 
     for (i = nroom - 1; i >= 0; --i) {
@@ -384,9 +385,31 @@ remove_rooms(lx, ly, hx, hy)
 
 	if (croom->lx < lx || croom->hx >= hx ||
 	    croom->ly < ly || croom->hy >= hy) { /* partial overlap */
-	    /* TODO: ensure remaining parts of room are still joined */
+		/* change room boundaries */
+		if (croom->lx < lx)
+			croom->hx = lx-1;
+		if (croom->ly < ly)
+			croom->hy = ly-1;
+		if (croom->hx >= hx)
+			croom->lx = hx;
+		if (croom->hy >= hy)
+			croom->ly = hy;
 
-	    if (!croom->irregular) impossible("regular room in joined map");
+		if (!croom->irregular) impossible("regular room in joined map");
+
+		/* if this clobbered the room, remove it */
+		register int x;
+		register int y;
+		register int n;
+		n = 0;
+		for (x = croom->lx; x < croom->hx; x++)
+		for (y = croom->ly; y < croom->hy; y++)
+		if (levl[x][y].typ != bg_typ)
+			n++;
+		if (!n)
+			remove_room((unsigned)i);
+
+	    /* TODO: ensure remaining parts of room are still joined */
 	} else {
 	    /* total overlap, remove the room */
 	    remove_room((unsigned)i);

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2536,7 +2536,7 @@ dlb *fd;
 		    Map[x][y] = 1;
 		}
 	    if (init_lev.init_present && init_lev.joined)
-		remove_rooms(xstart, ystart, xstart+xsize, ystart+ysize);
+		remove_rooms(xstart, ystart, xstart+xsize, ystart+ysize, init_lev.bg);
 	}
 
 	Fread((genericptr_t) &n, 1, sizeof(n), fd);


### PR DESCRIPTION
This doesn't fix the TODO of actually checking that the maps are still joined, but that's definitely a SMOP.
`remove_rooms()` is run before any mazewalks are done, which means even if the .des will connect the rooms via a mazewalk, a check done in `remove_rooms()` will fail. I would also be worried about side effects.

This does appear to prevent any rooms from surviving on the right of the spire. There are still occasional `room` tiles, but since they aren't part of formal rooms, they won't be considered as valid when placing the Dispensary branchstairs.