### PR TITLE
Port Paxed's #wizmakemap function

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -196,6 +196,7 @@ E int NDECL(uhpmax);
 
 /* ### ball.c ### */
 
+E void FDECL(ballrelease, (boolean));
 E void NDECL(ballfall);
 E void NDECL(placebc);
 E void NDECL(unplacebc);
@@ -714,6 +715,7 @@ E schar FDECL(print_dungeon, (BOOLEAN_P,schar *,int *));
 E int NDECL(donamelevel);
 E int NDECL(dooverview);
 E void FDECL(forget_mapseen, (int));
+E void FDECL(rm_mapseen, (int));
 E void FDECL(init_mapseen, (d_level *));
 E void NDECL(recalc_mapseen);
 E void FDECL(recbranch_mapseen, (d_level *, d_level *));
@@ -1176,6 +1178,7 @@ E int NDECL(wiz_light_sources);
 E int NDECL(forcelock);
 E int NDECL(picklock);
 #endif
+E boolean NDECL(is_box_picking_context);
 E boolean FDECL(picking_lock, (int *,int *));
 E boolean FDECL(picking_at, (int,int));
 E boolean FDECL(forcing_door, (int *, int*));
@@ -2471,6 +2474,7 @@ E void FDECL(subfrombill, (struct obj *,struct monst *));
 E long FDECL(stolen_value, (struct obj *,XCHAR_P,XCHAR_P,BOOLEAN_P,BOOLEAN_P));
 E void FDECL(sellobj_state, (int));
 E void FDECL(sellobj, (struct obj *,XCHAR_P,XCHAR_P));
+E void FDECL(setpaid, (struct monst *));
 E int FDECL(doinvbill, (int));
 E long FDECL(getprice, (struct obj *, BOOLEAN_P, BOOLEAN_P));
 E struct monst *FDECL(shkcatch, (struct obj *,XCHAR_P,XCHAR_P));

--- a/src/ball.c
+++ b/src/ball.c
@@ -10,25 +10,33 @@ STATIC_DCL int NDECL(bc_order);
 STATIC_DCL void NDECL(litter);
 
 void
+ballrelease(showmsg)
+boolean showmsg;
+{
+    if (carried(uball)) {
+        if (showmsg)
+            pline("Startled, you drop the iron ball.");
+        if (uwep == uball)
+            setuwep((struct obj *) 0);
+        if (uswapwep == uball)
+            setuswapwep((struct obj *) 0);
+        if (uquiver == uball)
+            setuqwep((struct obj *) 0);
+        /* [this used to test 'if (uwep != uball)' but that always passes
+           after the setuwep() above] */
+        freeinv(uball); /* remove from inventory but don't place on floor */
+        encumber_msg();
+    }
+}
+
+void
 ballfall()
 {
 	boolean gets_hit;
 
 	gets_hit = (((uball->ox != u.ux) || (uball->oy != u.uy)) &&
 		    ((uwep == uball)? FALSE : (boolean)rn2(5)));
-	if (carried(uball)) {
-		pline("Startled, you drop the iron ball.");
-		if (uwep == uball)
-			setuwep((struct obj *)0);
-		if (uswapwep == uball)
-			setuswapwep((struct obj *)0);
-		if (uquiver == uball)
-			setuqwep((struct obj *)0);
-        /* [this used to test 'if (uwep != uball)' but that always passes
-           after the setuwep() above] */
-        freeinv(uball); /* remove from inventory but don't place on floor */
-        encumber_msg();
-	}
+	ballrelease(TRUE);
 	if(gets_hit){
 		int dmg = rn1(7,25);
 		pline_The("iron ball falls on your %s.",

--- a/src/do.c
+++ b/src/do.c
@@ -1381,15 +1381,7 @@ remake:
 		    You("fall down the %s.", at_ladder ? "ladder" : "stairs");
 		    if (Punished) {
 			drag_down();
-				if (carried(uball)) {
-					if (uwep == uball)
-					setuwep((struct obj *)0);
-					if (uswapwep == uball)
-					setuswapwep((struct obj *)0);
-					if (uquiver == uball)
-					setuqwep((struct obj *)0);
-					freeinv(uball);
-				}
+			ballrelease(FALSE);
 		    }
 			if(((uwep && is_lightsaber(uwep) && litsaber(uwep))) ||
 				(uswapwep && is_lightsaber(uswapwep) && litsaber(uswapwep) && u.twoweap)

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -2200,6 +2200,33 @@ int ledger_no;
 	}
 }
 
+void
+rm_mapseen(ledger_num)
+int ledger_num;
+{
+    mapseen *mptr, *mprev = (mapseen *)0;
+
+    for (mptr = mapseenchn; mptr; mprev = mptr, mptr = mptr->next)
+        if (dungeons[mptr->lev.dnum].ledger_start + mptr->lev.dlevel
+            == ledger_num)
+            break;
+
+    if (!mptr)
+        return;
+
+    if (mptr->custom)
+        free((genericptr_t) mptr->custom);
+
+    if (mprev) {
+        mprev->next = mptr->next;
+        free(mptr);
+    } else {
+        mapseenchn = mptr->next;
+        free(mptr);
+    }
+}
+
+
 STATIC_OVL void
 save_mapseen(fd, mptr)
 int fd;

--- a/src/light.c
+++ b/src/light.c
@@ -525,7 +525,8 @@ struct ls_t * ls;
 int fd;
 int mode;
 {
-	bwrite(fd, (genericptr_t)ls, sizeof(struct ls_t));
+	if (perform_bwrite(mode))
+	    bwrite(fd, (genericptr_t)ls, sizeof(struct ls_t));
 	if (release_data(mode))
 		del_light_source(ls);
 	return;

--- a/src/lock.c
+++ b/src/lock.c
@@ -32,7 +32,7 @@ And I shall endure eternally.\n\
 All hope abandon, ye who enter here!"
 };
 /* at most one of `door' and `box' should be non-null at any given time */
-STATIC_VAR NEARDATA struct xlock_s {
+NEARDATA struct xlock_s {
 	struct rm  *door;
 	struct obj *box;
 	int picktyp, chance, usedtime;
@@ -46,6 +46,11 @@ STATIC_VAR NEARDATA struct xlock_s {
 STATIC_DCL const char *NDECL(lock_action);
 STATIC_DCL boolean FDECL(obstructed,(int,int));
 STATIC_DCL void FDECL(chest_shatter_msg, (struct obj *));
+
+boolean
+is_box_picking_context() {
+	return (!xlock.box || !carried(xlock.box));
+}
 
 boolean
 picking_lock(x, y)

--- a/src/shk.c
+++ b/src/shk.c
@@ -26,7 +26,6 @@ extern const struct shclass shtypes[];	/* defined in shknam.c */
 
 STATIC_VAR NEARDATA long int followmsg;	/* last time of follow message */
 
-STATIC_DCL void FDECL(setpaid, (struct monst *));
 STATIC_DCL long FDECL(addupbill, (struct monst *));
 STATIC_DCL void FDECL(setallstolen, (struct obj *));
 STATIC_DCL void FDECL(setallpaid, (struct obj *));
@@ -311,7 +310,7 @@ register struct obj *list;
 #ifdef OVLB
 
 /* either you paid or left the shop or the shopkeeper died */
-STATIC_OVL void
+void
 setpaid(shkp)
 register struct monst *shkp;
 {


### PR DESCRIPTION
The command #wizmakemap recreates the current level, which can be useful
for testing the loading of special levels when reproducing bugs

Naturally, this is only accessible in wizard mode

It can be used whilst fuzzing as well if you remap a keybind (e.g. V) to
wizmakemap and allow it to happen

Roughly follows the behaviour of the 3.6 version, with minor tweaks to
get it to work in dnethack