### PR TITLE
Fix glass/rock rocks generated by polymorph

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -1740,11 +1740,10 @@ poly_obj(obj, id)
 		break;
 
 	case GEM_CLASS:
-	    if (otmp->quan > (long) rnd(4) &&
-		    obj->obj_material == MINERAL &&
-		    otmp->obj_material != MINERAL) {
-		otmp->otyp = ROCK;	/* transmutation backfired */
-		otmp->quan /= 2L;	/* some material has been lost */
+	    if (otmp->quan > (long)rnd(4) && obj->obj_material == MINERAL && otmp->obj_material != MINERAL) {
+			otmp->otyp = ROCK;	/* transmutation backfired */
+			set_material_gm(otmp, MINERAL);
+			otmp->quan /= 2L;	/* some material has been lost */
 	    }
 	    break;
 	}


### PR DESCRIPTION
If a gem becomes a rock (doable by polymorphing it) it doesn't reset the material correctly. This can lead to glass becoming "glass rocks", or gems becoming "rock rocks".