### PR TITLE
Add HAS_EPRI macro for guarding against accesses

### DIFF
--- a/include/exstruct.h
+++ b/include/exstruct.h
@@ -74,6 +74,7 @@ struct epri {
 	boolean pbanned;	/* player banned by priest */
 	char signspotted;	/* max number of signs spotted by priest */
 };
+#define HAS_EPRI(mon)	((mon) && (mon)->mextra_p && (mon)->mextra_p->epri_p)
 #define EPRI(mon)	((mon)->mextra_p->epri_p)
 /* A priest without ispriest is a roaming priest without a shrine, so
  * the fields (except shralign, which becomes only the priest alignment)

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -58,17 +58,17 @@
 #define is_lminion(mon)		(is_minion((mon)->data) && \
 				 (mon)->data->maligntyp > A_NEUTRAL && \
 				 ((mon)->mtyp != PM_ANGEL || \
-				  EPRI(mon)->shralign > 0))
+				  (HAS_EPRI(mon) && EPRI(mon)->shralign > 0)))
 
 #define is_nminion(mon)		(is_minion((mon)->data) && \
 				 (mon)->data->maligntyp == A_NEUTRAL && \
 				 ((mon)->mtyp != PM_ANGEL || \
-				  EPRI(mon)->shralign == 0))
+				  (HAS_EPRI(mon) && EPRI(mon)->shralign == 0)))
 
 #define is_cminion(mon)		(is_minion((mon)->data) && \
 				 (mon)->data->maligntyp < A_NEUTRAL && \
 				 ((mon)->mtyp != PM_ANGEL || \
-				  EPRI(mon)->shralign < 0))
+				 (HAS_EPRI(mon) && EPRI(mon)->shralign < 0)))
 
 #define notonline(ptr)			(((ptr)->mflagsm & MM_NOTONL) != 0L)
 #define fleetflee(ptr)			(((ptr)->mflagsm & MM_FLEETFLEE) != 0L)


### PR DESCRIPTION
Added to is_{l,m,c}minion macros as during fuzzing there was a curious
case of an angel with no mextra_p