### PR TITLE
Add new artifact: Bloodletter

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -293,6 +293,7 @@ struct artinstance{
 #define RoSPkills avar1
 #define BoISspell avar1
 #define RRSember avar1
+#define BLactive avar1
 	long avar2;
 #define SnSd2 avar2
 #define RoSPflights avar2
@@ -391,6 +392,7 @@ extern struct artifact artilist[];
 #define STONE_DRAGON    (LAST_PROP+78)
 #define MAD_KING        (LAST_PROP+79)
 #define RINGED_SPEAR    (LAST_PROP+80)
+#define BLOODLETTER     (LAST_PROP+81)
 
 
 #define MASTERY_ARTIFACT_LEVEL 20

--- a/include/extern.h
+++ b/include/extern.h
@@ -55,6 +55,7 @@ E void NDECL(reset_trapset);
 E void FDECL(fig_transform, (genericptr_t, long));
 E int FDECL(use_whip, (struct obj *));
 E int FDECL(use_force_sword, (struct obj *));
+E int FDECL(do_bloodletter, (struct obj *));
 E boolean FDECL(use_ring_of_wishes, (struct obj *));
 E boolean FDECL(use_candle_of_invocation, (struct obj *));
 E void FDECL(use_magic_whistle, (struct obj *));

--- a/src/apply.c
+++ b/src/apply.c
@@ -3,8 +3,7 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "hack.h"
-
-
+#include "artifact.h"
 #ifdef OVLB
 
 static const char tools[] = { COIN_CLASS, CHAIN_CLASS, TOOL_CLASS, WEAPON_CLASS, WAND_CLASS, 0 };
@@ -1429,6 +1428,31 @@ struct obj *obj;
 		return 0;
 	}
 }
+
+int
+do_bloodletter(obj)
+struct obj *obj;
+{
+	if(obj->oartifact != ART_BLOODLETTER || obj != uwep){
+		pline("You must be wielding Bloodletter to do that.");
+		return 0;
+	}
+	if (artinstance[obj->oartifact].BLactive < monstermoves){
+		pline("You must make an offering first.");
+		return 0; // unreachable as of now
+	}
+	
+	You("slam the bloodied morning star down, releasing it of the tainted blood in a burst.");
+	explode(u.ux, u.uy, AD_BLUD, 0, d(6, 6), EXPL_RED, 1);
+	if (has_blood_mon(&youmonst)){
+		losehp(u.ulevel, "splash of tainted blood", KILLED_BY_AN);
+	}
+	
+	artinstance[obj->oartifact].BLactive = 0;
+	
+	return 1;
+}
+
 
 STATIC_OVL int
 use_rakuyo(obj)
@@ -5992,6 +6016,7 @@ doapply()
 	
 	if(obj->oartifact == ART_SILVER_STARLIGHT) res = do_play_instrument(obj);
 	else if(obj->oartifact == ART_HOLY_MOONLIGHT_SWORD) use_lamp(obj);
+	else if(obj->oartifact == ART_BLOODLETTER && artinstance[obj->oartifact].BLactive >= monstermoves) res = do_bloodletter(obj);
 	else if(obj->oartifact == ART_AEGIS) res = swap_aegis(obj);
 	else if(obj->otyp == RAKUYO || obj->otyp == RAKUYO_SABER){
 		return use_rakuyo(obj);

--- a/src/apply.c
+++ b/src/apply.c
@@ -1444,9 +1444,6 @@ struct obj *obj;
 	
 	You("slam the bloodied morning star down, releasing it of the tainted blood in a burst.");
 	explode(u.ux, u.uy, AD_BLUD, 0, d(6, 6), EXPL_RED, 1);
-	if (has_blood_mon(&youmonst)){
-		losehp(u.ulevel, "splash of tainted blood", KILLED_BY_AN);
-	}
 	
 	artinstance[obj->oartifact].BLactive = 0;
 	

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1683,6 +1683,10 @@ boolean narrow_only;
 			if (Dark_res(mdef))
 				return FALSE;
 		break;
+		case AD_BLUD:
+			if (!has_blood(mdef->data))
+				return FALSE;
+		break;
 		default:
 			impossible("Weird weapon special attack: (%d).", weap->adtyp);
 		}
@@ -1932,6 +1936,16 @@ int * truedmgptr;
 		/* premium heart has special cases to get a huge damage multiplier -- player only */
 		if (otmp==uarmg && otmp->oartifact == ART_PREMIUM_HEART)
 			multiplier = get_premium_heart_multiplier();
+		
+		if(otmp->oartifact == ART_BLOODLETTER){
+		 	int *hp = (Upolyd) ? (&u.mh) : (&u.uhp);
+		 	int *hpmax = (Upolyd) ? (&u.mhmax) : (&u.uhpmax);
+
+			if (*hp < (*hpmax / 4))
+				multiplier = 4;
+			else if (*hp < (*hpmax / 2))
+				multiplier = 2;
+		}
 		/* some artifacts are 3x damage, or add 2dX damage */
 		if (double_bonus_damage_artifact(otmp->oartifact) ||
 			(otmp->oartifact == ART_FROST_BRAND && species_resists_fire(mon) && spec_dbon_applies) ||
@@ -3593,6 +3607,20 @@ boolean * messaged;
 	    if (!rn2(2)) (void) destroy_item(mdef, POTION_CLASS, AD_FIRE);
 //	    if (!rn2(4)) (void) destroy_item(mdef, SCROLL_CLASS, AD_FIRE);
 //	    if (!rn2(7)) (void) destroy_item(mdef, SPBOOK_CLASS, AD_FIRE);
+	}
+	if (attacks(AD_BLUD, otmp)){
+		if (vis&VIS_MAGR) {
+			pline_The("bloodstained %s %s %s%c",
+				wepdesc,
+				vtense(wepdesc, "hit"),
+				hittee, !spec_dbon_applies ? '.' : '!');
+			*messaged = TRUE;
+		}
+		if (otmp->oartifact == ART_BLOODLETTER){
+			if (spec_dbon_applies && artinstance[otmp->oartifact].BLactive >= monstermoves){
+				*truedmgptr += rnd(mlev(mdef));
+			}
+		}
 	}
 	if (arti_attack_prop(otmp, ARTA_MAGIC) && dieroll <= MB_MAX_DIEROLL) {
 		int dmg = basedmg;
@@ -7597,6 +7625,25 @@ arti_invoke(obj)
         case RINGED_SPEAR:
 			You("wake the ringed spear.");
 			doliving_ringed_spear(&youmonst, obj, TRUE);
+		break;
+		case BLOODLETTER:
+			if (artinstance[obj->oartifact].BLactive < monstermoves){
+				obj->age = 0;
+				
+				if (has_blood_mon(&youmonst)){
+					You("plunge Bloodletter into your chest, making an offering of your tainted blood.");
+					losehp(Upolyd ? u.mhmax * 0.2 : u.uhpmax * 0.2, "purging tainted blood", KILLED_BY);
+					artinstance[obj->oartifact].BLactive = monstermoves + 20 + rn2(10) + rn2(10);
+				} else {
+					You("are free of tainted blood, and have none to offer.");
+				}
+			} else {
+				You("slam the bloodied morning star down, releasing a burst of tainted blood.");
+				explode(u.ux, u.uy, AD_BLUD, 0, d(6, 6), EXPL_RED, 1);
+				if (has_blood_mon(&youmonst))
+					losehp(u.ulevel, "splash of tainted blood", KILLED_BY_AN);
+			}
+			
 		break;
 		default: pline("Program in dissorder.  Artifact invoke property not recognized");
 		break;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3618,7 +3618,8 @@ boolean * messaged;
 		}
 		if (otmp->oartifact == ART_BLOODLETTER){
 			if (spec_dbon_applies && artinstance[otmp->oartifact].BLactive >= monstermoves){
-				*truedmgptr += rnd(1+mlev(mdef));
+				*truedmgptr += mlev(mdef);
+				artinstance[otmp->oartifact].BLactive -= max(0, mlev(mdef)/10 - rn2(5));
 			}
 		}
 	}

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1684,7 +1684,7 @@ boolean narrow_only;
 				return FALSE;
 		break;
 		case AD_BLUD:
-			if (!has_blood(mdef->data))
+			if (!has_blood_mon(mdef))
 				return FALSE;
 		break;
 		default:
@@ -1942,7 +1942,7 @@ int * truedmgptr;
 		 	int *hpmax = (Upolyd) ? (&u.mhmax) : (&u.uhpmax);
 
 			if (*hp < (*hpmax / 4))
-				multiplier = 4;
+				multiplier = 3;
 			else if (*hp < (*hpmax / 2))
 				multiplier = 2;
 		}
@@ -3618,7 +3618,7 @@ boolean * messaged;
 		}
 		if (otmp->oartifact == ART_BLOODLETTER){
 			if (spec_dbon_applies && artinstance[otmp->oartifact].BLactive >= monstermoves){
-				*truedmgptr += rnd(mlev(mdef));
+				*truedmgptr += rnd(1+mlev(mdef));
 			}
 		}
 	}
@@ -7628,8 +7628,6 @@ arti_invoke(obj)
 		break;
 		case BLOODLETTER:
 			if (artinstance[obj->oartifact].BLactive < monstermoves){
-				obj->age = 0;
-				
 				if (has_blood_mon(&youmonst)){
 					You("plunge Bloodletter into your chest, making an offering of your tainted blood.");
 					losehp(Upolyd ? u.mhmax * 0.2 : u.uhpmax * 0.2, "purging tainted blood", KILLED_BY);
@@ -7638,10 +7636,7 @@ arti_invoke(obj)
 					You("are free of tainted blood, and have none to offer.");
 				}
 			} else {
-				You("slam the bloodied morning star down, releasing a burst of tainted blood.");
-				explode(u.ux, u.uy, AD_BLUD, 0, d(6, 6), EXPL_RED, 1);
-				if (has_blood_mon(&youmonst))
-					losehp(u.ulevel, "splash of tainted blood", KILLED_BY_AN);
+				do_bloodletter(obj);
 			}
 			
 		break;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3616,11 +3616,10 @@ boolean * messaged;
 				hittee, !spec_dbon_applies ? '.' : '!');
 			*messaged = TRUE;
 		}
-		if (otmp->oartifact == ART_BLOODLETTER){
-			if (spec_dbon_applies && artinstance[otmp->oartifact].BLactive >= monstermoves){
-				*truedmgptr += mlev(mdef);
+		if (spec_dbon_applies && !(otmp->oartifact == ART_BLOODLETTER && artinstance[otmp->oartifact].BLactive < monstermoves)){
+			*truedmgptr += mlev(mdef);
+			if (otmp->oartifact == ART_BLOODLETTER)
 				artinstance[otmp->oartifact].BLactive -= max(0, mlev(mdef)/10 - rn2(5));
-			}
 		}
 	}
 	if (arti_attack_prop(otmp, ARTA_MAGIC) && dieroll <= MB_MAX_DIEROLL) {

--- a/src/artilist.c
+++ b/src/artilist.c
@@ -767,10 +767,10 @@ A("The Holy Moonlight Sword",	LONG_SWORD,				(const char *)0, // begging for a d
 	ENLIGHTENING, NOFLAG
 	),
 
-/* can be transformed from a mace into a large (two-handed) bloody morning star */
-/* the transformation costs 20% health to activate, is lost when unwielding */
-/* and unlocks the blood damage + AoE invoke */
-A("Bloodletter",	MACE,				(const char *)0,
+/* can be transformed by offering your blood */
+/* transformation costs 20% health to activate, lasts for 20+2d10 turns */
+/* while active, adds +defender mlev to blood damage, can be applied to cause an AoE and clear active*/
+A("Bloodletter",	MORNING_STAR,				(const char *)0,
 	4000L, IRON, MZ_DEFAULT, WT_DEFAULT,
 	A_NONE, NON_PM, NON_PM, TIER_B, (ARTG_INHER),
 	NO_MONS(),

--- a/src/artilist.c
+++ b/src/artilist.c
@@ -767,6 +767,19 @@ A("The Holy Moonlight Sword",	LONG_SWORD,				(const char *)0, // begging for a d
 	ENLIGHTENING, NOFLAG
 	),
 
+/* can be transformed from a mace into a large (two-handed) bloody morning star */
+/* the transformation costs 20% health to activate, is lost when unwielding */
+/* and unlocks the blood damage + AoE invoke */
+A("Bloodletter",	MACE,				(const char *)0,
+	4000L, IRON, MZ_DEFAULT, WT_DEFAULT,
+	A_NONE, NON_PM, NON_PM, TIER_B, (ARTG_INHER),
+	NO_MONS(),
+	ATTK(AD_BLUD, 8, 12), NOFLAG,
+	PROPS(), NOFLAG,
+	PROPS(), NOFLAG,
+	BLOODLETTER, NOFLAG
+	),
+
 /*Needs encyc entry*/
 A("The Silence Glaive",	GLAIVE,							(const char *)0,
 	8000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,

--- a/src/explode.c
+++ b/src/explode.c
@@ -583,6 +583,10 @@ boolean yours; /* is it your fault (for killing monsters) */
 			You("are seared by the %s!", str);
 			damu += rnd(20);
 		}
+		if (adtyp == AD_BLUD && has_blood(youracedata)){
+			pline("Rotten blood tears through your veins!");
+			damu += u.ulevel;
+		}
 		/* do property damage first, in case we end up leaving bones */
 		if (adtyp == AD_FIRE){
 			burn_away_slime();

--- a/src/explode.c
+++ b/src/explode.c
@@ -267,6 +267,8 @@ boolean yours; /* is it your fault (for killing monsters) */
 			break;
 		case AD_DARK: str = "blast of darkness";
 			break;
+		case AD_BLUD: str = "splash of tainted blood";
+			break;
 		default:
 			impossible("unaccounted-for explosion damage type in do_explode: %d", adtyp);
 			str = "404 BLAST NOT FOUND";
@@ -313,6 +315,9 @@ boolean yours; /* is it your fault (for killing monsters) */
 				break;
 			case AD_DARK:
 				explmask = !!Dark_immune;
+				break;
+			case AD_BLUD:
+				explmask = !has_blood(youracedata);
 				break;
 			default:
 				impossible("explosion type %d?", adtyp);
@@ -364,6 +369,9 @@ boolean yours; /* is it your fault (for killing monsters) */
 				break;
 			case AD_DARK:
 				explmask |= dark_immune(mtmp);
+				break;
+			case AD_BLUD:
+				explmask |= has_blood_mon(mtmp);
 				break;
 			default:
 				impossible("explosion type %d?", adtyp);
@@ -547,6 +555,9 @@ boolean yours; /* is it your fault (for killing monsters) */
 				mdam *= 2;
 			else if (Dark_vuln(mtmp) && adtyp == AD_DARK)
 				mdam *= 2;
+			else if (has_blood_mon(mtmp) && adtyp == AD_BLUD)
+				mdam += mlev(mtmp);
+
 			mtmp->mhp -= mdam;
 			mtmp->mhp -= (idamres + idamnonres);
 		}

--- a/src/invent.c
+++ b/src/invent.c
@@ -2676,6 +2676,7 @@ winid *datawin;
 					case AD_DRLI: Strcat(buf, "life drain damage."); break;
 					case AD_STON: Strcat(buf, "petrifying damage."); break;
 					case AD_DARK: Strcat(buf, "dark damage."); break;
+					case AD_BLUD: Strcat(buf, "blood damage."); break;
 						break;
 					}
 				}

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -797,6 +797,11 @@ boolean dofull;
 			Strcat(buf, "gleaming ");
 	}
 	
+	if(obj->oartifact && get_artifact(obj)->inv_prop == BLOODLETTER){
+		if (artinstance[obj->oartifact].BLactive >= moves)
+			Strcat(buf, "sanguine ");
+	}
+	
 	if (!check_oprop(obj, OPROP_NONE) && (obj->oartifact == 0 || dofull)){
 		if (check_oprop(obj, OPROP_ASECW) && (obj->known || u.uinsight >= 10) && !(obj->opoisoned&OPOISON_ACID))
 			u.uinsight < 10 ? Strcat(buf, "self-acidifying ") : Strcat(buf, "acid-secreting ");

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -291,10 +291,8 @@ int oartifact;
 	if(obj && oartifact && get_artifact(obj)->inv_prop == RINGED_SPEAR && (artinstance[oartifact].RRSember >= moves || artinstance[oartifact].RRSlunar >= moves)){
 		attackmask |= SLASH;
 	}
-	if (obj && oartifact == ART_HOLY_MOONLIGHT_SWORD && artinstance[oartifact].BLactive >= moves){
-		attackmask |= PIERCE|EXPLOSION;
-	}
 	if ((obj && oartifact == ART_HOLY_MOONLIGHT_SWORD && obj->lamplit)
+		|| (oartifact == ART_BLOODLETTER && artinstance[oartifact].BLactive >= moves)
 		|| oartifact == ART_FIRE_BRAND
 		|| oartifact == ART_FROST_BRAND
 		){

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -291,6 +291,9 @@ int oartifact;
 	if(obj && oartifact && get_artifact(obj)->inv_prop == RINGED_SPEAR && (artinstance[oartifact].RRSember >= moves || artinstance[oartifact].RRSlunar >= moves)){
 		attackmask |= SLASH;
 	}
+	if (obj && oartifact == ART_HOLY_MOONLIGHT_SWORD && artinstance[oartifact].BLactive >= moves){
+		attackmask |= PIERCE|EXPLOSION;
+	}
 	if ((obj && oartifact == ART_HOLY_MOONLIGHT_SWORD && obj->lamplit)
 		|| oartifact == ART_FIRE_BRAND
 		|| oartifact == ART_FROST_BRAND


### PR DESCRIPTION
* unaligned (iron) morning star
* +1d8 to hit and +1d12 blood damage
  * Deals extra bonus blood damage at lower health. At under 50% of maximum health, deals an additional +1d12 for a total of +2d12. At under 25% of maximum health, deals an additional +1d12 for a total of +3d12.
* When invoked, self-impales (dealing damage equal to 20% of your max hp, can be lethal) to coat in blood. This lasts for 20 + 2z9 turns. While coated in blood:
  * Appears as "sanguine" in your inventory. 
  * Damage dealt is also treated as energy damage, in addition to being blunt and piercing.
  * Deals an extra flat +defender level damage to monsters with blood. 
  * Hitting high level monsters during this time can decrease the amount of time remaining on the blood coating. It subtracts `defender_level/10 - rn2(5)` (rounded down) from the time remaining, and never adds more time.
  * Can be applied to slam down, releasing the tainted blood. This ends the active effect but causes a 6d6 rotten blood explosion. The explosion only hurts creatures with blood, and also deals a flat +defender level damage to affected creatures.
