### PR TITLE
Drop trap ammo when replacing traps

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -263,6 +263,13 @@ register int x, y, typ;
 		memset(&ttmp->vl, 0, sizeof(union vlaunchinfo));
 		ttmp->ammo = (struct obj *)0;
 	}
+
+	if (oldplace && ttmp->ttyp != typ && ttmp->ammo) {
+		remove_trap_ammo(ttmp);
+		/* have to re-call maketrap, because remove_trap_ammo() deleted the trap */
+		return maketrap(x, y, typ);
+	}
+
 	ttmp->ttyp = typ;
 	switch(typ) {
 	    case STATUE_TRAP:	    /* create a "living" statue */


### PR DESCRIPTION
Digging down into a fire trap will yield its potions of oil, an arrow trap its arrows, a bear trap the beartrap, etc.
Much better then just changing the trap type and making a pit that contains arrows >_>

TODO: interactions for some traps when digging into them?