### PR TITLE
When given your quest, discover your quest artifact

### DIFF
--- a/src/quest.c
+++ b/src/quest.c
@@ -376,6 +376,8 @@ chat_with_leader()
 				Your("%s chains itself to you!", xname(obj));
 			}
 		}
+		/* you now know what you're looking for */
+		discover_artifact(urole.questarti);
 	  }
 	}
 }


### PR DESCRIPTION
Applied generically to all quests; I'm pretty sure all your starting quest texts talk about the artifact you are supposed to retrieve.

Notably does not apply to turning stag -- those texts don't describe your new quest artifact. (or at least, it doesn't for Hedrow Rogue turning stag).