### PR TITLE
Limit polymorphs of template'd monsters to reasonably retain template

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1569,6 +1569,7 @@ E void FDECL(give_mintrinsic, (struct monst *, long));
 E void FDECL(remove_mintrinsic, (struct monst *, long));
 E void FDECL(set_faction, (struct monst *, int));
 E void FDECL(set_template, (struct monst *, int));
+E boolean FDECL(mtemplate_accepts_mtyp, (int, int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(attacktype, (struct permonst *,int));
 E boolean FDECL(noattacks, (struct permonst *));

--- a/include/hack.h
+++ b/include/hack.h
@@ -142,7 +142,7 @@ NEARDATA extern coord bhitpos;	/* place where throw or zap hits or stops */
 #define MATCH_WARN_OF_MON(mon)	( MATCH_WARN_OF_MON_STRICT(mon) || \
 					(u.sealsActive&SEAL_PAIMON && is_magical((mon)->data)) || \
 					(u.sealsActive&SEAL_ANDROMALIUS && is_thief((mon)->data)) || \
-					(u.sealsActive&SEAL_TENEBROUS && !nonliving_mon(mon)) || \
+					(u.sealsActive&SEAL_TENEBROUS && !nonliving(mon->data)) || \
 					(Upolyd && youmonst.data->mtyp == PM_SHARK && has_blood((mon)->data) && \
 						(mon)->mhp < (mon)->mhpmax && is_pool(u.ux, u.uy, TRUE) && is_pool((mon)->mx, (mon)->my, TRUE)) || \
 					(u.specialSealsActive&SEAL_ACERERAK && is_undead(mon->data)) || \

--- a/include/hack.h
+++ b/include/hack.h
@@ -145,7 +145,7 @@ NEARDATA extern coord bhitpos;	/* place where throw or zap hits or stops */
 					(u.sealsActive&SEAL_TENEBROUS && !nonliving_mon(mon)) || \
 					(Upolyd && youmonst.data->mtyp == PM_SHARK && has_blood((mon)->data) && \
 						(mon)->mhp < (mon)->mhpmax && is_pool(u.ux, u.uy, TRUE) && is_pool((mon)->mx, (mon)->my, TRUE)) || \
-					(u.specialSealsActive&SEAL_ACERERAK && is_undead_mon(mon)) || \
+					(u.specialSealsActive&SEAL_ACERERAK && is_undead(mon->data)) || \
 					(uwep && uwep->oclass == WEAPON_CLASS && (uwep)->obj_material == WOOD && uwep->otyp != MOON_AXE &&\
 					 (uwep->oward & WARD_THJOFASTAFUR) && ((mon)->data->mlet == S_LEPRECHAUN || (mon)->data->mlet == S_NYMPH || is_thief((mon)->data))) \
 				)
@@ -161,7 +161,7 @@ NEARDATA extern coord bhitpos;	/* place where throw or zap hits or stops */
 						(flags.warntypea & (mon)->data->mflagsa)) || \
 					(Warn_of_mon && flags.warntypea && \
 						(flags.warntypea & MA_UNDEAD && \
-						is_undead_mon(mon))) || \
+						is_undead(mon->data))) || \
 					(Warn_of_mon && flags.warntypev && \
 						(flags.warntypev & (mon)->data->mflagsv)) || \
 					(Warn_of_mon && flags.montype && \

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -288,9 +288,9 @@
 							 (ptr)->mtyp == PM_MILITANT_CLERIC ||\
 							 (ptr)->mtyp == PM_HALF_ELF_RANGER)
 #define is_undead(ptr)		(((ptr)->mflagsa & MA_UNDEAD) != 0L)
-#define	can_undead_mon(mon)	(mon && !nonliving((mon)->data) && !is_minion((mon)->data) && ((mon)->data->mlet != S_PUDDING) &&\
-								((mon)->data->mlet != S_JELLY) && ((mon)->data->mlet != S_BLOB) && !is_elemental((mon)->data) &&\
-								!is_plant((mon)->data) && !is_demon((mon)->data) && !is_primordial((mon)->data) && !(mvitals[monsndx((mon)->data)].mvflags&G_NOCORPSE))
+#define	can_undead(ptr)	(!nonliving(ptr) && !is_minion(ptr) && ((ptr)->mlet != S_PUDDING) &&\
+								((ptr)->mlet != S_JELLY) && ((ptr)->mlet != S_BLOB) && !is_elemental(ptr) &&\
+								!is_plant(ptr) && !is_demon(ptr) && !is_primordial(ptr) && !(mvitals[monsndx(ptr)].mvflags&G_NOCORPSE))
 #define is_weldproof(ptr)		(is_undead(ptr) || is_demon(ptr) || is_were(ptr))
 #define is_weldproof_mon(mon)		(is_weldproof((mon)->data))
 #define is_were(ptr)		(((ptr)->mflagsa & MA_WERE) != 0L)

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -288,7 +288,6 @@
 							 (ptr)->mtyp == PM_MILITANT_CLERIC ||\
 							 (ptr)->mtyp == PM_HALF_ELF_RANGER)
 #define is_undead(ptr)		(((ptr)->mflagsa & MA_UNDEAD) != 0L)
-#define is_undead_mon(mon)	(mon && is_undead((mon)->data))
 #define	can_undead_mon(mon)	(mon && !nonliving_mon(mon) && !is_minion((mon)->data) && ((mon)->data->mlet != S_PUDDING) &&\
 								((mon)->data->mlet != S_JELLY) && ((mon)->data->mlet != S_BLOB) && !is_elemental((mon)->data) &&\
 								!is_plant((mon)->data) && !is_demon((mon)->data) && !is_primordial((mon)->data) && !(mvitals[monsndx((mon)->data)].mvflags&G_NOCORPSE))
@@ -538,7 +537,7 @@
 #define helm_match(ptr,obj)	(((ptr->mflagsb&MB_HEADMODIMASK) == (obj->bodytypeflag&MB_HEADMODIMASK)))
 /*Note: No-modifier helms are "normal"*/
 
-#define hates_holy_mon(mon)	(is_demon((mon)->data) || is_undead_mon(mon) || (((mon)->data->mflagsg&MG_HATESHOLY) != 0))
+#define hates_holy_mon(mon)	(is_demon((mon)->data) || is_undead(mon->data) || (((mon)->data->mflagsg&MG_HATESHOLY) != 0))
 #define hates_holy(ptr)		(is_demon(ptr) || is_undead(ptr) || (((ptr)->mflagsg&MG_HATESHOLY) != 0))
 #define hates_unholy(ptr)	((ptr->mflagsg&MG_HATESUNHOLY) != 0)
 #define hates_unholy_mon(mon)	(hates_unholy((mon)->data))
@@ -745,7 +744,7 @@
 				 (ptr)->mtyp == PM_MANES \
 				)
 
-#define nonliving_mon(mon)	(mon && (nonliving((mon)->data) || is_undead_mon(mon)))
+#define nonliving_mon(mon)	(mon && (nonliving((mon)->data) || is_undead(mon->data)))
 
 #define is_unalive(ptr)		(on_level(&valley_level, &u.uz) || is_naturally_unalive(ptr))
 

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -227,7 +227,7 @@
 #define intelligent_mon(mon)	(!mindless_mon(mon) && !is_animal((mon)->data))
 #define murderable_mon(mon)	((mon) && ((intelligent_mon(mon) && always_peaceful((mon)->data) && !always_hostile_mon(mon)) || (mon)->isshk || (mon)->isgd || (mon)->ispriest))
 
-#define mortal_race(mon)	(intelligent_mon(mon) && !nonliving_mon(mon) && !is_minion((mon)->data) && !is_demon((mon)->data) && !is_primordial((mon)->data))
+#define mortal_race(mon)	(intelligent_mon(mon) && !nonliving((mon)->data) && !is_minion((mon)->data) && !is_demon((mon)->data) && !is_primordial((mon)->data))
 #define dark_immune(mon)	(is_unalive((mon)->data) || is_primordial((mon)->data))
 
 #define slithy(ptr)			((ptr)->mflagsb & MB_SLITHY)
@@ -288,7 +288,7 @@
 							 (ptr)->mtyp == PM_MILITANT_CLERIC ||\
 							 (ptr)->mtyp == PM_HALF_ELF_RANGER)
 #define is_undead(ptr)		(((ptr)->mflagsa & MA_UNDEAD) != 0L)
-#define	can_undead_mon(mon)	(mon && !nonliving_mon(mon) && !is_minion((mon)->data) && ((mon)->data->mlet != S_PUDDING) &&\
+#define	can_undead_mon(mon)	(mon && !nonliving((mon)->data) && !is_minion((mon)->data) && ((mon)->data->mlet != S_PUDDING) &&\
 								((mon)->data->mlet != S_JELLY) && ((mon)->data->mlet != S_BLOB) && !is_elemental((mon)->data) &&\
 								!is_plant((mon)->data) && !is_demon((mon)->data) && !is_primordial((mon)->data) && !(mvitals[monsndx((mon)->data)].mvflags&G_NOCORPSE))
 #define is_weldproof(ptr)		(is_undead(ptr) || is_demon(ptr) || is_were(ptr))
@@ -743,8 +743,6 @@
 #define nonliving(ptr)	(is_unalive(ptr) || is_undead(ptr) || \
 				 (ptr)->mtyp == PM_MANES \
 				)
-
-#define nonliving_mon(mon)	(mon && (nonliving((mon)->data) || is_undead(mon->data)))
 
 #define is_unalive(ptr)		(on_level(&valley_level, &u.uz) || is_naturally_unalive(ptr))
 

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1782,7 +1782,7 @@ boolean narrow_only;
 		if (weap->mflagsa != 0L){
 			if ((weap->name == artilist[ART_SCOURGE_OF_LOLTH].name) && is_drow(ptr))
 				; // skip; the scourge of lolth hates Elves but not Drow.
-			else if ((weap->mflagsa & MA_UNDEAD) && is_undead_mon(mdef))
+			else if ((weap->mflagsa & MA_UNDEAD) && is_undead(ptr))
 				return TRUE;
 			else if (
 				(ptr->mflagsa & weap->mflagsa) ||
@@ -7168,7 +7168,7 @@ arti_invoke(obj)
 			for (mtmp = fmon; mtmp; mtmp = mtmp2) {
 				mtmp2 = mtmp->nmon;
 				/* The eye is never blind ... */
-				if (couldsee(mtmp->mx, mtmp->my) && !is_undead_mon(mtmp)) {
+				if (couldsee(mtmp->mx, mtmp->my) && !is_undead(mtmp->data)) {
 					pline("%s screams in agony!",Monnam(mtmp));
 					mtmp->mhp /= 4;
 					if (mtmp->mhp < 1) mtmp->mhp = 1;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2355,7 +2355,7 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		}
 		if(youdefend ? is_golem(youracedata) : is_golem(mdef->data)){
 			*dmgptr += d(2*dnum,4);
-		} else if(youdefend ? nonliving(youracedata) : nonliving_mon(mdef)){
+		} else if(youdefend ? nonliving(youracedata) : nonliving(mdef->data)){
 			*dmgptr += d(dnum,4);
 		}
 	} // nvPh - golem/nonliving
@@ -2380,7 +2380,7 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 			else and ? Strcat(buf, " and thirsty") : Sprintf(buf, "thirsty");
 			and = TRUE;
 		}
-		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving_mon(mdef) || is_anhydrous(mdef->data))){
+		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving(mdef->data) || is_anhydrous(mdef->data))){
 			*dmgptr += d(dnum,4);
 		}
 	} // nvPh - hydrous
@@ -2639,7 +2639,7 @@ struct obj *pen;	/* Pen of the Void */
 	if (pen->ovar1&SEAL_FAFNIR){
 		if(youdefend ? is_golem(youracedata) : is_golem(mdef->data)){
 			return TRUE;
-		} else if(youdefend ? nonliving(youracedata) : nonliving_mon(mdef)){
+		} else if(youdefend ? nonliving(youracedata) : nonliving(mdef->data)){
 			return TRUE;
 		}
 	}
@@ -2652,7 +2652,7 @@ struct obj *pen;	/* Pen of the Void */
 		}
 	}
 	if (pen->ovar1&SEAL_IRIS) {
-		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving_mon(mdef) || is_anhydrous(mdef->data))){
+		if(youdefend ? !(nonliving(youracedata) || is_anhydrous(youracedata)) : !(nonliving(mdef->data) || is_anhydrous(mdef->data))){
 			return TRUE;
 		}
 	}
@@ -3569,7 +3569,7 @@ boolean * messaged;
 				*truedmgptr += basedmg + 1;
 			else if (otmp->osinging == OSING_DEATH && !rn2(4)){
 				if (!resists_death(mdef)){
-					if (!(nonliving_mon(mdef) || is_demon(pd) || is_angel(pd))){
+					if (!(nonliving(mdef->data) || is_demon(pd) || is_angel(pd))){
 						pline("%s withers under the touch of %s.", The(Monnam(mdef)), The(xname(otmp)));
 						mdef->mhp = 1;
 						*truedmgptr += 10;
@@ -4570,7 +4570,7 @@ boolean * messaged;
 				}
 			}
 		}
-		else if (!(thick_skinned(pd) || (youdef && u.sealsActive&SEAL_ECHIDNA) || nonliving_mon(mdef)))
+		else if (!(thick_skinned(pd) || (youdef && u.sealsActive&SEAL_ECHIDNA) || nonliving(mdef->data)))
 		{
 			static long ulastscreamed = 0;
 			static long lastscreamed = 0;
@@ -6286,7 +6286,7 @@ arti_invoke(obj)
 				/* message */
 				pline("You reach out and stab at %s very soul.", s_suffix(mon_nam(mtmp)));
 				/* nonliving, demons, angels are immune */
-				if (nonliving_mon(mtmp) || is_demon(mtmp->data) || is_angel(mtmp->data))
+				if (nonliving(mtmp->data) || is_demon(mtmp->data) || is_angel(mtmp->data))
 					pline("... but %s seems to lack one!", mon_nam(mtmp));
 				/* circle of acheron provides protection */
 				else if (ward_at(mtmp->mx, mtmp->my) == CIRCLE_OF_ACHERON)
@@ -7401,7 +7401,7 @@ arti_invoke(obj)
                 struct monst *mtmp;
                 if((u.dx || u.dy) && (mtmp = m_at(u.ux+u.dx,u.uy+u.dy))){
                   if(!resists_death(mtmp)){
-                    if(!(nonliving_mon(mtmp) || is_demon(mtmp->data) || is_angel(mtmp->data))){
+                    if(!(nonliving(mtmp->data) || is_demon(mtmp->data) || is_angel(mtmp->data))){
                       pline("%s withers under the touch of %s.", The(Monnam(mtmp)), The(xname(obj)));
                       xkilled(mtmp, 1);
                       obj->ovar1 = COMMAND_LIFE;

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -780,7 +780,7 @@ maybe_append_injury_desc(mtmp, buf)
 struct monst * mtmp;
 char * buf;
 {
-	if (((u.sealsActive&SEAL_MOTHER && !is_undead(mtmp->data)) || (Role_if(PM_HEALER) && (!nonliving_mon(mtmp) || has_blood_mon(mtmp))) || (ublindf && ublindf->otyp == ANDROID_VISOR))
+	if (((u.sealsActive&SEAL_MOTHER && !is_undead(mtmp->data)) || (Role_if(PM_HEALER) && (!nonliving(mtmp->data) || has_blood_mon(mtmp))) || (ublindf && ublindf->otyp == ANDROID_VISOR))
 		&& !flags.suppress_hurtness){
 		if (mtmp->mhp >= mtmp->mhpmax) (has_blood_mon(mtmp)) ? Strcat(buf, "uninjured ") : Strcat(buf, "undamaged ");
 		else if (mtmp->mhp >= .9*mtmp->mhpmax) Strcat(buf, "scuffed ");

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -780,7 +780,7 @@ maybe_append_injury_desc(mtmp, buf)
 struct monst * mtmp;
 char * buf;
 {
-	if (((u.sealsActive&SEAL_MOTHER && !is_undead_mon(mtmp)) || (Role_if(PM_HEALER) && (!nonliving_mon(mtmp) || has_blood_mon(mtmp))) || (ublindf && ublindf->otyp == ANDROID_VISOR))
+	if (((u.sealsActive&SEAL_MOTHER && !is_undead(mtmp->data)) || (Role_if(PM_HEALER) && (!nonliving_mon(mtmp) || has_blood_mon(mtmp))) || (ublindf && ublindf->otyp == ANDROID_VISOR))
 		&& !flags.suppress_hurtness){
 		if (mtmp->mhp >= mtmp->mhpmax) (has_blood_mon(mtmp)) ? Strcat(buf, "uninjured ") : Strcat(buf, "undamaged ");
 		else if (mtmp->mhp >= .9*mtmp->mhpmax) Strcat(buf, "scuffed ");

--- a/src/dog.c
+++ b/src/dog.c
@@ -1023,7 +1023,7 @@ rock:
 			return (herbi ? CADAVER : MANFOOD);
 		    else return (carni ? CADAVER : MANFOOD);
 		case CLOVE_OF_GARLIC:
-		    return (is_undead_mon(mon) ? TABU :
+		    return (is_undead(mon->data) ? TABU :
 			    ((herbi || starving) ? ACCFOOD : MANFOOD));
 		case TIN:
 		    return (metallivorous(mon->data) ? ACCFOOD : MANFOOD);

--- a/src/dog.c
+++ b/src/dog.c
@@ -672,7 +672,7 @@ long nmv;		/* number of moves */
 			mtmp->mhp = mtmp->mhpmax;
 		else mtmp->mhp += imv;
 	}
-	if(!nonliving_mon(mtmp)){
+	if(!nonliving(mtmp->data)){
 		imv = imv*(mtmp->m_lev + mtmp->mcon)/30;
 		if (mtmp->mhp + imv >= mtmp->mhpmax)
 			mtmp->mhp = mtmp->mhpmax;

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -858,7 +858,7 @@ boolean ranged;
 		  || (Role_if(PM_NOBLEMAN) && (mtmp->mtyp == PM_KNIGHT || mtmp->mtyp == PM_MAID || mtmp->mtyp == PM_PEASANT) && mtmp->mpeaceful)
 		  || (Race_if(PM_DROW) && is_drow(mtmp->data) && mtmp->mpeaceful)
 		  || (Role_if(PM_KNIGHT) && (mtmp->mtyp == PM_KNIGHT) && mtmp->mpeaceful)
-		  || (Race_if(PM_GNOME) && (is_gnome(mtmp->data) && !is_undead_mon(mtmp)) && mtmp->mpeaceful)
+		  || (Race_if(PM_GNOME) && (is_gnome(mtmp->data) && !is_undead(mtmp->data)) && mtmp->mpeaceful)
 		  || always_peaceful(mtmp2->data)) &&
 		 mtmp2->mpeaceful && !(Conflict || mtmp->mberserk)) ||
 	   (!ranged && touch_petrifies(mtmp2->data) &&

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -10303,7 +10303,7 @@ struct monst *mtmp, *victim;
 		if (sensemon(mtmp))
 		    pline("As %s grows up into %s, %s %s!", mon_nam(mtmp),
 			an(ptr->mname), mhe(mtmp),
-			nonliving_mon(mtmp) ? "expires" : "dies");
+			nonliving(ptr) ? "expires" : "dies");
 		set_mon_data(mtmp, newtype);	/* keep mvitals[] accurate */
 		mondied(mtmp);
 		return (struct permonst *)0;

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -8476,13 +8476,13 @@ register int	mmflags;
 			undeadtemplate = FRACTURED;
 			unsethouse = TRUE;
 		}
-	} else if(randmonst && !undeadtemplate && can_undead_mon(mtmp) && check_insight()){
+	} else if(randmonst && !undeadtemplate && can_undead(mtmp->data) && check_insight()){
 		undeadtemplate = PSEUDONATURAL;
 		unsethouse = TRUE;
 	} else if(randmonst && !undeadtemplate && is_rat(mtmp->data) && check_insight()){
 		undeadtemplate = CRANIUM_RAT;
 		unsethouse = TRUE;
-	} else if(randmonst && !undeadtemplate && can_undead_mon(mtmp) && !Is_rogue_level(&u.uz)){
+	} else if(randmonst && !undeadtemplate && can_undead(mtmp->data) && !Is_rogue_level(&u.uz)){
 		if(In_mines(&u.uz)){
 			if(Race_if(PM_GNOME) && Role_if(PM_RANGER) && rn2(10) <= 5){
 				undeadtemplate = ZOMBIFIED;

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -2758,7 +2758,7 @@ int tary;
 				pline("%s's using the touch of death!", upstart(heshe));
 
 			/* check resistance cases and do effects */
-			if (nonliving_mon(mdef) || is_demon(mdef->data)) {
+			if (nonliving(mdef->data) || is_demon(mdef->data)) {
 				if (youdef || canseemon(mdef)) {
 					pline("%s seem%s no deader than before.",
 						youdef ? "You" : Monnam(mdef),

--- a/src/mon.c
+++ b/src/mon.c
@@ -1185,7 +1185,7 @@ register struct monst *mtmp;
 		break;
 	}
 	if(obj && obj->otyp == CORPSE){
-		if(is_undead_mon(mtmp)){
+		if(is_undead(mtmp->data)){
 			obj->age -= 100;		/* this is an *OLD* corpse */
 		}
 		/* All special cases should precede the G_NOCORPSE check */
@@ -3489,7 +3489,7 @@ struct monst * mdef;	/* another monster which is next to it */
 		  || (Role_if(PM_NOBLEMAN) && (ma->mtyp == PM_KNIGHT || ma->mtyp == PM_MAID || ma->mtyp == PM_PEASANT) && magr->mpeaceful && In_quest(&u.uz))
 		  || (Role_if(PM_KNIGHT) && ma->mtyp == PM_KNIGHT && magr->mpeaceful && In_quest(&u.uz))
 		  || (Race_if(PM_DROW) && is_drow(ma) && magr->mfaction == u.uhouse)
-		  || (Race_if(PM_GNOME) && (is_gnome(ma) && !is_undead_mon(magr)) && magr->mpeaceful)
+		  || (Race_if(PM_GNOME) && (is_gnome(ma) && !is_undead(ma)) && magr->mpeaceful)
 		)
 		&& !(Race_if(PM_DROW) && !(flags.stag || Role_if(PM_NOBLEMAN) || !is_drow(md)))
 		&& !(Role_if(PM_EXILE))
@@ -3502,7 +3502,7 @@ struct monst * mdef;	/* another monster which is next to it */
 		  || (Role_if(PM_NOBLEMAN) && (md->mtyp == PM_KNIGHT || md->mtyp == PM_MAID || md->mtyp == PM_PEASANT) && mdef->mpeaceful && In_quest(&u.uz))
 		  || (Role_if(PM_KNIGHT) && md->mtyp == PM_KNIGHT && mdef->mpeaceful && In_quest(&u.uz))
 		  || (Race_if(PM_DROW) && is_drow(md) && mdef->mfaction == u.uhouse)
-		  || (Race_if(PM_GNOME) && (is_gnome(md) && !is_undead_mon(mdef)) && mdef->mpeaceful)
+		  || (Race_if(PM_GNOME) && (is_gnome(md) && !is_undead(md)) && mdef->mpeaceful)
 		)
 		&& !(Race_if(PM_DROW) && !(flags.stag || Role_if(PM_NOBLEMAN) || !is_drow(ma)))
 		&& !(Role_if(PM_EXILE))
@@ -3513,24 +3513,24 @@ struct monst * mdef;	/* another monster which is next to it */
 
 	/* elves (and Eladrin) vs. (orcs and undead and wargs) */
 	if((is_elf(ma) || is_eladrin(ma) || ma->mtyp == PM_GROVE_GUARDIAN || ma->mtyp == PM_FORD_GUARDIAN || ma->mtyp == PM_FORD_ELEMENTAL)
-		&& (is_orc(md) || md->mtyp == PM_WARG || is_ogre(md) || is_undead_mon(mdef))
-		&& !(is_orc(ma) || is_ogre(ma) || is_undead_mon(magr))
+		&& (is_orc(md) || md->mtyp == PM_WARG || is_ogre(md) || is_undead(md))
+		&& !(is_orc(ma) || is_ogre(ma) || is_undead(ma))
 	)
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
 	if((is_elf(md) || is_eladrin(md) || md->mtyp == PM_GROVE_GUARDIAN || md->mtyp == PM_FORD_GUARDIAN || md->mtyp == PM_FORD_ELEMENTAL) 
-		&& (is_orc(ma) || ma->mtyp == PM_WARG || is_ogre(ma) || is_undead_mon(magr))
-		&& !(is_orc(md) || is_ogre(md) || is_undead_mon(mdef))
+		&& (is_orc(ma) || ma->mtyp == PM_WARG || is_ogre(ma) || is_undead(ma))
+		&& !(is_orc(md) || is_ogre(md) || is_undead(md))
 	)
 		return ALLOW_M|ALLOW_TM;
 
 	/* dwarves vs. orcs */
 	if(is_dwarf(ma) && (is_orc(md) || is_ogre(md) || is_troll(md))
-					&&!(is_orc(ma) || is_ogre(ma) || is_troll(ma) || is_undead_mon(magr)))
+					&&!(is_orc(ma) || is_ogre(ma) || is_troll(ma) || is_undead(ma)))
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
 	if(is_dwarf(md) && (is_orc(ma) || is_ogre(ma) || is_troll(ma))
-					&&!(is_orc(md) || is_ogre(md) || is_troll(md) || is_undead_mon(mdef)))
+					&&!(is_orc(md) || is_ogre(md) || is_troll(md) || is_undead(md)))
 		return ALLOW_M|ALLOW_TM;
 
 	/* elves vs. drow */
@@ -3541,12 +3541,12 @@ struct monst * mdef;	/* another monster which is next to it */
 
 	/* undead vs civs */
 	if(!(In_quest(&u.uz) || u.uz.dnum == temple_dnum || u.uz.dnum == tower_dnum || In_cha(&u.uz) || Is_stronghold(&u.uz) || Is_rogue_level(&u.uz) || Inhell || Is_astralevel(&u.uz))){
-		if(is_undead_mon(magr) && 
-			(!is_witch_mon(mdef) && !always_hostile_mon(mdef) && !is_undead_mon(mdef) && !(is_animal(md) && !is_domestic(md)) && !mindless_mon(mdef))
+		if(is_undead(ma) && 
+			(!is_witch_mon(mdef) && !always_hostile_mon(mdef) && !is_undead(md) && !(is_animal(md) && !is_domestic(md)) && !mindless_mon(mdef))
 		)
 			return ALLOW_M|ALLOW_TM;
-		if((!always_hostile_mon(magr) && !is_witch_mon(magr) && !is_undead_mon(magr) && !(is_animal(ma) && !is_domestic(ma)) && !mindless_mon(magr))
-			&& is_undead_mon(mdef)
+		if((!always_hostile_mon(magr) && !is_witch_mon(magr) && !is_undead(ma) && !(is_animal(ma) && !is_domestic(ma)) && !mindless_mon(magr))
+			&& is_undead(md)
 		)
 			return ALLOW_M|ALLOW_TM;
 	}
@@ -3554,12 +3554,12 @@ struct monst * mdef;	/* another monster which is next to it */
 	/* Alabaster elves vs. oozes */
 	if((ma->mtyp == PM_ALABASTER_ELF || ma->mtyp == PM_ALABASTER_ELF_ELDER || ma->mtyp == PM_SENTINEL_OF_MITHARDIR) 
 		&& (md->mlet == S_PUDDING || md->mlet == S_BLOB || md->mlet == S_UMBER)
-				&&	!(is_undead_mon(magr)))
+				&&	!(is_undead(ma)))
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
 	if((md->mtyp == PM_ALABASTER_ELF || md->mtyp == PM_ALABASTER_ELF_ELDER || md->mtyp == PM_SENTINEL_OF_MITHARDIR)
 		&& (ma->mlet == S_PUDDING || ma->mlet == S_BLOB || ma->mlet == S_UMBER)
-				&&	!(is_undead_mon(mdef)))
+				&&	!(is_undead(md)))
 		return ALLOW_M|ALLOW_TM;
 
 	/* Androids vs. mind flayers */
@@ -3626,10 +3626,10 @@ struct monst * mdef;	/* another monster which is next to it */
 		return ALLOW_M|ALLOW_TM;
 
 	/* monadics vs. undead */
-	if(ma->mtyp == PM_MONADIC_DEVA && (is_undead_mon(mdef)))
+	if(ma->mtyp == PM_MONADIC_DEVA && (is_undead(md)))
 		return ALLOW_M|ALLOW_TM;
 	/* and vice versa */
-	if(md->mtyp == PM_MONADIC_DEVA && (is_undead_mon(magr)))
+	if(md->mtyp == PM_MONADIC_DEVA && (is_undead(ma)))
 		return ALLOW_M|ALLOW_TM;
 
 	/* woodchucks vs. The Oracle */

--- a/src/mon.c
+++ b/src/mon.c
@@ -1554,7 +1554,7 @@ mcalcdistress()
 			if(tmpm->mhp < 1){
 				if (canspotmon(tmpm))
 					pline("%s %s!", Monnam(tmpm),
-					nonliving_mon(tmpm)
+					nonliving(tmpm->data)
 					? "is destroyed" : "dies");
 				tmpm->mhp = 0;
 				grow_up(mtmp,tmpm);
@@ -1633,7 +1633,7 @@ mcalcdistress()
 			if(distmin(tmpm->mx,tmpm->my,mtmp->mx,mtmp->my) <= 4
 				&& tmpm->mpeaceful != mtmp->mpeaceful
 				&& tmpm->mtame != mtmp->mtame
-				&& !nonliving_mon(tmpm)
+				&& !nonliving(tmpm->data)
 				&& !DEADMONSTER(tmpm)
 				&& !(tmpm->mtrapped && t_at(tmpm->mx, tmpm->my) && t_at(tmpm->mx, tmpm->my)->ttyp == VIVI_TRAP)
 			) targets++;
@@ -1648,7 +1648,7 @@ mcalcdistress()
 			if(distmin(tmpm->mx,tmpm->my,mtmp->mx,mtmp->my) <= 4
 				&& tmpm->mpeaceful != mtmp->mpeaceful
 				&& tmpm->mtame != mtmp->mtame
-				&& !nonliving_mon(tmpm)
+				&& !nonliving(tmpm->data)
 				&& !DEADMONSTER(tmpm)
 				&& !(tmpm->mtrapped && t_at(tmpm->mx, tmpm->my) && t_at(tmpm->mx, tmpm->my)->ttyp == VIVI_TRAP)
 			) targets--;
@@ -1672,7 +1672,7 @@ mcalcdistress()
 			if(tmpm->mhp < 1){
 				if (canspotmon(tmpm))
 					pline("%s %s!", Monnam(tmpm),
-					nonliving_mon(tmpm)
+					nonliving(tmpm->data)
 					? "is destroyed" : "dies");
 				tmpm->mhp = 0;
 				grow_up(mtmp,tmpm);
@@ -1738,7 +1738,7 @@ mcalcdistress()
 					if(distmin(tmpm->mx,tmpm->my,mtmp->mx,mtmp->my) <= BOLT_LIM
 						&& tmpm->mpeaceful != mtmp->mpeaceful
 						&& tmpm->mtame != mtmp->mtame
-						&& !(nonliving_mon(tmpm) || is_demon(tmpm->data))
+						&& !(nonliving(tmpm->data) || is_demon(tmpm->data))
 						&& !(ward_at(tmpm->mx,tmpm->my) == CIRCLE_OF_ACHERON)
 						&& !(resists_death(tmpm))
 						&& !DEADMONSTER(tmpm)
@@ -1758,7 +1758,7 @@ mcalcdistress()
 						if(targ->mhp < 1){
 							if (canspotmon(targ))
 								pline("%s %s!", Monnam(targ),
-								nonliving_mon(targ)
+								nonliving(targ->data)
 								? "is destroyed" : "dies");
 							targ->mhp = 0;
 							grow_up(mtmp,targ);
@@ -1769,7 +1769,7 @@ mcalcdistress()
 						if(targ->mhp < 1){
 							if (canspotmon(targ))
 								pline("%s %s!", Monnam(targ),
-								nonliving_mon(targ)
+								nonliving(targ->data)
 								? "is destroyed" : "dies");
 							targ->mhp = 0;
 							grow_up(mtmp,targ);
@@ -1778,7 +1778,7 @@ mcalcdistress()
 					} else {
 						if (canspotmon(targ))
 							pline("%s %s!", Monnam(targ),
-							nonliving_mon(targ)
+							nonliving(targ->data)
 							? "is destroyed" : "dies");
 						targ->mhp = 0;
 						grow_up(mtmp,targ);
@@ -3275,7 +3275,7 @@ nexttry:
 			if(flag & NOTONL) continue;
 			info[cnt] |= NOTONL;
 		}
-		if (levl[nx][ny].typ == CLOUD && Is_lolth_level(&u.uz) && !(nonliving_mon(mon) || breathless_mon(mon) || resists_poison(mon))) {
+		if (levl[nx][ny].typ == CLOUD && Is_lolth_level(&u.uz) && !(nonliving(mdat) || breathless_mon(mon) || resists_poison(mon))) {
 			if(!(flag & ALLOW_TRAPS)) continue;
 			info[cnt] |= ALLOW_TRAPS;
 		}
@@ -3848,7 +3848,7 @@ struct obj *
 mlifesaver(mon)
 struct monst *mon;
 {
-	if (!nonliving_mon(mon)) {
+	if (!nonliving(mon->data)) {
 	    struct obj *otmp = which_armor(mon, W_AMUL);
 
 	    if (otmp && otmp->otyp == AMULET_OF_LIFE_SAVING)
@@ -4659,7 +4659,7 @@ boolean was_swallowed;			/* digestion */
 				else pline("%s lets out a terrible shriek!", Monnam(mon));
 				for (mtmp = fmon; mtmp; mtmp = mtmp2){
 					mtmp2 = mtmp->nmon;
-					if(mtmp->data->geno & G_GENO && !nonliving_mon(mon) && !is_demon(mon->data) && !is_keter(mon->data) && mtmp->mhp <= 100){
+					if(mtmp->data->geno & G_GENO && !nonliving(mon->data) && !is_demon(mon->data) && !is_keter(mon->data) && mtmp->mhp <= 100){
 						if (DEADMONSTER(mtmp)) continue;
 						mtmp->mhp = -10;
 						monkilled(mtmp,"",AD_DRLI);
@@ -5550,7 +5550,7 @@ xkilled(mtmp, dest)
 	}
 	
 	if (dest & 1) {
-	    const char *verb = nonliving_mon(mtmp) ? "destroy" : "kill";
+	    const char *verb = nonliving(mtmp->data) ? "destroy" : "kill";
 
 	    if (!wasinside && !canspotmon(mtmp))
 		You("%s it!", verb);
@@ -6228,7 +6228,7 @@ register int x, y, distance;
 					if(distmin(tmpm->mx,tmpm->my,mtmp->mx,mtmp->my) <= 4
 						&& tmpm->mpeaceful != mtmp->mpeaceful
 						&& tmpm->mtame != mtmp->mtame
-						&& !nonliving_mon(tmpm)
+						&& !nonliving(tmpm->data)
 						&& !resists_drain(tmpm)
 						&& !DEADMONSTER(tmpm)
 						&& !(tmpm->mtrapped && t_at(tmpm->mx, tmpm->my) && t_at(tmpm->mx, tmpm->my)->ttyp == VIVI_TRAP)
@@ -6244,7 +6244,7 @@ register int x, y, distance;
 					if(dist2(tmpm->mx,tmpm->my,mtmp->mx,mtmp->my) <= distance
 						&& tmpm->mpeaceful != mtmp->mpeaceful
 						&& tmpm->mtame != mtmp->mtame
-						&& !nonliving_mon(tmpm)
+						&& !nonliving(tmpm->data)
 						&& !resists_drain(tmpm)
 						&& !DEADMONSTER(tmpm)
 						&& !(tmpm->mtrapped && t_at(tmpm->mx, tmpm->my) && t_at(tmpm->mx, tmpm->my)->ttyp == VIVI_TRAP)

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -569,6 +569,65 @@ int faction;
 	return;
 }
 
+/* returns TRUE if mtyp and mtemplate are compatible */
+boolean
+mtemplate_accepts_mtyp(mtemplate, mtyp)
+int mtemplate;
+int mtyp;
+{
+	struct permonst * ptr = &mons[mtyp];
+	switch(mtemplate)
+	{
+	case ZOMBIFIED:
+		/* basic undead check */
+		return can_undead(ptr);
+	case SKELIFIED:
+		/* basic undead check */
+		/* we don't have a way to check if a permonst has a skeleton ??? */
+		return can_undead(ptr);
+	case CRYSTALFIED:
+		/* anything goes */
+		return TRUE;
+	case FRACTURED:
+		/* kamerel are particularly vulnerable, but can afflict anything with eyes */
+		return haseyes(ptr);
+	case VAMPIRIC:
+		/* must have blood */
+		return has_blood(ptr);
+	case ILLUMINATED:
+		/* needs a soul -- not nonliving */
+		return !nonliving(ptr);
+	case INCUBUS_FACTION:
+	case SUCCUBUS_FACTION:
+		/* these are actually much more like proper factions -- leave be for now */
+		return TRUE;
+	case PSEUDONATURAL:
+		/* basic undead check; good enough */
+		return can_undead(ptr);
+	case TOMB_HERD:
+		/* anything goes */
+		return TRUE;
+	case YITH:
+		/* must have had a mind for the yith to have swapped with */
+		return !mindless(ptr);
+	case CRANIUM_RAT:
+		/* is a rodent */
+		return is_rat(ptr);
+	case MISTWEAVER:
+		/* could be a worshipper of the Goat */
+		return !(nonliving(ptr) || is_whirly(ptr) || noncorporeal(ptr));
+	case DELOUSED:
+		/* had a louse */
+		return is_delouseable(ptr);
+	case M_BLACK_WEB:
+	case M_GREAT_WEB:
+		/* ??? */
+		return TRUE;
+	}
+	/* default fall through -- allow all */
+	return TRUE;
+}
+
 /* 
  * Returns a pointer to the appropriate permonst structure for the monster parameters given
  * 

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1218,7 +1218,7 @@ struct monst *mon;
 	
 	if(mon == u.usteed && u.sealsActive&SEAL_BERITH && u.sealsActive&SEAL_OSE) return TRUE;
 	
-	return nonliving_mon(mon) || is_demon(mon->data) || is_angel(mon->data) || is_keter(mon->data);
+	return nonliving(mon->data) || is_demon(mon->data) || is_angel(mon->data) || is_keter(mon->data);
 }
 
 /* TRUE iff monster is resistant to light-induced blindness */

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1190,7 +1190,7 @@ struct monst *mon;
 	if(!mon) return FALSE;
 	ptr = mon->data;
 
-	return (boolean)(is_undead_mon(mon) || is_demon(ptr) || is_were(ptr) ||
+	return (boolean)(is_undead(ptr) || is_demon(ptr) || is_were(ptr) ||
 			 species_resists_drain(mon) || 
 			 ptr->mtyp == PM_DEATH ||
 			 mon_resistance(mon, DRAIN_RES) ||

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -309,7 +309,7 @@ struct monst *mtmp;
 			(mtmp->data->mlet == S_LIGHT && complete >= 4) ||
 			(mtmp->data->mlet == S_DRAGON && complete >= 4) ||
 			(mtmp->data->mlet == S_NAGA && complete >= 4) ||
-			(is_undead_mon(mtmp) && complete >= 4) ||
+			(is_undead(mtmp->data) && complete >= 4) ||
 			(mtmp->data->mlet == S_TRAPPER && complete >= 4  && /*This one means "is a metroid", which are being counted as energions for this*/
 				mtmp->mtyp != PM_TRAPPER &&
 				mtmp->mtyp != PM_LURKER_ABOVE) ||
@@ -470,7 +470,7 @@ struct monst *mtmp;
 			is_lminion(mtmp) || mtmp->mtyp == PM_ANGEL ||
 			mtmp->mtyp == PM_MAANZECORIAN ||
 			is_rider(mtmp->data)) return FALSE;
-	return mtmp->mtyp == PM_CERBERUS || is_undead_mon(mtmp);
+	return mtmp->mtyp == PM_CERBERUS || is_undead(mtmp->data);
 }
 
 boolean
@@ -519,7 +519,7 @@ struct monst *mtmp;
 		) return FALSE;
 	return( !(is_human(mtmp->data) || is_elf(mtmp->data) || is_dwarf(mtmp->data) ||
 		  is_gnome(mtmp->data) || is_orc(mtmp->data)) || 
-		  is_undead_mon(mtmp) || is_were(mtmp->data));
+		  is_undead(mtmp->data) || is_were(mtmp->data));
 	
 }
 boolean
@@ -535,7 +535,7 @@ struct monst *mtmp;
 		) return FALSE;
 	if((is_human(mtmp->data) || is_elf(mtmp->data) || is_dwarf(mtmp->data) ||
 		  is_gnome(mtmp->data) || is_orc(mtmp->data)) && 
-		  !is_undead_mon(mtmp) && 
+		  !is_undead(mtmp->data) && 
 		  !is_were(mtmp->data)){
 			mtmp->mcrazed = 1;
 			return !rn2(10);
@@ -2129,7 +2129,7 @@ not_special:
 	if (passes_bars(mtmp) && !Is_illregrd(&u.uz) ) flag |= ALLOW_BARS;
 	if (can_tunnel) flag |= ALLOW_DIG;
 	if (is_human(ptr) || ptr->mtyp == PM_MINOTAUR) flag |= ALLOW_SSM;
-	if (is_undead_mon(mtmp) && ptr->mlet != S_GHOST && ptr->mlet != S_SHADE) flag |= NOGARLIC;
+	if (is_undead(ptr) && ptr->mlet != S_GHOST && ptr->mlet != S_SHADE) flag |= NOGARLIC;
 	if (throws_rocks(ptr)) flag |= ALLOW_ROCK;
 	if (can_open) flag |= OPENDOOR;
 	if (can_unlock) flag |= UNLOCKDOOR;

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -685,7 +685,7 @@ boolean digest_meal;
 	}
 	/* Clouds on Lolth's level deal damage */
 	if(Is_lolth_level(&u.uz) && levl[mon->mx][mon->my].typ == CLOUD){
-		if (!(nonliving_mon(mon) || breathless_mon(mon))){
+		if (!(nonliving(mon->data) || breathless_mon(mon))){
 			if (haseyes(mon->data) && mon->mcansee){
 				mon->mblinded = 1;
 				mon->mcansee = 0;
@@ -714,7 +714,7 @@ boolean digest_meal;
 		mon->mhp += 25; //Fast healing
 	} else {
 		if(mon->mhp < mon->mhpmax && mon_resistance(mon,REGENERATION)) mon->mhp++;
-		if(!nonliving_mon(mon)){
+		if(!nonliving(mon->data)){
 			if (mon->mhp < mon->mhpmax){
 				//recover 1/HEALCYCLEth hp per turn:
 				mon->mhp += (mon->m_lev)/HEALCYCLE;
@@ -1326,7 +1326,7 @@ register struct monst *mtmp;
 				}
 				else {
 					//Note: body armor blocks healing, healing is also reduced by the rolled DR
-					if(nonliving_mon(patient) || patient->mpeaceful != mtmp->mpeaceful || which_armor(patient, W_ARM))
+					if(nonliving(patient->data) || patient->mpeaceful != mtmp->mpeaceful || which_armor(patient, W_ARM))
 						continue;
 					if(patient->mhp < patient->mhpmax){
 						nurse_heal(mtmp, patient, canseemon(mtmp) || canseemon(patient));

--- a/src/muse.c
+++ b/src/muse.c
@@ -2479,7 +2479,7 @@ struct monst *mtmp;
 	if (difficulty < 6 && !rn2(30))
 	    return rn2(6) ? POT_POLYMORPH : WAN_POLYMORPH;
 	
-	if (!rn2(40) && !nonliving_mon(mtmp)) return AMULET_OF_LIFE_SAVING;
+	if (!rn2(40) && !nonliving(mtmp->data)) return AMULET_OF_LIFE_SAVING;
 
 	if(difficulty > 6 && rn2(50) < difficulty) return rnd_utility_potion(mtmp);
 
@@ -2557,7 +2557,7 @@ struct obj *obj;
 	    break;
 	case AMULET_CLASS:
 	    if (typ == AMULET_OF_LIFE_SAVING)
-		return (boolean)(!nonliving_mon(mon));
+		return (boolean)(!nonliving(mon->data));
 	    if (typ == AMULET_OF_REFLECTION)
 		return TRUE;
 	    break;

--- a/src/music.c
+++ b/src/music.c
@@ -610,7 +610,7 @@ struct obj * instr;
 	
 	/* Defense level */
 	dlev = (int)mtmp->m_lev*2;
-	if (nonliving_mon(mtmp) && mindless_mon(mtmp)) dlev = 100;
+	if (nonliving(mtmp->data) && mindless_mon(mtmp)) dlev = 100;
 	dlev0 = dlev;
 
 	/* "peaceful" songs */
@@ -1570,9 +1570,9 @@ do_pit:		    chasm = maketrap(x,y,PIT);
 									   if(!cansee(x,y) || mon)
 										   pline("%s is %sed!",
 												   cansee(x,y) ? "It" : Monnam(mtmp),
-												  nonliving_mon(mtmp) ? "destroy" : "kill");
+												  nonliving(mtmp->data) ? "destroy" : "kill");
 						else {
-										   You("%s %s!", nonliving_mon(mtmp) ? "destroy" :
+										   You("%s %s!", nonliving(mtmp->data) ? "destroy" :
 											   "kill", mtmp->mtame ?
 							x_monnam(mtmp, ARTICLE_THE, "poor",
 					M_HAS_NAME(mtmp) ? SUPPRESS_SADDLE : 0, FALSE):

--- a/src/music.c
+++ b/src/music.c
@@ -622,7 +622,7 @@ struct obj * instr;
 		if (your_race(mtmp->data)) dlev -= dlev0/10;
 
 		// undead and demons don't care about 'peaceful' music
-		if (is_undead_mon(mtmp) || is_demon(mtmp->data)) dlev += 50;
+		if (is_undead(mtmp->data) || is_demon(mtmp->data)) dlev += 50;
 		if (always_hostile_mon(mtmp)) dlev += dlev0/10;
 		if (race_peaceful(mtmp->data)) dlev -= dlev0/10;
 
@@ -663,7 +663,7 @@ struct obj * instr;
 		// the Lyre isn't so good to scare people or to sow confusion
 		if (instr->oartifact == ART_LYRE_OF_ORPHEUS) alev /= 2;
 		// undeads and demons like scary music
-		if (song == SNG_FEAR && is_undead_mon(mtmp)) dlev -= dlev0/3;
+		if (song == SNG_FEAR && is_undead(mtmp->data)) dlev -= dlev0/3;
 		if (song == SNG_FEAR && is_demon(mtmp->data)) dlev -= dlev0/5;
 		// monster is scared/confused easily if it can't see you
 		canseeu = m_canseeu(mtmp);
@@ -797,14 +797,14 @@ int distance;
 		if (!DEADMONSTER(mtmp) && distu(mtmp->mx, mtmp->my) < distance &&
 			mon_affected_by_song(mtmp) && r >= 0) {
 
-			if (is_undead_mon(mtmp) || is_demon(mtmp->data)) {
+			if (is_undead(mtmp->data) || is_demon(mtmp->data)) {
 				// small chance of side effect
 				r = r/songs[song_being_played()].turns;
 				// if (wizard) pline("[%i%% side effect]", r);
 			}
 	
 			/* fear song actually can pacify undead */
-			if (is_undead_mon(mtmp)) {
+			if (is_undead(mtmp->data)) {
 				if (rn2(100) < r) {
 					if (canseemon(mtmp))
 						pline((Hallucination ? "%s starts to coreograph a dance!" 

--- a/src/pager.c
+++ b/src/pager.c
@@ -335,7 +335,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 				ways_seen = 0;
 				if(u.sealsActive&SEAL_PAIMON && is_magical((mtmp)->data)) ways_seen++;
 				if(u.sealsActive&SEAL_ANDROMALIUS && is_thief((mtmp)->data)) ways_seen++;
-				if(u.sealsActive&SEAL_TENEBROUS && !nonliving_mon(mtmp)) ways_seen++;
+				if(u.sealsActive&SEAL_TENEBROUS && !nonliving(mtmp->data)) ways_seen++;
 				if(u.specialSealsActive&SEAL_ACERERAK && is_undead(mtmp->data)) ways_seen++;
 				if(uwep && ((uwep->oward & WARD_THJOFASTAFUR) && 
 					((mtmp)->data->mlet == S_LEPRECHAUN || (mtmp)->data->mlet == S_NYMPH || is_thief((mtmp)->data)))) ways_seen++;
@@ -366,7 +366,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 					Strcat(monbuf, wbuf);
 					if (ways_seen-- > 1) Strcat(monbuf, ", ");
 					}
-					if(u.sealsActive&SEAL_TENEBROUS && !nonliving_mon(mtmp)){
+					if(u.sealsActive&SEAL_TENEBROUS && !nonliving(mtmp->data)){
 					Sprintf(wbuf, "warned of living beings");
 					Strcat(monbuf, wbuf);
 					if (ways_seen-- > 1) Strcat(monbuf, ", ");

--- a/src/pager.c
+++ b/src/pager.c
@@ -336,7 +336,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 				if(u.sealsActive&SEAL_PAIMON && is_magical((mtmp)->data)) ways_seen++;
 				if(u.sealsActive&SEAL_ANDROMALIUS && is_thief((mtmp)->data)) ways_seen++;
 				if(u.sealsActive&SEAL_TENEBROUS && !nonliving_mon(mtmp)) ways_seen++;
-				if(u.specialSealsActive&SEAL_ACERERAK && is_undead_mon(mtmp)) ways_seen++;
+				if(u.specialSealsActive&SEAL_ACERERAK && is_undead(mtmp->data)) ways_seen++;
 				if(uwep && ((uwep->oward & WARD_THJOFASTAFUR) && 
 					((mtmp)->data->mlet == S_LEPRECHAUN || (mtmp)->data->mlet == S_NYMPH || is_thief((mtmp)->data)))) ways_seen++;
 				if(youracedata->mtyp == PM_SHARK && has_blood_mon(mtmp) &&
@@ -361,7 +361,7 @@ lookat(x, y, buf, monbuf, shapebuff)
 					Strcat(monbuf, wbuf);
 					if (ways_seen-- > 1) Strcat(monbuf, ", ");
 					}
-					if(u.specialSealsActive&SEAL_ACERERAK && is_undead_mon(mtmp)){
+					if(u.specialSealsActive&SEAL_ACERERAK && is_undead(mtmp->data)){
 					Sprintf(wbuf, "warned of the undead");
 					Strcat(monbuf, wbuf);
 					if (ways_seen-- > 1) Strcat(monbuf, ", ");
@@ -1675,7 +1675,7 @@ get_ma_description_of_monster_type(struct monst * mtmp, char * description)
 	struct permonst * ptr = mtmp->data;
 	strcat(description, "Race: ");
 	int many = 0;
-	many = append(description, (is_undead_mon(mtmp))			, "undead"				, many);
+	many = append(description, (ptr->mflagsa & MA_UNDEAD)		, "undead"				, many);
 	many = append(description, (ptr->mflagsa & MA_WERE)			, "lycanthrope"			, many);
 	many = append(description, (ptr->mflagsa & MA_HUMAN)		, "human"				, many);
 	many = append(description, (ptr->mflagsa & MA_ELF)			, "elf"					, many);

--- a/src/potion.c
+++ b/src/potion.c
@@ -1557,7 +1557,7 @@ boolean your_fault;
 		}
 		break;
 	case POT_WATER:
-		if (is_undead_mon(mon) || is_demon(mon->data) ||
+		if (is_undead(mon->data) || is_demon(mon->data) ||
 			is_were(mon->data)) {
 		    if (obj->blessed) {
 			pline("%s %s in pain!", Monnam(mon),

--- a/src/pray.c
+++ b/src/pray.c
@@ -3598,7 +3598,7 @@ doturn()
 	    if (!cansee(mtmp->mx,mtmp->my) ||
 		distu(mtmp->mx,mtmp->my) > range) continue;
 
-	    if (!mtmp->mpeaceful && (is_undead_mon(mtmp) ||
+	    if (!mtmp->mpeaceful && (is_undead(mtmp->data) ||
 		   (is_demon(mtmp->data) && (u.ulevel > (MAXULEV/2))))) {
 
 		    mtmp->msleeping = 0;

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -384,7 +384,7 @@ dosounds()
     if (level.flags.has_morgue && !rn2(200)) {
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
 	    if (DEADMONSTER(mtmp)) continue;
-	    if (is_undead_mon(mtmp) &&
+	    if (is_undead(mtmp->data) &&
 		mon_in_room(mtmp, MORGUE)) {
 		switch (rn2(2)+hallu) {
 		    case 0:
@@ -2745,7 +2745,7 @@ int dz;
 		mtmp = tamedog(mtmp, (struct obj *)0);
 		return 1;
 	}
-	if(is_undead_mon(mtmp) && u.specialSealsActive&SEAL_ACERERAK && u.ulevel > mtmp->m_lev){
+	if(is_undead(mtmp->data) && u.specialSealsActive&SEAL_ACERERAK && u.ulevel > mtmp->m_lev){
 		You("order the lesser dead to stand at ease.");
 		mtmp->mpeaceful = 1;
 		mtmp->mhp = mtmp->mhpmax;

--- a/src/spell.c
+++ b/src/spell.c
@@ -2434,7 +2434,7 @@ spiriteffects(power, atme)
 				mon = m_at(u.ux+u.dx, u.uy+u.dy);
 				if(!mon) break;
 				You("heal %s.", mon_nam(mon));
-				if (nonliving_mon(mon)){	/* match effect on player */
+				if (nonliving(mon->data)){	/* match effect on player */
 					shieldeff(mon->mx, mon->my);
 				} else {
 					mon->mhp += d(5,dsize);
@@ -2488,7 +2488,7 @@ spiriteffects(power, atme)
 			} else if(isok(u.ux+u.dx, u.uy+u.dy)) {
 				mon = m_at(u.ux+u.dx, u.uy+u.dy);
 				if(!mon) break;
-				if (nonliving_mon(mon)){	/* match effect on player */
+				if (nonliving(mon->data)){	/* match effect on player */
 					shieldeff(mon->mx, mon->my);
 				} else {
 					pline("%s recovers.", Monnam(mon));
@@ -2858,7 +2858,7 @@ spiriteffects(power, atme)
 				if(mon && is_golem(mon->data)){
 					mon->mhp = 0;
 					xkilled(mon, 1);
-				} else if(mon && nonliving_mon(mon)){
+				} else if(mon && nonliving(mon->data)){
 					mon->mhp -= d(rnd(5),dsize);
 					if(mon->mhp <= 0){
 						mon->mhp = 0;
@@ -2907,7 +2907,7 @@ spiriteffects(power, atme)
 				if(!mon){
 					pline("\"There's no one there, buddy!\"");
 					return 0;
-				} if(nonliving_mon(mon) || is_anhydrous(mon->data)){
+				} if(nonliving(mon->data) || is_anhydrous(mon->data)){
 					shieldeff(mon->mx, mon->my);
 					break;
 				}
@@ -3693,7 +3693,7 @@ spiriteffects(power, atme)
 			if(!getdir((char *)0) || (!u.dx && !u.dy)) return 0;
 			mon = m_at(u.ux+u.dx,u.uy+u.dy);
 			if(!mon) return 0;
-			if(resists_drli(mon) || nonliving_mon(mon)){
+			if(resists_drli(mon) || nonliving(mon->data)){
 				pline("You can't swallow the soul of %s.", mon_nam(mon));
 				shieldeff(mon->mx, mon->my);
 			} else if(mon->m_lev > u.ulevel){

--- a/src/spell.c
+++ b/src/spell.c
@@ -402,7 +402,7 @@ raise_dead:
 	    mtmp2 = mtmp->nmon;		/* tamedog() changes chain */
 	    if (DEADMONSTER(mtmp)) continue;
 
-	    if (is_undead_mon(mtmp) && cansee(mtmp->mx, mtmp->my)) {
+	    if (is_undead(mtmp->data) && cansee(mtmp->mx, mtmp->my)) {
 		mtmp->mpeaceful = TRUE;
 		if(sgn(mtmp->data->maligntyp) == sgn(u.ualign.type)
 		   && distu(mtmp->mx, mtmp->my) < 4)
@@ -1804,7 +1804,7 @@ genericptr_t val;
 	    snuff_light_source(x, y);
 		newsym(x,y);
 		if(mon){
-			if(is_undead_mon(mon) || resists_drain(mon) || is_demon(mon->data)){
+			if(is_undead(mon->data) || resists_drain(mon) || is_demon(mon->data)){
 				shieldeff(mon->mx, mon->my);
 			} else {
 				setmangry(mon);
@@ -1814,7 +1814,7 @@ genericptr_t val;
 		}
 	} else {
 		if(mon){
-			if(is_undead_mon(mon) || resists_drain(mon) || is_demon(mon->data)){
+			if(is_undead(mon->data) || resists_drain(mon) || is_demon(mon->data)){
 				shieldeff(mon->mx, mon->my);
 			} else {
 				setmangry(mon);
@@ -4169,7 +4169,7 @@ int x, y;
 		newsym(x,y);
 	}
 	if(mon && !mon->mpeaceful){
-		if(is_undead_mon(mon))
+		if(is_undead(mon->data))
 			dmod++;
 		if(is_demon(mon->data))
 			dmod++;
@@ -4279,7 +4279,7 @@ int spell;
 						}
 						if(mon && !mon->mpeaceful){
 							if(is_elemental(mon->data) 
-								|| is_undead_mon(mon) 
+								|| is_undead(mon->data) 
 								|| mon->mtyp == PM_ASPECT_OF_THE_SILENCE 
 								|| mon->mtyp == PM_SENTINEL_OF_MITHARDIR 
 								|| mon->mtyp == PM_STONE_GOLEM 

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1682,7 +1682,7 @@ boolean give_feedback;
 			aggravate();
 		}
 		if(!DEADMONSTER(mtmp)){
-			if(canspotmon(mtmp)) pline("Unfortunately, that equipment was the only thing keeping %s %s.", himherit(mtmp), nonliving_mon(mtmp) ? "intact" : "alive");
+			if(canspotmon(mtmp)) pline("Unfortunately, that equipment was the only thing keeping %s %s.", himherit(mtmp), nonliving(mtmp->data) ? "intact" : "alive");
 			mondied(mtmp);
 		}
 	}

--- a/src/trap.c
+++ b/src/trap.c
@@ -625,7 +625,7 @@ int *fail_reason;
 	if (mon->m_ap_type) seemimic(mon);
 	else mon->mundetected = FALSE;
 	if ((x == u.ux && y == u.uy) || cause == ANIMATE_SPELL) {
-	    const char *comes_to_life = nonliving_mon(mon) ?
+	    const char *comes_to_life = nonliving(mon->data) ?
 					"moves" : "comes to life"; 
 	    if (cause == ANIMATE_SPELL){
 	    	if(cansee(x,y)) pline("%s %s!", upstart(statuename),
@@ -4408,7 +4408,7 @@ struct obj * tool;
 						reward_untrap(ttmp, mtmp);
 					} else {
 						You("try to free %s from the delicate equipment that imprisons %s.", mon_nam(mtmp), himherit(mtmp));
-						pline("Unfortunately, that equipment was the only thing keeping %s %s.", himherit(mtmp), nonliving_mon(mtmp) ? "intact" : "alive");
+						pline("Unfortunately, that equipment was the only thing keeping %s %s.", himherit(mtmp), nonliving(mtmp->data) ? "intact" : "alive");
 						// xkilled(mtmp,1); //Breaks pacifist
 						mondied(mtmp);
 					}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -4714,7 +4714,7 @@ boolean ranged;
 		else {
 			if(canseemon(mdef))
 				pline("%s is covered in pollen!", Monnam(mdef));
-			if(!breathless_mon(mdef) && !nonliving_mon(mdef)){
+			if(!breathless_mon(mdef) && !nonliving(mdef->data)){
 				if(canseemon(mdef))
 					pline("%s starts sneezing uncontrollably!", Monnam(mdef));
 				mdef->mcanmove = 0;
@@ -9908,7 +9908,7 @@ int vis;
 			}
 		}
 		else {
-			if (nonliving_mon(mdef) || is_demon(pd)) {
+			if (nonliving(mdef->data) || is_demon(pd)) {
 				if (vis&VIS_MDEF && vis&VIS_MAGR) {
 					pline("%s seems no deader than before.",
 						Monnam(mdef));

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -2081,9 +2081,9 @@ int * tohitmod;					/* some attacks are made with decreased accuracy */
 
 	/* Undead damage multipliers -- note that these must be after actual replacements are done */
 	/* zombies deal double damage, and all undead deal double damage at midnight (the midnight multiplier is not shown in the pokedex) */
-	if (!youagr && has_template(magr, ZOMBIFIED) && (is_undead_mon(magr) && midnight() && !by_the_book))
+	if (!youagr && has_template(magr, ZOMBIFIED) && (is_undead(pa) && midnight() && !by_the_book))
 		attk->damn *= 3;
-	else if (!youagr && (has_template(magr, ZOMBIFIED) || (is_undead_mon(magr) && midnight() && !by_the_book)))
+	else if (!youagr && (has_template(magr, ZOMBIFIED) || (is_undead(pa) && midnight() && !by_the_book)))
 		attk->damn *= 2;
 
 	/* Bandersnatches become frumious instead of fleeing, dealing double damage -- not shown in the pokedex */
@@ -7631,7 +7631,7 @@ boolean ranged;
 				case 7:		hurts = !Stone_res(mdef); break;
 				case 8:		hurts = !Drain_res(mdef); break;
 				case 9:		hurts = !Sick_res(mdef); break;
-				case 10:	hurts = is_undead_mon(mdef); break;
+				case 10:	hurts = is_undead(pd); break;
 				case 11:	hurts = is_fungus(pd); break;
 				case 12:	hurts = infravision(pd); break;
 				case 13:	hurts = opaque(pd); break;
@@ -7679,7 +7679,7 @@ boolean ranged;
 				);
 		}
 		/* undead are immune to the special effect */
-		if (is_undead_mon(mdef) || (youdef && u.sealsActive&SEAL_OSE)) {
+		if (is_undead(pd) || (youdef && u.sealsActive&SEAL_OSE)) {
 			if (youdef) {
 				pline("Was that the touch of death?");
 			}
@@ -9324,7 +9324,7 @@ int vis;
 				dmg = 0;
 			goto expl_common;
 		case AD_DESC:
-			if (is_anhydrous(pd) || is_undead_mon(mdef))
+			if (is_anhydrous(pd) || is_undead(pd))
 				dmg = 0;
 			goto expl_common;
 expl_common:
@@ -12415,7 +12415,7 @@ int vis;						/* True if action is at all visible to the player */
 				break;
 
 			case CLOVE_OF_GARLIC:
-				if (!youdef && is_undead_mon(mdef)) {/* no effect against demons */
+				if (!youdef && is_undead(pd)) {/* no effect against demons */
 					monflee(mdef, d(2, 4), FALSE, TRUE);
 				}
 				basedmg = 1;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -12093,14 +12093,14 @@ int vis;						/* True if action is at all visible to the player */
 
 	/* set zombify resulting from melee mvm combat */
 	if (magr && !youagr && !youdef && melee && !recursed) {
-		if ((has_template(magr, ZOMBIFIED) || (has_template(magr, SKELIFIED) && !rn2(20))) && can_undead_mon(mdef)){
+		if ((has_template(magr, ZOMBIFIED) || (has_template(magr, SKELIFIED) && !rn2(20))) && can_undead(mdef->data)){
 			mdef->zombify = 1;
 		}
 
 		if ((magr->mtyp == PM_UNDEAD_KNIGHT
 			|| magr->mtyp == PM_WARRIOR_OF_SUNLIGHT
 			|| magr->mtyp == PM_DREAD_SERAPH
-			) && can_undead_mon(mdef)){
+			) && can_undead(mdef->data)){
 			mdef->zombify = 1;
 		}
 

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1629,7 +1629,7 @@ struct obj * weapon;
 			))
 			return 1;
 
-		if (is_undead_mon(mdef) && (
+		if (is_undead(pd) && (
 			(weapon->otyp == CLOVE_OF_GARLIC)	/* causes shades to flee */
 			))
 			return 1;

--- a/src/zap.c
+++ b/src/zap.c
@@ -870,7 +870,7 @@ boolean dolls;
 				panic("revive");
 			}
 			if(wasfossil){
-				if (can_undead_mon(mtmp)) {
+				if (can_undead(mtmp->data)) {
 					set_template(mtmp, SKELIFIED);
 					newsym(mtmp->mx, mtmp->my);
 				}

--- a/src/zap.c
+++ b/src/zap.c
@@ -253,7 +253,7 @@ struct obj *otmp;
 	case SPE_TURN_UNDEAD:
 		wake = FALSE;
 		if (unturn_dead(mtmp)) wake = TRUE;
-		if (is_undead_mon(mtmp)) {
+		if (is_undead(mtmp->data)) {
 			reveal_invis = TRUE;
 			wake = TRUE;
 			if(otyp == WAN_UNDEAD_TURNING) dmg = d(wand_damage_die(P_SKILL(P_WAND_POWER)),8);


### PR DESCRIPTION
We started needing `is_x_mon()` macros to accommodate templates (formerly 'factions') because `mon->data` wasn't reflecting the modified creature. Since then, we've fixed it so `mon->data` _is_ correct, so these are not needed anymore.