### PR TITLE
Fix buffer overflow when adding cmds

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5326,10 +5326,12 @@ struct ext_func_tab extcmdlist[] = {
 	{(char *)0, (char *)0, donull, TRUE}, /* #portdebug */
 #endif
 	{(char *)0, (char *)0, donull, TRUE}, /* #seenv */
-	{(char *)0, (char *)0, donull, TRUE}, /* #showkills (showborn patch) */
 	{(char *)0, (char *)0, donull, TRUE}, /* #stats */
 	{(char *)0, (char *)0, donull, TRUE}, /* #timeout */
 	{(char *)0, (char *)0, donull, TRUE}, /* #vision */
+	{(char *)0, (char *)0, donull, TRUE}, /* #showkills (showborn patch) */
+	{(char *)0, (char *)0, donull, TRUE}, /* #setinsight */
+	{(char *)0, (char *)0, donull, TRUE}, /* #setsanity */
 	{(char *)0, (char *)0, donull, TRUE}, /* #dump_map */
 #ifdef DEBUG
 	{(char *)0, (char *)0, donull, TRUE}, /* #wizdebug */


### PR DESCRIPTION
There were missing entries for some of the extended commands that get
added if the player is in wizard mode, causing adding the debug commands
to overflow the buffer.

Additionally moves a comment such that the null entries' comments are in
consistent order with the command entries themselves.