### PR TITLE
Fix use after free from light disintegration

### DIFF
--- a/src/worn.c
+++ b/src/worn.c
@@ -2008,7 +2008,6 @@ long timeout;
 				obj->oeroded = 0;
 			} else {
 				useupall(obj);
-				obj->oeroded = 0;
 			}
 	    } else if (obj == uquiver) {
 			uqwepgone();


### PR DESCRIPTION
Spotted in the specific case of a droven chain mail wielded in the
swap weapon slot being destroyed due to light