### PR TITLE
Guard against OOB in mon_in_room

### DIFF
--- a/src/sounds.c
+++ b/src/sounds.c
@@ -220,7 +220,7 @@ int rmtyp;
 {
     int rno = levl[mon->mx][mon->my].roomno;
 
-    return rooms[rno - ROOMOFFSET].rtype == rmtyp;
+    return rno >= ROOMOFFSET && rooms[rno - ROOMOFFSET].rtype == rmtyp;
 }
 
 void


### PR DESCRIPTION
This is just a guard, I'm not sure how it comes up so often during
fuzzing or what the ultimate cause is

I've only ever seen this occur when rno is 0, but just in case I've set
the guard for all left OOB access