### PR TITLE
Fix two simple warnings

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -941,7 +941,7 @@ int how;
 		else {
 			killer = 0;
 			killer_format = 0;
-			const char * llogstr;
+			char * llogstr;
 			switch (lsvd)
 			{
 			case LSVD_MISC: llogstr = "averted death";

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1981,9 +1981,9 @@ register struct monst *mon;
 					((tobj = m_carrying_charged(mon, HAND_BLASTER)) && tobj != MON_WEP(mon)) ||
 					/* bullets */
 					((m_carrying(mon, BULLET) || m_carrying(mon, SILVER_BULLET)) &&
-						((tobj = oselect(mon, ASSAULT_RIFLE, W_SWAPWEP))) ||
+						(((tobj = oselect(mon, ASSAULT_RIFLE, W_SWAPWEP))) ||
 						((tobj = oselect(mon, SUBMACHINE_GUN, W_SWAPWEP))) ||
-						((tobj = oselect(mon, PISTOL, W_SWAPWEP)))) ||
+						((tobj = oselect(mon, PISTOL, W_SWAPWEP))))) ||
 					/* shotgun shells */
 					((m_carrying(mon, SHOTGUN_SHELL)) &&
 						((tobj = oselect(mon, SHOTGUN, W_SWAPWEP))))


### PR DESCRIPTION
Unnecessary `const` that caused a warning, bad paren order of ops.