### PR TITLE
Tweak wishing for rematerialed objects

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1375,7 +1375,7 @@ E struct obj *FDECL(mksobj, (int,BOOLEAN_P,BOOLEAN_P));
 E int FDECL(bcsign, (struct obj *));
 E void FDECL(set_obj_size, (struct obj *, int));
 E void FDECL(set_obj_quan, (struct obj *, int));
-E void FDECL(maybe_set_material, (struct obj *, int, boolean));
+E void FDECL(maybe_set_material, (struct obj *, int));
 E void FDECL(set_material, (struct obj *, int));
 E void FDECL(set_material_gm, (struct obj *, int));
 E int FDECL(weight, (struct obj *));

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1814,16 +1814,13 @@ struct obj* obj;
 }
 
 /* Tries to set obj's material to mat
- * Is limited by material lists and probabilities
- * If check_all is true, go through the object's whole mat list;
- *   otherwise, limited by probability
+ * Checks material list for obj.
  * Used by wishing code
  */
 void
-maybe_set_material(obj, mat, check_all)
+maybe_set_material(obj, mat)
 struct obj *obj;
 int mat;
-boolean check_all;
 {
 	const struct icp* random_mat_list;
 
@@ -1837,14 +1834,12 @@ boolean check_all;
 	if (!random_mat_list)
 		return;
 
-	int i = (check_all ? 1000 : rnd(1000));
-	while (i > 0) {
-		if ((i <= random_mat_list->iprob) || (random_mat_list->iclass == mat))
-			break;
+	int i = 1000;
+	while (random_mat_list->iclass != mat && i > 0) {
 		i -= random_mat_list->iprob;
 		random_mat_list++;
 	}
-	if (random_mat_list->iclass) /* a 0 indicates to use default material */
+	if (random_mat_list->iclass == mat)
 		set_material_gm(obj, random_mat_list->iclass);
 }
 

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -5087,7 +5087,7 @@ typfnd:
 		if (wizwish)
 			set_material_gm(otmp, mat);
 		else if (!otmp->oartifact || is_malleable_artifact(&artilist[otmp->oartifact]))
-			maybe_set_material(otmp, mat, TRUE);	// always limited by allowable random materials, but ignore normal probabilities
+			maybe_set_material(otmp, mat);	// always limited by allowable random materials, but ignore normal probabilities
 		/* set gemtype, if specified and allowable*/
 		if (mat == GEMSTONE && otmp->oclass != GEM_CLASS && gemtype && !obj_type_uses_ovar1(otmp) && !obj_art_uses_ovar1(otmp)) {
 			otmp->ovar1 = gemtype;


### PR DESCRIPTION
If your wish couldn't get you the material you want, give a random material, not last-on-the-list.

I'm also considering disallowing wishing for rematerialed objects. Most variants with obj materials do that.
Grunthack doesn't, but in Grunthack the player needs every edge they can get over the evils of the dungeon. dNethack characters tend to be strong enough without also having dragonhide speed boots and cloaks of protection.