### PR TITLE
Reduce Poison, Filth instakill damage; rewrite Plague's effect.

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -294,10 +294,12 @@ struct artinstance{
 #define BoISspell avar1
 #define RRSember avar1
 #define BLactive avar1
+#define PlagueDuration avar1
 	long avar2;
 #define SnSd2 avar2
 #define RoSPflights avar2
 #define RRSlunar avar2
+#define PlagueDoOnHit avar2
 	long avar3;
 #define SnSd3 avar3
 	long avar4;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -4051,9 +4051,9 @@ boolean * messaged;
 		}
 	} 
 	/* while Plague is invoked, lethal-filth arrows cause victims to virulently explode.
-	 * Not you, though. You just die. It's simpler that way.
-	 * Slightly different from actual Vorpal; the dieroll is hacked in xhity to ==1 if and only if we have lethal filth. */
-	if (oartifact == ART_PLAGUE && (monstermoves < otmp->ovar1) && (dieroll == 1) && !youdef) {
+	 * Not you, though. You just die. It's simpler that way. */
+	if (oartifact == ART_PLAGUE && artinstance[ART_PLAGUE].PlagueDoOnHit && (*hp(mdef) <= currdmg + 100) && !youdef) {
+		artinstance[ART_PLAGUE].PlagueDoOnHit = FALSE;
 		int mx, my;
 		if (vis&VIS_MAGR && vis&VIS_MDEF) {
 			pline_The("tainted %s strikes true!", xname(msgr));
@@ -7602,8 +7602,8 @@ arti_invoke(obj)
 			else {
 				pline("%s vibrates softly.", The(xname(obj)));
 			}
-			/* if time < ovar1, arrows will be filthed (done in xhity.c) */
-			obj->ovar1 = monstermoves + 13;
+			/* while monstermoves < duration, arrows will be filthed (done in xhity.c) */
+			artinstance[ART_PLAGUE].PlagueDuration = monstermoves + 13;
 		break;
 		case INVOKE_DARK:{
           struct obj *wand;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -11895,7 +11895,7 @@ int vis;						/* True if action is at all visible to the player */
 			poisons |= OPOISON_ACID;
 		/* Plague adds poisons to its launched ammo */
 		if (launcher && launcher->oartifact == ART_PLAGUE) {
-			if (monstermoves < launcher->ovar1)
+			if (monstermoves < artinstance[ART_PLAGUE].PlagueDuration)
 				poisons |= OPOISON_FILTH;
 			else
 				poisons |= OPOISON_BASIC;
@@ -11959,7 +11959,7 @@ int vis;						/* True if action is at all visible to the player */
 			case OPOISON_FILTH:
 				resists = Sick_res(mdef);
 				majoreff = !rn2(10);
-				if (launcher && launcher->oartifact == ART_PLAGUE && monstermoves < launcher->ovar1)
+				if (launcher && launcher->oartifact == ART_PLAGUE && monstermoves < artinstance[ART_PLAGUE].PlagueDuration)
 					majoreff = !rn2(5);	/* while invoked, Plague's arrows are twice as likely to instakill (=20%) */
 				break;
 			case OPOISON_SLEEP:
@@ -12020,10 +12020,10 @@ int vis;						/* True if action is at all visible to the player */
 			switch (i)
 			{
 			case OPOISON_BASIC:
-				poisdmg += (major) ? (youdef ? d(3, 6) : 9999) : rnd(6);
+				poisdmg += (major) ? (youdef ? d(3, 6) : 80) : rnd(6);
 				break;
 			case OPOISON_FILTH:
-				poisdmg += (major) ? (youdef ? d(3, 12) : 9999) : rnd(12);
+				poisdmg += (major) ? (youdef ? d(3, 12) : 100) : rnd(12);
 				break;
 			case OPOISON_SLEEP:
 				/* no damage */
@@ -12045,6 +12045,9 @@ int vis;						/* True if action is at all visible to the player */
 				break;
 			}
 		}
+		/* if Plague is being used, note whether or not the current shot is filthed */
+		if (launcher && launcher->oartifact == ART_PLAGUE && monstermoves < artinstance[ART_PLAGUE].PlagueDuration)
+			artinstance[ART_PLAGUE].PlagueDoOnHit = !!(poisons_majoreff&OPOISON_FILTH);
 	}
 
 	/* Clockwork heat - player melee only */
@@ -12887,9 +12890,6 @@ int vis;						/* True if action is at all visible to the player */
 		if (fired && launcher && valid_weapon_attack) {
 			otmp = launcher;
 			if (otmp) {
-				/* kludge for Plague: artifact_hit() needs to know if lethal filth occured */
-				if (otmp->oartifact == ART_PLAGUE)
-					dieroll = (poisons_majoreff&OPOISON_FILTH) ? 1 : (dieroll == 1) ? 2 : dieroll;
 				returnvalue = apply_hit_effects(magr, mdef, otmp, weapon, basedmg, &artidmg, &elemdmg, dieroll, &hittxt);
 				if (returnvalue == MM_MISS || (returnvalue & (MM_DEF_DIED | MM_DEF_LSVD)))
 					return returnvalue;


### PR DESCRIPTION
Poison "instakill" vs monsters -> nerfed to a flat 80 damage.
Filth "instakill" vs monsters -> nerfed to a flat 100 damage.

Plague uses artinstance and doesn't screw with dieroll.