### PR TITLE
Fix ls bug

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -3799,7 +3799,7 @@ struct permonst *mptr;	/* reflects mtmp->data _prior_ to mtmp's death */
 	mtmp->mhp = 0; /* simplify some tests: force mhp to 0 */
 	relobj(mtmp, 0, FALSE);
 	remove_monster(mtmp->mx, mtmp->my);
-	if (emits_light_mon(mtmp))
+	if (emits_light_mon(mtmp) || emits_light(mptr))	/* TODO: actually check if the monster has an attached ls */
 	    del_light_source(LS_MONSTER, (genericptr_t)mtmp, FALSE);
 	newsym(mtmp->mx,mtmp->my);
 	unstuck(mtmp);


### PR DESCRIPTION
Steps to reproduce bug:
- Turn on monpolycontrol
- ^G a chameleon into yellow light form
- let it die

On death, the chameleon's data is set to `&mons[PM_CHAMELEON]`.
m_detach() was checking mon->data "should this monster emit light".
It was not considering mptr, which would have said "this monster used to emit light".

TODO:
Actually store ls pointers (and timers?) on monsters and objects instead of in the processing chain, so that we can more easily check "does X have an attached lightsource"