### PR TITLE
Grappler's Grasp fixes

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3412,8 +3412,8 @@ boolean * messaged;
 
 	/* The Grappler's Grasp has a chance to begin grapples.  */
 	if (oartifact == ART_GRAPPLER_S_GRASP) {
-		/* cannot begin a grapple -- Damage is done by adding an AT_HUGS to your attack chain, NOT here. */
-		if ((youagr || youdef) && !u.ustuck)
+		/* check if we can begin a grapple -- Damage is done by adding an AT_HUGS to your attack chain, NOT here. */
+		if ((youagr || youdef) && !u.ustuck && !sticks(mdef))
 		{
 			int newres = xmeleehurty(magr, mdef, &grapple, &grapple, otmp, (youagr || youdef), 0, dieroll, -1, FALSE);
 

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -2075,7 +2075,9 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 	/* creatures wearing the Grappler's Grasp and currently grappling something get a hug attack if they don't have one already */
 	if (is_null_attk(attk) && !by_the_book && !dmgtype(pa, AT_HUGS) && !(*subout&SUBOUT_GRAPPLE)) {
 		struct obj * otmp = (youagr ? uarmg : which_armor(magr, W_ARMG));
-		if (otmp && otmp->oartifact == ART_GRAPPLER_S_GRASP) {
+		/* magr must already have hold of mdef, however, which makes it much less useful mvm */
+		if (otmp && otmp->oartifact == ART_GRAPPLER_S_GRASP &&
+			((youagr || youdef) && !u.uswallow && u.ustuck && u.ustuck == (youagr ? mdef : magr))) {
 			*attk = grapple;
 			attk->damn = youagr ? ((P_SKILL(P_BARE_HANDED_COMBAT) + 1) / 2 + martial_bonus()) : 2;
 			*subout |= SUBOUT_GRAPPLE;


### PR DESCRIPTION
1) Only attempt to make grab attacks on grabbable targets
2) Only make crushing attack if the defender has been grabbed