### PR TITLE
Catch null pointer write

### DIFF
--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -326,9 +326,11 @@ mkmivault()
 				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
 				if (rn2(2)) add_to_container(otmp, mkobj(SCROLL_CLASS, FALSE));
 			}
-			mon->mstrategy |= STRAT_WAITFORU;
-			mon->mpeaceful = FALSE;
-			set_malign(mon);
+			if (mon) {
+			    mon->mstrategy |= STRAT_WAITFORU;
+			    mon->mpeaceful = FALSE;
+			    set_malign(mon);
+			}
 		}
 	}
 }


### PR DESCRIPTION
In mkmiroom, creating a monster can fail and return a null value for
mon, which is then written to