### PR TITLE
Destroy nhwin after #ability early return

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -660,6 +660,7 @@ boolean you_abilities;
 		else {
 			pline("You are extraordinary mundane.");
 		}
+		destroy_nhwindow(tmpwin);
 		return 0;
 	}
 	


### PR DESCRIPTION
The tmpwin set up doesn't get torn down upon an early exit from the
function.

Simply calling #ability 20 times without having any abilities causes
a panic.