### PR TITLE
All ammo in trap should have otrap set

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -910,8 +910,11 @@ boolean ghostly;
 	       trap->tx != 0) {	/* need "!= 0" to work around DICE 3.0 bug */
 		/* if there's a stale pointer, we need to reload the old saved ammo */
 		if (trap->ammo) {
-			if ((trap->ammo = restobjchn(fd, ghostly, FALSE)))
-				trap->ammo->otrap = trap;	/* only set it if we found an ammo item */
+			struct obj * obj;
+			trap->ammo = restobjchn(fd, ghostly, FALSE);
+			/* restore trap back pointer */
+			for (obj = trap->ammo; obj; obj = obj->nobj)
+				obj->otrap = trap;
 		}
 		trap->ntrap = ftrap;
 		ftrap = trap;


### PR DESCRIPTION
This is currently moot as all traps have at most a single object, but this could have been a hair-puller in the far future.