### PR TITLE
Revert changes made to remove_rooms(); use different Spire-Dispensary…

### DIFF
--- a/dat/dngnch1.def
+++ b/dat/dngnch1.def
@@ -149,7 +149,7 @@ LEVEL:		"out3" "C" @ (4,0)
 LEVEL:		"out4" "D" @ (5,0)
 LEVEL:		"spire" "E" @ (6,0)
 LEVEL:		"sumall" "none" @ (7,0)
-BRANCH:		"The Dispensary" @ (2, 5)
+BRANCH:		"The Dispensary" @ (2, 4)
 BRANCH:		"The Lost Cities" @ (-1, 0)
 
 

--- a/dat/dngnch2.def
+++ b/dat/dngnch2.def
@@ -149,7 +149,7 @@ LEVEL:		"out3" "C" @ (4,0)
 LEVEL:		"out4" "D" @ (5,0)
 LEVEL:		"spire" "E" @ (6,0)
 LEVEL:		"sumall" "none" @ (7,0)
-BRANCH:		"The Dispensary" @ (2, 5)
+BRANCH:		"The Dispensary" @ (2, 4)
 BRANCH:		"The Lost Cities" @ (-1, 0)
 
 

--- a/dat/dngnch3.def
+++ b/dat/dngnch3.def
@@ -149,7 +149,7 @@ LEVEL:		"out3" "C" @ (4,0)
 LEVEL:		"out4" "D" @ (5,0)
 LEVEL:		"spire" "E" @ (6,0)
 LEVEL:		"sumall" "none" @ (7,0)
-BRANCH:		"The Dispensary" @ (2, 5)
+BRANCH:		"The Dispensary" @ (2, 4)
 BRANCH:		"The Lost Cities" @ (-1, 0)
 
 

--- a/src/mkmap.c
+++ b/src/mkmap.c
@@ -375,7 +375,7 @@ remove_rooms(lx, ly, hx, hy, bg_typ)
 int lx, ly, hx, hy;
 schar bg_typ;
 {
-	int i;
+    int i;
     struct mkroom *croom;
 
     for (i = nroom - 1; i >= 0; --i) {
@@ -385,31 +385,9 @@ schar bg_typ;
 
 	if (croom->lx < lx || croom->hx >= hx ||
 	    croom->ly < ly || croom->hy >= hy) { /* partial overlap */
-		/* change room boundaries */
-		if (croom->lx < lx)
-			croom->hx = lx-1;
-		if (croom->ly < ly)
-			croom->hy = ly-1;
-		if (croom->hx >= hx)
-			croom->lx = hx;
-		if (croom->hy >= hy)
-			croom->ly = hy;
-
-		if (!croom->irregular) impossible("regular room in joined map");
-
-		/* if this clobbered the room, remove it */
-		register int x;
-		register int y;
-		register int n;
-		n = 0;
-		for (x = croom->lx; x < croom->hx; x++)
-		for (y = croom->ly; y < croom->hy; y++)
-		if (levl[x][y].typ != bg_typ)
-			n++;
-		if (!n)
-			remove_room((unsigned)i);
-
 	    /* TODO: ensure remaining parts of room are still joined */
+
+	    if (!croom->irregular) impossible("regular room in joined map");
 	} else {
 	    /* total overlap, remove the room */
 	    remove_room((unsigned)i);


### PR DESCRIPTION
… fix

Turns out I made a big mistake changing remove_rooms().
The roomno of parts of levl[][] wasn't being cleared when rooms were.

This rolls back remove_rooms() to prior to that change, which reintroduces the issue of the dispensary stairs appearing behind the Spire.
Fixes that issue by forcing the dispensary stairs to appear in one of the prior levels (it can never appear on the spire level now).