### PR TITLE
Fix off-by-one error in safety check

### DIFF
--- a/src/botl.c
+++ b/src/botl.c
@@ -375,7 +375,7 @@ bot1()
 	    char tmp[MAXCO];
 	    char *p = tmp;
 	    int filledbar = ((uhp() < 0) ? 0 : uhp()) * bar_length / uhpmax();
-	    if (filledbar >= MAXCO) { filledbar = MAXCO-1; }
+	    if (filledbar >= MAXCO-1) { filledbar = MAXCO-2; }
 	    Strcpy(tmp, newbot1);
 	    p++;
 


### PR DESCRIPTION
`p` starts writing at the 1 index of tmp[MAXCO], so we can only index p to MAXCO-2 at most