### PR TITLE
Guard against null mon in canspotmon macro

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -149,7 +149,7 @@
  * known.
  */
 #define canspotmon(mon) \
-	(canseemon(mon) || sensemon(mon))
+	((mon) && (canseemon(mon) || sensemon(mon)))
 
 /* knowninvisible(mon)
  * This one checks to see if you know a monster is both there and invisible.


### PR DESCRIPTION
This prevents at least one segfault, from #tipping a nonexistent monster

Note that canseemon and sensemon weren't touched here, perhaps they ought to be as well?