### PR TITLE
Clamp circle_ptr radius to [0, MAX_RADIUS]

### DIFF
--- a/include/vision.h
+++ b/include/vision.h
@@ -75,7 +75,9 @@ extern char *viz_rmax;			/* max could see indices */
  */
 #define MAX_RADIUS 21	/* this is in points from the source */
 
-/* Use this macro to get a list of distances of the edges (see vision.c). */
-#define circle_ptr(z) (&circle_data[(int)circle_start[z]])
+/* Use this macro to get a list of distances of the edges (see vision.c).
+ * We clamp this in [0,MAX_RADIUS] to avoid reading out of bounds
+ */
+#define circle_ptr(z) (&circle_data[(int)circle_start[z < 0 ? 0 : z > MAX_RADIUS ? MAX_RADIUS : z]])
 
 #endif /* VISION_H */


### PR DESCRIPTION
We already expanded max radius to 21, and there are two monsters for
which this ought to perhaps be expanded further up to 27

Regardless of if we do that or not, it is sensible to clamp the radius
anyway to prevent out of bounds reads.