### PR TITLE
Change ranged weapon balance

### DIFF
--- a/src/artilist.c
+++ b/src/artilist.c
@@ -940,12 +940,12 @@ A("Plague",				BOW,							(const char *)0,
 	),
 
 /*Needs encyc entry*/
-/* all non-artifact arrows fired from it return to your inventory 5 turns later */
+/* all arrows fired from it return to your inventory 5 turns later */
 A("Epoch's Curve",			BOW,							"white ash longbow",
 	4000L, WOOD, MZ_DEFAULT, WT_DEFAULT,
 	A_NEUTRAL, NON_PM, NON_PM, TIER_B, (ARTG_GIFT),
 	NO_MONS(),
-	ATTK(AD_PHYS, 5, 6), NOFLAG,
+	ATTK(AD_PHYS, 5, 1), NOFLAG,
 	PROPS(TELEPORT_CONTROL), NOFLAG,
 	PROPS(), NOFLAG,
 	TELEPORT_SHOES, NOFLAG
@@ -2279,7 +2279,7 @@ A("The Longbow of Diana",			BOW,				(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_CHAOTIC, PM_RANGER, NON_PM, TIER_A, (ARTG_NOGEN|ARTG_NOWISH|ARTG_MAJOR),
 	NO_MONS(),
-	ATTK(AD_PHYS, 5, 0), (ARTA_SILVER),
+	ATTK(AD_PHYS, 5, 6), (ARTA_SILVER),
 	PROPS(REFLECTING), NOFLAG,
 	PROPS(TELEPAT), NOFLAG,
 	CREATE_AMMO, NOFLAG
@@ -2332,7 +2332,7 @@ A("The Moonbow of Sehanine",		ELVEN_BOW,			(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_CHAOTIC, PM_RANGER, PM_ELF, TIER_A, (ARTG_NOGEN|ARTG_NOWISH|ARTG_MAJOR),
 	NO_MONS(),
-	ATTK(AD_PHYS, 5, 0), (ARTA_SILVER),
+	ATTK(AD_PHYS, 5, 6), (ARTA_SILVER),
 	PROPS(), NOFLAG,
 	PROPS(), NOFLAG,
 	CREATE_AMMO, NOFLAG
@@ -2388,7 +2388,7 @@ A("Belthronding",					ELVEN_BOW,			(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_CHAOTIC, NON_PM, PM_ELF, TIER_A, (ARTG_NOGEN|ARTG_NOWISH|ARTG_MAJOR),
 	NO_MONS(),
-	ATTK(AD_PHYS, 5, 0), NOFLAG,
+	ATTK(AD_PHYS, 5, 6), NOFLAG,
 	PROPS(STEALTH), NOFLAG,
 	PROPS(DISPLACED), NOFLAG,
 	CREATE_AMMO, NOFLAG

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -182,11 +182,13 @@ boolean impaired;				/* TRUE if throwing/firing slipped OR magr is confused/stun
 	if (youagr && fired && (
 		thrownobj->oartifact == ART_SUNBEAM ||
 		thrownobj->oartifact == ART_MOONBEAM ||
-		(launcher && launcher->oartifact == ART_EPOCH_S_CURVE && !thrownobj->oartifact)
+		(launcher && launcher->oartifact == ART_EPOCH_S_CURVE)
 		)) {
-		int delay = rnz(20);
-		if (launcher && launcher->oartifact == ART_EPOCH_S_CURVE)	/* accelerates return of sunbeam/moonbeam */
+		int delay = rnd(20)+2;
+		if (launcher && launcher->oartifact == ART_EPOCH_S_CURVE)
 			delay = min(delay, 5);
+		if (thrownobj->oartifact)
+			delay += rnz(10);
 
 		start_timer(delay, TIMER_OBJECT, RETURN_AMMO, (genericptr_t)thrownobj);
 	}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -11962,8 +11962,6 @@ int vis;						/* True if action is at all visible to the player */
 			case OPOISON_FILTH:
 				resists = Sick_res(mdef);
 				majoreff = !rn2(10);
-				if (launcher && launcher->oartifact == ART_PLAGUE && monstermoves < artinstance[ART_PLAGUE].PlagueDuration)
-					majoreff = !rn2(5);	/* while invoked, Plague's arrows are twice as likely to instakill (=20%) */
 				break;
 			case OPOISON_SLEEP:
 				resists = Sleep_res(mdef);
@@ -12798,12 +12796,12 @@ int vis;						/* True if action is at all visible to the player */
 				/* precision fired ammo gets skill bonuses, multiplied */
 				if (is_ammo(weapon) && (precision_mult))
 					skill_damage = weapon_dam_bonus(launcher, wtype) * precision_mult;
-				/* spears fired from atlatls also get their skill bonus */
-				else if (launcher->otyp == ATLATL)
-					skill_damage = weapon_dam_bonus(launcher, wtype);
-				/* other fired ammo does not get skill bonuses */
-				else
+				/* non-precision guns (all but the sniper rifle) do not get skill damage */
+				else if (is_firearm(launcher))
 					skill_damage = 0;
+				/* other fired ammo gets normal skill bonus */
+				else
+					skill_damage = weapon_dam_bonus(launcher, wtype);
 			}
 			/* things thrown with no launcher */
 			else if (fired && !launcher) {


### PR DESCRIPTION
Why:
Bows suck too much for casual use. Unenchanted ammo with a non-artifact bow is just horribly low damage, even at Expert skill. Throwing daggers or darts is much better than using a bow. No more!

What:
All ammo fired from a launcher now gets +Skill damage, except for guns. This buffs bows and slings; crossbows already got skill damage from their precision.

To compensate, several bow artifacts were nerfed:
Ranger quest artifacts changed from 2x damage to +1d6. For +7 arrows, that's a net change of -2 per arrow.
Epoch's Curve bonus damage reduced from +1d6 to +1. It now returns artifact arrows fired, though they are slower to return.
Plague's invoke changed to not increase the critical filth rate.

Sunbeam and Moonbeam received changes to how quickly they return after being fired, particularly in conjunction with Epoch's Curve.

The following bow artifacts were not changed:
Yoichi no Yumi, the Lawful Samurai crowning gift. It still has less DPR than an Elven Ranger wielding Belthronding.
The Bow of Skadi, the Neutral Valkyrie crowning gift.