### PR TITLE
Prevent overflow in setting directions at start

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -6412,7 +6412,8 @@ char sym;
 	if(iflags.num_pad) sdp = ndir; else sdp = sdir;	/* DICE workaround */
 
 	u.dz = 0;
-	if(!(dp = index(sdp, sym))) return 0;
+	/* sym defaults to null at game start, causing dp - sdp to be 10, overflowing */
+	if(!sym || !(dp = index(sdp, sym))) return 0;
 	u.dx = xdir[dp-sdp];
 	u.dy = ydir[dp-sdp];
 	u.dz = zdir[dp-sdp];


### PR DESCRIPTION
When the game starts the referenced sym defaults to null. When checking
the directions, it searches for a null in the string

It finds the terminator at position 10, causing an OOB access