### PR TITLE
Fix impossible moving to a new level that's full

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1497,8 +1497,16 @@ misc_levelport:
 		mnexto(mtmp);
 
 	    if ((mtmp = m_at(u.ux, u.uy)) != 0) {
-		impossible("mnexto failed (do.c)?");
-		(void) rloc(mtmp, FALSE);
+#ifdef WIZARD
+		/* there was an unconditional impossible("mnearto failed")
+		   here, but it's not impossible and we're prepared to cope
+		   with the situation, so only say something when debugging */
+		if (wizard) pline("(monster in hero's way)");
+#endif
+		if (!rloc(mtmp, TRUE))
+		    /* no room to move it; send it away, to return later */
+		    migrate_to_level(mtmp, ledger_no(&u.uz),
+				     MIGR_RANDOM, (coord *)0);
 	    }
 	}
 


### PR DESCRIPTION
If a position is determined for you to be placed in that's occupied by a
monster, then it tries once to move the monster then hits an impossible

This is seen very commonly when fuzzing

Vanilla takes a different approach, and migrates the monster to the void
temporarily until it can be later reintroduced

See vanilla commit 2e8c4b08 corresponding to this