### PR TITLE
Fix null mdef segfault

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -1812,7 +1812,7 @@ int tary;
 	/* print spell-cast message */
 	if (spellnum) {
 		if ((youagr || (youdef && !is_undirected_spell(spellnum)) || canspotmon(magr)) && magr->mtyp != PM_HOUND_OF_TINDALOS) {
-			if (is_undirected_spell(spellnum))
+			if (is_undirected_spell(spellnum) || notarget)
 				buf[0] = '\0';
 			else
 			{


### PR DESCRIPTION
Could happen for a spell that can be cast without a target, but is directable (ex, mon_protection can be self-cast mdef==null or cast at a far target)