### PR TITLE
Attach lightsources directly to mons/objs

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1147,15 +1147,13 @@ E int NDECL(dosuspend);
 
 /* ### light.c ### */
 
-E void FDECL(new_light_source, (XCHAR_P, XCHAR_P, int, int, genericptr_t));
-E void FDECL(del_light_source, (int, genericptr_t, int));
+E void FDECL(new_light_source, (int, genericptr_t, int));
+E void FDECL(del_light_source, (struct ls_t *));
 E void FDECL(do_light_sources, (char **));
 E boolean NDECL(uswallow_indark);
 E struct monst *FDECL(find_mid, (unsigned, unsigned));
-E void FDECL(save_light_sources, (int, int, int));
-E void FDECL(restore_light_sources, (int));
-E void FDECL(relink_light_sources, (BOOLEAN_P));
-E void FDECL(obj_move_light_source, (struct obj *, struct obj *));
+E void FDECL(save_lightsource, (struct ls_t *, int, int));
+E void FDECL(rest_lightsource, (int, genericptr_t, struct ls_t *, int, boolean));
 E boolean NDECL(any_light_source);
 E void FDECL(snuff_light_source, (int, int));
 E boolean FDECL(obj_sheds_light, (struct obj *));

--- a/include/lev.h
+++ b/include/lev.h
@@ -39,13 +39,13 @@ struct bubble {
 };
 
 /* used in light.c */
-typedef struct ls_t {
-    struct ls_t *next;
+struct ls_t {
+    struct ls_t *next;	/* next in global processing chain */
     xchar x, y;		/* source's position */
     short range;	/* source's current range */
     short flags;
-    short type;		/* type of light source */
-    genericptr_t id;	/* source's identifier */
-} light_source;
+    short lstype;		/* type of light source */
+    genericptr_t owner;	/* source's identifier */
+};
 
 #endif /* LEV_H */

--- a/include/monst.h
+++ b/include/monst.h
@@ -260,6 +260,8 @@ struct monst {
 	long mvar2;
 	long mvar3;
 
+	struct ls_t * light;
+
 	union mextra * mextra_p;
 };
 

--- a/include/obj.h
+++ b/include/obj.h
@@ -346,6 +346,8 @@ struct obj {
 	
 	struct mask_properties *mp;
 
+	struct ls_t * light;
+
 	union oextra * oextra_p;
 };
 

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -7643,8 +7643,7 @@ xchar x, y;	/* clone's preferred location or 0 (near mon) */
 	if (mon->ispriest) m2->ispriest = FALSE;
 	place_monster(m2, m2->mx, m2->my);
 	if (emits_light_mon(m2))
-	    new_light_source(m2->mx, m2->my, emits_light_mon(m2),
-			     LS_MONSTER, (genericptr_t)m2);
+	    new_light_source(LS_MONSTER, (genericptr_t)m2, emits_light_mon(m2));
 	if (M_HAS_NAME(mon)) {
 		cpy_mx(mon, m2, MX_ENAM);
 	} else if (mon->isshk) {
@@ -8947,8 +8946,7 @@ register int	mmflags;
 		mtmp->mhp = mtmp->mhpmax;
 	}
 	if ((ct = emits_light_mon(mtmp)) > 0)
-		new_light_source(mtmp->mx, mtmp->my, ct,
-				 LS_MONSTER, (genericptr_t)mtmp);
+		new_light_source(LS_MONSTER, (genericptr_t)mtmp, ct);
 	mitem = 0;	/* extra inventory item for this monster */
 
 	if ((mcham = pm_to_cham(mndx)) != CHAM_ORDINARY) {

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2539,6 +2539,7 @@ struct monst *mtmp;
 	EMON(obj)->nmon     = (struct monst *)0;
 	EMON(obj)->data     = (struct permonst *)0;
 	EMON(obj)->minvent  = (struct obj *)0;
+	EMON(obj)->light    = (struct ls_t *)0;
 	return obj;
 }
 

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -391,6 +391,11 @@ long num;
 	    panic("splitobj");	/* can't split containers */
 	otmp = newobj(0);
 	*otmp = *obj;		/* copies whole structure */
+	/* invalidate pointers */
+	otmp->light = (struct ls_t *)0;
+	otmp->oextra_p = (union oextra *)0;
+	otmp->mp = (struct mask_properties *)0;	/* not sure if correct -- these are very unfinished */
+
 	otmp->o_id = flags.ident++;
 	if (!otmp->o_id) otmp->o_id = flags.ident++;	/* ident overflowed */
 	otmp->timed = 0;	/* not timed, yet */
@@ -3186,9 +3191,9 @@ dealloc_obj(obj)
 
     /*
      * Free up any light sources attached to the object.
-     *
      */
-	del_light_source(LS_OBJECT, (genericptr_t) obj, TRUE);
+	if (obj->light)
+	del_light_source(obj->light);
 
     //if (obj == thrownobj) thrownobj = (struct obj*)0;
 

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -351,12 +351,10 @@ boolean forcecontrol;
  made_change:
 	new_light = Upolyd ? emits_light(youmonst.data) : 0;
 	if (old_light != new_light) {
-	    if (old_light)
-		del_light_source(LS_MONSTER, (genericptr_t)&youmonst, FALSE);
+	    del_light_source((&youmonst)->light);
 	    if (new_light == 1) ++new_light;  /* otherwise it's undetectable */
 	    if (new_light)
-		new_light_source(u.ux, u.uy, new_light,
-				 LS_MONSTER, (genericptr_t)&youmonst);
+			new_light_source(LS_MONSTER, (genericptr_t)&youmonst, new_light);
 	}
 	if (is_pool(u.ux,u.uy, FALSE) && was_floating && !(Levitation || Flying) &&
 		!breathless(youmonst.data) && !amphibious(youmonst.data) &&
@@ -804,8 +802,9 @@ rehumanize()
 		done(DIED);
 	}
 
-	if (emits_light(youracedata))
-	    del_light_source(LS_MONSTER, (genericptr_t)&youmonst, FALSE);
+	/* delete any ls attached to you */
+	del_light_source((&youmonst)->light);
+
 	polyman("return to %s form!", urace.adj);
 
 	if (u.uhp < 1) {

--- a/src/restore.c
+++ b/src/restore.c
@@ -216,6 +216,9 @@ boolean ghostly, frozen;
 		if(otmp->oextra_p){
 			rest_oextra(otmp, fd, ghostly);
 		}
+		if (otmp->light) {
+			rest_lightsource(LS_OBJECT, otmp, otmp->light, fd, ghostly);
+		}
 		if (ghostly) {
 		    unsigned nid = flags.ident++;
 		    add_id_mapping(otmp->o_id, nid);
@@ -275,6 +278,9 @@ boolean ghostly;
 		mread(fd, (genericptr_t) mtmp, sizeof(struct monst));
 		if (mtmp->mextra_p) {
 			rest_mextra(mtmp, fd, ghostly);
+		}
+		if (mtmp->light) {
+			rest_lightsource(LS_MONSTER, mtmp, mtmp->light, fd, ghostly);
 		}
 		if (ghostly) {
 			unsigned nid = flags.ident++;
@@ -462,7 +468,6 @@ unsigned int *stuckid, *steedid;	/* STEED */
 
 	/* this stuff comes after potential aborted restore attempts */
 	restore_timers(fd, RANGE_GLOBAL, FALSE, 0L);
-	restore_light_sources(fd);
 	invent = restobjchn(fd, FALSE, FALSE);
 	bc_obj = restobjchn(fd, FALSE, FALSE);
 	while (bc_obj) {
@@ -523,7 +528,6 @@ unsigned int *stuckid, *steedid;	/* STEED */
 #endif
 	/* must come after all mons & objs are restored */
 	relink_timers(FALSE);
-	relink_light_sources(FALSE);
 #ifdef WHEREIS_FILE
         touch_whereis();
 #endif
@@ -901,7 +905,6 @@ boolean ghostly;
 	    doorindex = 0;
 
 	restore_timers(fd, RANGE_LEVEL, ghostly, monstermoves - omoves);
-	restore_light_sources(fd);
 	fmon = restmonchn(fd, ghostly);
 
 	rest_worm(fd);	/* restore worm information */
@@ -995,7 +998,6 @@ boolean ghostly;
 
 	/* must come after all mons & objs are restored */
 	relink_timers(ghostly);
-	relink_light_sources(ghostly);
 	reset_oattached_mids(ghostly);
 
 	/* regenerate animals while on another level */

--- a/src/save.c
+++ b/src/save.c
@@ -314,7 +314,6 @@ register int fd, mode;
 
 	/* must come before migrating_objs and migrating_mons are freed */
 	save_timers(fd, mode, RANGE_GLOBAL);
-	save_light_sources(fd, mode, RANGE_GLOBAL);
 
 	if (CHAIN_IN_MON) {
 		uchain->nobj = bc_objs;
@@ -583,7 +582,6 @@ int mode;
  skip_lots:
 	/* must be saved before mons, objs, and buried objs */
 	save_timers(fd, mode, RANGE_LEVEL);
-	save_light_sources(fd, mode, RANGE_LEVEL);
 
 	savemonchn(fd, fmon, mode);
 	save_worm(fd, mode);	/* save worm information */
@@ -910,6 +908,9 @@ register struct obj *otmp;
 			if (otmp->oextra_p) {
 				save_oextra(otmp, fd, mode);
 			}
+			if (otmp->light) {
+				save_lightsource(otmp->light, fd, mode);
+			}
 	    }
 	    if (Has_contents(otmp))
 		saveobjchn(fd,otmp->cobj,mode);
@@ -948,6 +949,9 @@ register struct monst *mtmp;
 		if(mtmp->mextra_p)
 			save_mextra(mtmp, fd, mode);
 	    }
+		if (mtmp->light) {
+			save_lightsource(mtmp->light, fd, mode);
+		}
 	    if (mtmp->minvent)
 		saveobjchn(fd,mtmp->minvent,mode);
 	    if (release_data(mode))
@@ -1092,7 +1096,6 @@ freedynamicdata()
 # define free_waterlevel() save_waterlevel(0, FREE_SAVE)
 # define free_worm()	 save_worm(0, FREE_SAVE)
 # define free_timers(R)	 save_timers(0, FREE_SAVE, R)
-# define free_light_sources(R) save_light_sources(0, FREE_SAVE, R);
 # define free_engravings() save_engravings(0, FREE_SAVE)
 # define freedamage()	 savedamage(0, FREE_SAVE)
 # define free_animals()	 mon_animal_list(FALSE)
@@ -1102,7 +1105,6 @@ freedynamicdata()
 
 	/* level-specific data */
 	free_timers(RANGE_LEVEL);
-	free_light_sources(RANGE_LEVEL);
 	freemonchn(fmon);
 	free_worm();		/* release worm segment information */
 	freetrapchn(ftrap);
@@ -1114,7 +1116,6 @@ freedynamicdata()
 
 	/* game-state data */
 	free_timers(RANGE_GLOBAL);
-	free_light_sources(RANGE_GLOBAL);
 	freeobjchn(invent);
 	for(i=0;i<10;i++) freeobjchn(magic_chest_objs[i]);
 	freeobjchn(migrating_objs);

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -2328,15 +2328,9 @@ begin_burn(obj)
 
 	if (obj->lamplit) {
 	    xchar x, y;
-		if (already_lit)
-			del_light_source(LS_OBJECT, (genericptr_t)obj, TRUE);
-		if (get_obj_location(obj, &x, &y, CONTAINED_TOO | BURIED_TOO)) {
-			new_light_source(x, y, radius, LS_OBJECT, (genericptr_t)obj);
-		}
-	    else{
-			/* make the new light source at (0,0) since we can't get its position */
-			new_light_source(0, 0, radius, LS_OBJECT, (genericptr_t)obj);
-		}
+		if (already_lit)	/* to give an error if already_lit != actually had an ls */
+			del_light_source(obj->light);
+		new_light_source(LS_OBJECT, (genericptr_t)obj, radius);
 	}
 }
 
@@ -2364,7 +2358,7 @@ end_burn(obj, timer_attached)
 
 	if (!timer_attached) {
 	    /* [DS] Cleanup explicitly, since timer cleanup won't happen */
-	    del_light_source(LS_OBJECT, (genericptr_t)obj, FALSE);
+	    del_light_source(obj->light);
 	    obj->lamplit = 0;
 	    if (obj->where == OBJ_INVENT)
 		update_inventory();
@@ -2394,8 +2388,7 @@ cleanup_burn(arg, expire_time)
 	impossible("cleanup_burn: obj %s not lit", xname(obj));
 	return;
     }
-
-    del_light_source(LS_OBJECT, arg, FALSE);
+	del_light_source(((struct obj *)arg)->light);
 
     /* restore unused time */
     obj->age += expire_time - monstermoves;

--- a/src/were.c
+++ b/src/were.c
@@ -195,14 +195,10 @@ struct monst *mon;
 	}
 	/* regenerate by 1/4 of the lost hit points */
 	mon->mhp += (mon->mhpmax - mon->mhp) / 4;
-	if (emits_light(olddata) != emits_light_mon(mon)) {
-	    /* used to give light, now doesn't, or vice versa,
-	       or light's range has changed */
-	    if (emits_light(olddata) || has_template(mon, ILLUMINATED))
-		del_light_source(LS_MONSTER, (genericptr_t)mon, FALSE);
-	    if (emits_light_mon(mon))
-		new_light_source(mon->mx, mon->my, emits_light_mon(mon),
-				 LS_MONSTER, (genericptr_t)mon);
+	/* recheck if monster is a lightsource */
+	del_light_source(mon->light);
+	if (emits_light_mon(mon)) {
+		new_light_source(LS_MONSTER, (genericptr_t)mon, emits_light_mon(mon));
 	}
 	newsym(mon->mx,mon->my);
 	if(is_eeladrin(mon->data)){
@@ -229,38 +225,15 @@ struct monst *mon;
 			}
 		}
 		if(mon->mtyp == PM_ANCIENT_TEMPEST){
+			static int elemtypes[] = {PM_WATER_ELEMENTAL, PM_AIR_ELEMENTAL, PM_LIGHTNING_PARAELEMENTAL, PM_ICE_PARAELEMENTAL};
 			struct monst *ltnt;
-			for(ltnt = fmon; ltnt; ltnt = ltnt->nmon) if(ltnt->mtyp == PM_WIDE_CLUBBED_TENTACLE){
-				switch(rnd(4)){
-					case 1:
-						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_WATER_ELEMENTAL);
-						newsym(ltnt->mx,ltnt->my);
-						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
-								 LS_MONSTER, (genericptr_t)ltnt);
-					break;
-					case 2:
-						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_AIR_ELEMENTAL);
-						newsym(ltnt->mx,ltnt->my);
-						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
-								 LS_MONSTER, (genericptr_t)ltnt);
-					break;
-					case 3:
-						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_LIGHTNING_PARAELEMENTAL);
-						newsym(ltnt->mx,ltnt->my);
-						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
-								 LS_MONSTER, (genericptr_t)ltnt);
-					break;
-					case 4:
-						if (emits_light_mon(ltnt)) del_light_source(LS_MONSTER, (genericptr_t)ltnt, FALSE);
-						set_mon_data(ltnt, PM_ICE_PARAELEMENTAL);
-						newsym(ltnt->mx,ltnt->my);
-						if (emits_light_mon(ltnt)) new_light_source(ltnt->mx, ltnt->my, emits_light_mon(ltnt),
-								 LS_MONSTER, (genericptr_t)ltnt);
-					break;
-				}
+			for(ltnt = fmon; ltnt; ltnt = ltnt->nmon)
+			if(ltnt->mtyp == PM_WIDE_CLUBBED_TENTACLE){
+				del_light_source(ltnt->light);
+				set_mon_data(ltnt, elemtypes[rn2(4)]);
+				newsym(ltnt->mx,ltnt->my);
+				if (emits_light_mon(ltnt))
+					new_light_source(LS_MONSTER, (genericptr_t)ltnt, emits_light_mon(ltnt));
 			}
 		}
 	} else if(is_heladrin(mon->data)){


### PR DESCRIPTION
Based on oextra, which is based on mextra. (To eliminate merge conflicts in save.c and restore.c)

Greatly reduces tomfoolery need to save/restore lightsources.

Confidently tell if a mon/obj has an attached lightsource.