### PR TITLE
Don't print "Use the command #monster to speak a word of power" on polyself

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -262,6 +262,7 @@ E void NDECL(add_debug_extended_commands);
 #endif /* WIZARD */
 E void FDECL(rhack, (char *));
 E void NDECL(dokeylist);
+E char * FDECL(find_command_key, (const char *, char *));
 E int NDECL(doextlist);
 E int NDECL(extcmd_via_menu);
 E void FDECL(enlightenment, (int));

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5667,6 +5667,43 @@ dokeylist(void)
 	destroy_nhwindow(datawin);
 }
 
+/* find the 1st command key that binds to the desired command */
+char *
+find_command_key(command_name, buf)
+const char * command_name;
+char * buf;
+{
+	int i;
+	int key;
+	boolean keys_used[256] = { 0 };
+
+	/* kludge: copy from above to find all keys used by non-commands */
+	for (i = 0; i < 10; i++) {
+		key = iflags.num_pad ? ndir[i] : sdir[i];
+		keys_used[key] = TRUE;
+		if (!iflags.num_pad) {
+			keys_used[toupper(key)] = TRUE;
+			keys_used[C(key)] = TRUE;
+		}
+	}
+	for (i = 0; i < MISC_CMD_COUNT; i++) {
+		keys_used[misc_cmds[i]] = TRUE;
+	}
+
+	for (i = 0; i <= 255; i++) {
+		struct ext_func_tab * extcmd;
+		char* mapping;
+		key = i;
+		if (keys_used[i]) continue;
+		if (key == ' ' && !flags.rest_on_space) continue;
+		if ((extcmd = cmdlist[i].bind_cmd)) {
+			if (!strcmpi(extcmd->ef_txt, command_name))
+				return key2txt(key, buf);
+		}
+	}
+	return (char *)0;
+}
+
 static const char template[] = "%-18s %4ld  %6ld";
 static const char count_str[] = "                   count  bytes";
 static const char separator[] = "------------------ -----  ------";

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -609,8 +609,6 @@ int	mntmp;
 	if (flags.verbose) {
 	    static const char use_thec[] = "Use the command #%s to %s.";
 	    static const char monsterc[] = "monster";
-	    if (u.ufirst_light || u.ufirst_sky || u.ufirst_life || u.ufirst_know)
-		pline(use_thec,monsterc,"speak a word of power");
 #ifdef YOUMONST_SPELL
 	    if (attacktype(youmonst.data, AT_MAGC))
 		pline(use_thec,monsterc,"cast monster spells");

--- a/src/read.c
+++ b/src/read.c
@@ -781,6 +781,16 @@ learn_word()
 			u.ufirst_know_timeout = 0;
 		break;
 	}
+	if (flags.verbose) {
+		char buf[BUFSZ];
+		char buf2[BUFSZ];
+		char * ptr;
+		if (ptr = find_command_key("ability", buf))
+			Sprintf(buf2, "or %s ", ptr);
+		else
+			Strcpy(buf2, "");
+		pline("Use the command #ability %sto speak it.", buf2);
+	}
 	//Note: the word of knowledge can't actually give the mithardir trophy, but it's harmless to check.
 	check_mithardir_trophy();
 	check_illumian_trophy();


### PR DESCRIPTION
Instead, prompt after learning each word of power.

New feature function: `find_command_key()`.
Given an extcmd name (ie `monster` for `#monster`) and a char buffer, returns a string containing the 1st keybinding found for it, if there was one, stored in the given char buffer.