### PR TITLE
Fix targeting for mass cure close and friends

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -4861,8 +4861,14 @@ int tary;
 	struct monst *tmpm;
 	/* Most spells need a target */
 	boolean notarget = (!mdef || (!tarx && !tary));
-	if (notarget && !is_undirected_spell(spellnum))
-		return TRUE;
+	if (notarget) {
+		if (!is_undirected_spell(spellnum))
+			return TRUE;
+		else {
+			tarx = x(magr);
+			tary = y(magr);
+		}
+	}
 
 	/* Some spells work with a valid line of sight */
 	boolean clearpath = clear_path(x(magr), y(magr), tarx, tary);

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -4862,9 +4862,12 @@ int tary;
 	/* Most spells need a target */
 	boolean notarget = (!mdef || (!tarx && !tary));
 	if (notarget) {
-		if (!is_undirected_spell(spellnum))
+		/* most spells need a target */
+		if (!is_undirected_spell(spellnum) && !is_buff_spell(spellnum)) {
 			return TRUE;
+		}
 		else {
+			/* undirected spells, or directed buff spells with no target, are instead self-targeted */
 			tarx = x(magr);
 			tary = y(magr);
 		}


### PR DESCRIPTION
The check for "is this useless" was trying to center the spell around (0,0), not the caster's location.