### PR TITLE
Make boulders scary

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -443,7 +443,7 @@ hurtle_step(arg, x, y)
     		dotrap(ttmp,0);
 		*range = 0;
 		return TRUE;
-    	} else {
+    	} else if (*range > 1) {
 		if (ttmp->tseen)
 		    You("pass right over %s %s.",
 		    	(ttmp->ttyp == ARROW_TRAP) ? "an" : "a",
@@ -538,6 +538,7 @@ hurtle(dx, dy, range, verbose, do_nomul)
     cc.x = u.ux + (dx * range);
     cc.y = u.uy + (dy * range);
     (void) walk_path(&uc, &cc, hurtle_step, (genericptr_t)&range);
+	teleds(u.ux, u.uy, TRUE);
 }
 
 /* Move a monster through the air for a few squares.

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -384,10 +384,22 @@ boolean impaired;				/* TRUE if throwing/firing slipped OR magr is confused/stun
 
 			result = projectile_attack(magr, mdef, thrownobj_p, vpointer, hmoncode, &dx, &dy, &range, &initrange, forcedestroy);
 
-			if (result)
-			{
-				break;
+			/* stop on hit? */
+			if (!thrownobj)
+				break;	/* projectile was destroyed */
+			else if (is_boulder(thrownobj)) {
+				if (result)
+					range /= 2;	/* continue with less range on hit; keep going on miss */
 			}
+			else if (
+				thrownobj->otyp == BLASTER_BOLT ||
+				thrownobj->otyp == HEAVY_BLASTER_BOLT ||
+				thrownobj->otyp == LASER_BEAM) {
+				if (result)
+					break;	/* stop on hit; keep going on miss */
+			}
+			else
+				break;	/* stop on hit or miss */
 		}
 
 		/* projectile is on a sink (it "sinks" down) or is on a non-allowable square */
@@ -1350,12 +1362,6 @@ boolean forcedestroy;			/* TRUE if projectile should be forced to be destroyed a
 			(!inside_shop(u.ux, u.uy) ||
 			!index(in_rooms(mdef->mx, mdef->my, SHOPBASE), *u.ushops)))
 			hot_pursuit(mdef);
-			
-		/* cause projectile to fall onto the floor -- not for blaster bolts */
-		if (thrownobj->otyp != BLASTER_BOLT &&
-			thrownobj->otyp != HEAVY_BLASTER_BOLT &&
-			thrownobj->otyp != LASER_BEAM)
-			*prange = *prange2 = 0;
 		return MM_MISS;
 	}
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1352,7 +1352,8 @@ register struct monst *mtmp;
 	propellor = &zeroobj;
 	Oselect(EGG, W_QUIVER); /* cockatrice egg */
 	if(throws_rocks(mtmp->data))	/* ...boulders for giants */
-	    oselectBoulder(mtmp);
+	if(otmp = oselectBoulder(mtmp))
+		return otmp;
 
 	/* Select polearms first; they do more damage and aren't expendable */
 	/* The limit of 13 here is based on the monster polearm range limit

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -13908,7 +13908,7 @@ int vis;						/* True if action is at all visible to the player */
 		}
 	}
 
-	/* hurtle mdef (player-inflicted only for now, as long as staggering strikes and jousting are) */
+	/* hurtle mdef */
 	if (staggering_strike || jousting || (fired && weapon && is_boulder(weapon))) {
 		int dx, dy;
 		/* in what direction? */
@@ -13933,9 +13933,10 @@ int vis;						/* True if action is at all visible to the player */
 		}
 
 		if (youdef) {
-			hurtle(dx, dy, 1, FALSE, TRUE);
+			hurtle(dx, dy, 1, FALSE, FALSE);
 			if (staggering_strike)
 				make_stunned(HStun + rnd(10), TRUE);
+			nomul(0, "being knocked back");
 		}
 		else {
 			mhurtle(mdef, dx, dy, 1);


### PR DESCRIPTION
1) Like for rolling boulder traps, thrown boulders follow through on-hit, although their range halves every time they hit.
2) Boulders knock back creatures hit 1 tile. This happens *before* the boulder moves.
3) Buff the accuracy and damage of rolling boulder traps.
4) Bugfix to make monsters actually throw boulders.

1+2 together makes for much deadlier thrown boulders. Thankfully, there's a 1/3 chance that you'll be thrown slightly to the side when hit by a boulder, interrupting the ouch-train.
Worst-case, you'll be hit ~5 times before a boulder reaches its resting point.
Yes, these can knock you back into traps or water or lava.
Yes, this may need to be toned down. In the meantime, good luck and have fun!