### PR TITLE
Catch out of bounds array read

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -82,7 +82,7 @@ register struct obj *otmp;
 	    (('a' <= i && i <= 'z') || ('A' <= i && i <= 'Z')))
 		return;
 	for(i = lastinvnr+1; i != lastinvnr; i++) {
-		if(i == 52) { i = -1; continue; }
+		if(i >= 52) { i = -1; continue; }
 		if(!inuse[i]) break;
 	}
 	otmp->invlet = (inuse[i] ? NOINVSYM :


### PR DESCRIPTION
If lastinvnr is 52 or greater here, the loop continues to increment i
until a stack overflow is thrown or it reads a 0

This can happen if an inventory reassign occurs with a lot of items
in the item chain