### PR TITLE
Zero initialise special rooms

### DIFF
--- a/src/mklev.c
+++ b/src/mklev.c
@@ -802,7 +802,7 @@ random_special_room()
 	struct {
 		int type;
 		int prob;
-	} special_rooms[MAXRTYPE];
+	} special_rooms[MAXRTYPE] = {0};
 
 #define mnotgone(x) !(mvitals[(x)].mvflags & G_GONE && !In_quest(&u.uz))
 #define add_rspec_room(t, p, c) if(c) {special_rooms[i].type = (t); special_rooms[i].prob = (p); total_prob += (p); i++;} else


### PR DESCRIPTION
Without this the data in the array can be garbage causing a panic when
making a room with id set to (eg) some large negative value