### PR TITLE
Move global curses declarations from .h to .c

### DIFF
--- a/include/wincurs.h
+++ b/include/wincurs.h
@@ -3,16 +3,15 @@
 
 /* Global declarations for curses interface */
 
-int term_rows, term_cols; /* size of underlying terminal */
+extern int term_rows, term_cols; /* size of underlying terminal */
 
-WINDOW *base_term;    /* underlying terminal window */
+extern WINDOW *base_term;    /* underlying terminal window */
 
-WINDOW *mapwin, *statuswin, *messagewin;    /* Main windows */
+extern WINDOW *mapwin, *statuswin, *messagewin;    /* Main windows */
 
-int orig_cursor;	/* Preserve initial cursor state */
+extern int orig_cursor;	/* Preserve initial cursor state */
 
-boolean counting;   /* Count window is active */
-
+extern boolean counting;   /* Count window is active */
 
 #define TEXTCOLOR   /* Allow color */
 #define NHW_END 19

--- a/win/curses/cursinit.c
+++ b/win/curses/cursinit.c
@@ -8,6 +8,15 @@
 
 #include <ctype.h>
 
+/* Global curses variables extern'd in wincurs.h */
+boolean counting;
+int orig_cursor;	         /* Preserve initial cursor state */
+int term_rows, term_cols; /* size of underlying terminal */
+
+WINDOW *base_term;    /* underlying terminal window */
+
+WINDOW *mapwin, *statuswin, *messagewin;    /* Main windows */
+
 /* Initialization and startup functions for curses interface */
 
 /* Private declarations */


### PR DESCRIPTION
These declarations were occurring multiple times during compilation,
when they should occur only once.

Fixes compiling in gcc 10 without setting -fcommon in the flags