### PR TITLE
New artifact: Apotheosis Veil

### DIFF
--- a/src/artilist.c
+++ b/src/artilist.c
@@ -1181,6 +1181,17 @@ A("Stormhelm",						HELM_OF_BRILLIANCE,				(const char *)0,
 	NOINVOKE, (ARTI_PLUSSEV)
 	),
 
+/* non-wizards wearing it get reduced-hunger casting (with a -4 INT penalty) */
+A("Apotheosis Veil",				CRYSTAL_HELM,			(const char *)0,
+	2500L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	A_NONE, NON_PM, NON_PM, TIER_C, NOFLAG,
+	NO_MONS(),
+	NO_ATTK(), NOFLAG,
+	PROPS(SEE_INVIS, DRAIN_RES, EXTRAMISSION), NOFLAG,
+	PROPS(), NOFLAG,
+	ENLIGHTENING, (ARTI_PLUSSEV)
+	),
+
 A("Hellrider's Saddle",				SADDLE,					(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_NONE, NON_PM, NON_PM, TIER_A, NOFLAG,

--- a/src/spell.c
+++ b/src/spell.c
@@ -1603,7 +1603,8 @@ int energy;
 	 */
 	intell = acurr(A_INT);
 	if (!Role_if(PM_WIZARD)){
-		if(u.sealsActive&SEAL_PAIMON) intell -= 6;
+		if(uarmh && uarmh->oartifact == ART_APOTHEOSIS_VEIL) intell -= 4;
+		else if(u.sealsActive&SEAL_PAIMON) intell -= 6;
 		else intell -= 10;
 	}
 	if(intell < 15);


### PR DESCRIPTION
Unaligned Crystal Helm

Grants:
* Drain resistance
* See invisible
* Ability to see in both light and dark
* Reduced-hunger spellcasting (at a -4 INT penalty compared to being a wizard)

It'll be good to have another artifact helmet besides Stormhelm (even if it is a crystal helm). Open to revisions and suggestions, too.