### PR TITLE
Always keep mvar_vector >=0

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1369,7 +1369,7 @@ karemade:
 				if(mtmp->mtyp == PM_CLOCKWORK_SOLDIER || mtmp->mtyp == PM_CLOCKWORK_DWARF || 
 				   mtmp->mtyp == PM_FABERGE_SPHERE || mtmp->mtyp == PM_FIREWORK_CART ||
 				   mtmp->mtyp == PM_ID_JUGGERNAUT
-				) if(rn2(2)) mtmp->mvar_vector = ((int)mtmp->mvar_vector + rn2(3)-1)%8;
+				) if(rn2(2)) mtmp->mvar_vector = ((int)mtmp->mvar_vector + rn2(3) + 7)%8;
 				if((mtmp->mtyp == PM_JUGGERNAUT || mtmp->mtyp == PM_ID_JUGGERNAUT) && !rn2(3)){
 					int mdx=0, mdy=0, i;
 					if(mtmp->mux == 0 && mtmp->muy == 0){

--- a/src/mon.c
+++ b/src/mon.c
@@ -3687,8 +3687,8 @@ register int x,y;
 		else if(rn2(2) && mon->mx + xdir[((int)mon->mvar_vector + 1)%8] == x && 
 		   mon->my + ydir[((int)mon->mvar_vector + 1)%8] == y 
 		) return (!rn2(2) && (distance < 3));
-		else if(mon->mx + xdir[((int)mon->mvar_vector - 1)%8] == x && 
-		   mon->my + ydir[((int)mon->mvar_vector - 1)%8] == y 
+		else if(mon->mx + xdir[((int)mon->mvar_vector + 7)%8] == x && 
+		   mon->my + ydir[((int)mon->mvar_vector + 7)%8] == y 
 		) return (!rn2(2) && (distance < 3));
 		else return 0;
 	}


### PR DESCRIPTION
We intend to keep `mvar_vector` in the bounds of [0, 7].
But,
`(0-1)%8` is not equivalent to `(0+8-1)%8` or `(0+7)%8`.
The first results in `-1`, which gives us out-of-bound array indices. The latter two correctly give `7`.