### PR TITLE
Rewrite obj_to_glyph as function

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -43,7 +43,6 @@ E NEARDATA int occtime;
 E uchar warnsyms[WARNCOUNT];
 
 E int x_maze_max, y_maze_max;
-E int otg_temp;
 
 #ifdef REDO
 E NEARDATA int in_doagain;

--- a/include/display.h
+++ b/include/display.h
@@ -348,17 +348,6 @@
 #define peace_to_glyph(mon) ((int) what_mon(monsndx((mon)->data), mon)+GLYPH_PEACE_OFF)
 #define zombie_to_glyph(mon) ((int) what_mon(monsndx((mon)->data), mon)+GLYPH_ZOMBIE_OFF)
 
-/* This has the unfortunate side effect of needing a global variable	*/
-/* to store a result. 'otg_temp' is defined and declared in decl.{ch}.	*/
-#define obj_to_glyph(obj)						      \
-    (Hallucination ?							      \
-	((otg_temp = random_object()) == CORPSE ?			      \
-	    random_monster() + GLYPH_BODY_OFF :				      \
-	    ((otg_temp << 4) + rn2(16)) + GLYPH_OBJ_OFF)	:				      \
-	((obj)->otyp == CORPSE ?					      \
-	    (int) (obj)->corpsenm + GLYPH_BODY_OFF :			      \
-	    (int) ((obj)->otyp << 4) + object_color(obj) + GLYPH_OBJ_OFF))
-
 #define cmap_to_glyph(cmap_idx) ((int) (cmap_idx)   + GLYPH_CMAP_OFF)
 #define explosion_to_glyph(expltype,idx)	\
 		((((expltype) * MAXEXPCHARS) + ((idx) - S_explode1)) + GLYPH_EXPLODE_OFF)

--- a/include/extern.h
+++ b/include/extern.h
@@ -392,6 +392,7 @@ E struct obj * FDECL(vobj_at, (XCHAR_P,XCHAR_P));
 E void FDECL(magic_map_background, (XCHAR_P,XCHAR_P,int));
 E void FDECL(map_background, (XCHAR_P,XCHAR_P,int));
 E void FDECL(map_trap, (struct trap *,int));
+E int FDECL(obj_to_glyph, (struct obj *));
 E void FDECL(map_object, (struct obj *,int));
 E void FDECL(map_invisible, (XCHAR_P,XCHAR_P));
 E void FDECL(unmap_object, (int,int));

--- a/src/decl.c
+++ b/src/decl.c
@@ -33,7 +33,6 @@ NEARDATA int nsubroom = 0;
 NEARDATA int occtime = 0;
 
 int x_maze_max, y_maze_max;	/* initialized in main, used in mkmaze.c */
-int otg_temp;			/* used by object_to_glyph() [otg] */
 
 #ifdef REDO
 NEARDATA int in_doagain = 0;

--- a/src/display.c
+++ b/src/display.c
@@ -249,6 +249,22 @@ map_trap(trap, show)
     if (show) show_glyph(x, y, glyph);
 }
 
+int
+obj_to_glyph(obj)
+    struct obj *obj;
+{
+    int otyp = Hallucination ? random_object() : obj->otyp;
+
+    if (otyp == CORPSE) {
+	int corpsenm = Hallucination ? random_monster() : obj->corpsenm;
+	return corpsenm + GLYPH_MON_OFF;
+    }
+
+    int ocolor = Hallucination ? rn2(16) : object_color(obj);
+    return (otyp << 4) + ocolor + GLYPH_OBJ_OFF;
+}
+
+
 /*
  * map_object()
  *

--- a/src/display.c
+++ b/src/display.c
@@ -257,7 +257,7 @@ obj_to_glyph(obj)
 
     if (otyp == CORPSE) {
 	int corpsenm = Hallucination ? random_monster() : obj->corpsenm;
-	return corpsenm + GLYPH_MON_OFF;
+	return corpsenm + GLYPH_BODY_OFF;
     }
 
     int ocolor = Hallucination ? rn2(16) : object_color(obj);


### PR DESCRIPTION
This rewrites obj_to_glyph to avoid the unusual use of a global variable
to store an integer