### PR TITLE
Set iflags.travelcc to -1 in wizmakemap

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1276,7 +1276,7 @@ wiz_makemap(VOID_ARGS)
 
 	if (on_level(&digging.level, &u.uz))
 	    (void) memset((genericptr_t) &digging, 0, sizeof (struct dig_info));
-	iflags.travelcc.x = iflags.travelcc.y = 0;
+	iflags.travelcc.x = iflags.travelcc.y = -1;
 
 	u.utrap = 0;
 	u.utraptype = 0;


### PR DESCRIPTION
In dnh the special values to signify a lack of a cached destination is
in fact -1,-1 and not 0,0

This will otherwise crash during fuzzing if '_K' is sent