### PR TITLE
Add impossible guard for Armor_off with null uarm

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -790,7 +790,11 @@ Armor_off()
 	boolean checkweight = FALSE;
     takeoff_mask &= ~W_ARM;
 	if(arti_lighten(uarmu, FALSE)) checkweight = TRUE;
-	if((uarm->otyp == NOBLE_S_DRESS || uarm->otyp == BLACK_DRESS) && !cancelled_don) {
+
+	if(!uarm) {
+		impossible("Armor_off called with no uarm");
+	}
+	else if((uarm->otyp == NOBLE_S_DRESS || uarm->otyp == BLACK_DRESS) && !cancelled_don) {
 		ABON(A_CHA) -= (1 + uarm->spe);
 		flags.botl = 1;
 	}


### PR DESCRIPTION
Occurred during fuzzing but I haven't a clue how to reproduce this.

Somehow, uarm was set to 0 while the armour was being taken off, which
causes a segfault on reading from low addresses

This guard avoids the segfault and reports an impossible so if a player
manages to trigger this we can hopefully get more information