### PR TITLE
Fix read after free from destroyed wand engraving

### DIFF
--- a/src/engrave.c
+++ b/src/engrave.c
@@ -2456,7 +2456,7 @@ int mode;
 				"sand" :
 				"dust");
 	    useup(otmp);
-	    ptext = FALSE;
+	    return(1);
 	}
 
 	if (!ptext) {		/* Early exit for some implements. */


### PR DESCRIPTION
If a wand turns to dust during the engrave it would be used up then
immediately read from. This just returns slightly earlier than before