### PR TITLE
Use a proper untame() function to remember to clean MX_EDOG as needed

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -593,6 +593,7 @@ E void FDECL(migrate_to_level, (struct monst *,int,XCHAR_P,coord *));
 E int FDECL(dogfood, (struct monst *,struct obj *));
 E struct monst *FDECL(tamedog, (struct monst *,struct obj *));
 E struct monst *FDECL(tamedog_core, (struct monst *,struct obj *, int));
+E void FDECL(untame, (struct monst *, boolean));
 E struct monst *FDECL(make_pet_minion, (int,aligntyp));
 E void FDECL(abuse_dog, (struct monst *));
 E void FDECL(wary_dog, (struct monst *, BOOLEAN_P));

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1216,7 +1216,7 @@ moveloop()
 							if(blade == nxtmon) nxtmon = nxtmon->nmon;
 							tamedog(blade, (struct obj *) 0);
 						} else if(!mtmp->mtame && blade->mtame){
-							blade->mtame = 0;
+							untame(blade, mtmp->mpeaceful);
 						}
 						if(mtmp->mpeaceful != blade->mpeaceful){
 							mtmp->mpeaceful = blade->mpeaceful;

--- a/src/apply.c
+++ b/src/apply.c
@@ -3045,9 +3045,8 @@ struct obj *hypo;
 					if (canseemon(mtarg))
 						pline("%s looks more tranquil.", Monnam(mtarg));
 					if(!amp->blessed){
-						mtarg->mtame = 0;
+						untame(mtarg, 1);
 						mtarg->mferal = 0;
-						mtarg->mpeaceful = 1;
 					}
 					mtarg->mcrazed = 0;
 					mtarg->mdisrobe = 0;
@@ -3055,12 +3054,11 @@ struct obj *hypo;
 				} else {
 					if (canseemon(mtarg))
 						pline("%s looks angry and confused!", Monnam(mtarg));
+					untame(mtarg, 0);
 					mtarg->mcrazed = 1;
 					mtarg->mberserk = 1;
 					mtarg->mconf = 1;
-					mtarg->mtame = 0;
 					mtarg->mferal = 0;
-					mtarg->mpeaceful = 0;
 				}
 			break;
 		}

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -8861,8 +8861,7 @@ read_necro(VOID_ARGS)
 							initedog(mtmp);
 							mtmp->m_lev += d(1,15) - 5;
 							if(u.ulevel < mtmp->m_lev && !rn2(10)){
-								mtmp->mtame = 0;
-								mtmp->mpeaceful = 0;
+								untame(mtmp, 0);
 								mtmp->mtraitor = 1;
 							}
 							mtmp->mhpmax = (mtmp->m_lev * 8) - 4;
@@ -8904,8 +8903,7 @@ read_necro(VOID_ARGS)
 							mtmp->m_lev += d(1,(3 * mtmp->m_lev)/2);
 							mtmp->mhpmax = mtmp->mhp = mtmp->m_lev*8 - rnd(7);
 							if(u.ulevel < mtmp->m_lev && !rn2(10)){
-								mtmp->mtame = 0;
-								mtmp->mpeaceful = 0;
+								untame(mtmp, 0);
 								mtmp->mtraitor = 1;
 							}
 							mtmp->mhpmax = (mtmp->m_lev * 8) - 4;
@@ -8924,8 +8922,7 @@ read_necro(VOID_ARGS)
 						if(!rn2(9)) mtmp->m_lev += d(1,(3 * mtmp->m_lev)/2);
 						mtmp->mhpmax = mtmp->mhp = mtmp->m_lev*8 - rnd(7);
 						if(u.ulevel < mtmp->m_lev && !rn2(20)){
-							mtmp->mtame = 0;
-							mtmp->mpeaceful = 0;
+							untame(mtmp, 0);
 							mtmp->mtraitor = 1;
 						}
 					}
@@ -8940,8 +8937,7 @@ read_necro(VOID_ARGS)
 						if(!rn2(6)) mtmp->m_lev += d(1,(3 * mtmp->m_lev)/2);
 						mtmp->mhpmax = mtmp->mhp = mtmp->m_lev*8 - rnd(7);
 						if((u.ulevel < mtmp->m_lev || rn2(2)) && !rn2(10)){
-							mtmp->mtame = 0;
-							mtmp->mpeaceful = 0;
+							untame(mtmp, 0);
 							mtmp->mtraitor = 1;
 						}
 					}

--- a/src/dog.c
+++ b/src/dog.c
@@ -157,7 +157,7 @@ boolean quietly;
 				!(is_animal(mtmp->data) || mindless_mon(mtmp)))
 		) {
 
-		mtmp->mtame = 0;	/* not tame after all */
+		untame(mtmp, 1);	/* not tame after all */
 		if (chance == 2) { /* hostile (cursed figurine) */
 		    if (!quietly)
 		       You("get a bad feeling about this.");
@@ -622,9 +622,9 @@ long nmv;		/* number of moves */
 		    wilder *= 150;
 #endif
 	    if (mtmp->mtame > wilder) mtmp->mtame -= wilder;	/* less tame */
-	    else if (mtmp->mtame > rn2(wilder)) mtmp->mtame = 0;  /* untame */
+	    else if (mtmp->mtame > rn2(wilder)) untame(mtmp, 1);  /* untame, peaceful */
 	    else{
-			mtmp->mtame = mtmp->mpeaceful = 0;		/* hostile! */
+			untame(mtmp, 0);		/* hostile! */
 			mtmp->mferal = 1;
 		}
 	}
@@ -1339,6 +1339,21 @@ int enhanced;
 	return(mtmp);
 }
 
+/* untames mtmp, if it was tame. Sets mtmp->mpeaceful whether or not mtmp was tame */
+void
+untame(mtmp, be_peaceful)
+struct monst * mtmp;
+boolean be_peaceful;
+{
+	if (mtmp->mtame) {
+		rem_mx(mtmp, MX_EDOG);
+		mtmp->mtame = 0;
+	}
+	mtmp->mpeaceful = be_peaceful;
+	newsym(mtmp->mx, mtmp->my);
+	return;
+}
+
 struct monst *
 make_pet_minion(mtyp,alignment)
 int mtyp;
@@ -1389,7 +1404,7 @@ boolean was_dead;
     }
 
     if (edog && (edog->killed_by_u == 1 || edog->abuse > 2)) {
-	mtmp->mpeaceful = mtmp->mtame = 0;
+	untame(mtmp, 0);
 	if (edog->abuse >= 0 && edog->abuse < 10)
 	    if (!rn2(edog->abuse + 1)) mtmp->mpeaceful = 1;
 	if(!quietly && cansee(mtmp->mx, mtmp->my)) {
@@ -1408,7 +1423,7 @@ boolean was_dead;
     } else {
 	/* chance it goes wild anyway - Pet Semetary */
 	if (!(edog && edog->loyal) && !rn2(mtmp->mtame)) {
-	    mtmp->mpeaceful = mtmp->mtame = 0;
+	    untame(mtmp, 0);
 	}
     }
     if (!mtmp->mtame) {

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -884,8 +884,7 @@ register struct monst *mtmp;
 	    pline("%s turns on you!", Monnam(mtmp));
 	else
 	    pline("You feel uneasy about %s.", y_monnam(mtmp));
-	mtmp->mpeaceful = 0;
-	mtmp->mtame = 0;
+	untame(mtmp, 0);
 	mtmp->mtraitor = TRUE;
 
 	/* Do we need to call newsym() here? */

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -10340,8 +10340,7 @@ struct monst *mtmp, *victim;
 			struct monst *baby;
 			int tnum = d(1,6);
 			int i;
-			mtmp->mtame = 0;
-			mtmp->mpeaceful = 1;
+			untame(mtmp, 1);
 			for(i = 0; i < 6; i++){
 				baby = makemon(&mons[PM_METROID], mtmp->mx, mtmp->my, MM_ADJACENTOK);
 				if(tnum-->0) tamedog(baby,(struct obj *) 0);

--- a/src/minion.c
+++ b/src/minion.c
@@ -265,7 +265,7 @@ register struct monst *mtmp;
 			|| uwep->oartifact == ART_LANCE_OF_LONGINUS
 		) ) {
 	    pline("%s looks very angry.", Amonnam(mtmp));
-	    mtmp->mpeaceful = mtmp->mtame = 0;
+	    untame(mtmp, 0);
 	    set_malign(mtmp);
 	    newsym(mtmp->mx, mtmp->my);
 	    return 0;

--- a/src/mon.c
+++ b/src/mon.c
@@ -1849,7 +1849,7 @@ mcalcdistress()
 					pline("%s turns to glass!", Monnam(tmpm));
 				tmpm->mpeaceful = mtmp->mpeaceful;
 				if(tmpm->mtame && tmpm->mtame != mtmp->mtame)
-					tmpm->mtame = 0;
+					untame(tmpm, mtmp->mpeaceful);
 				set_template(tmpm, CRYSTALFIED);
 				newsym(tmpm->mx, tmpm->my);
 				mtmp->mhp += tmpm->mhp;
@@ -2239,8 +2239,7 @@ movemon()
 			struct monst *baby;
 			int tnum = d(1,6);
 			int i;
-			mtmp->mtame = 0;
-			mtmp->mpeaceful = 1;
+			untame(mtmp, 1);
 			for(i = 0; i < 6; i++){
 				baby = makemon(&mons[PM_METROID], mtmp->mx, mtmp->my, MM_ADJACENTOK);
 				if(tnum-- > 0) tamedog(baby,(struct obj *) 0);
@@ -2277,8 +2276,7 @@ movemon()
 		mtmp->mpeaceful
 	){
 		if(canseemon(mtmp)) pline("%s gets angry...", mon_nam(mtmp));
-		mtmp->mpeaceful = 0;
-		mtmp->mtame = 0;
+		untame(mtmp, 0);
 	}
 	if(mtmp->mtyp == PM_UVUUDAUM){
 		if(u.uevent.invoked 
@@ -4048,8 +4046,7 @@ struct monst *mtmp;
 					You_hear("something crack%s!", !is_silent(mtmp->data) ? " with an unearthly scream" : "");
 			}
 			/* make hostile */
-			mtmp->mtame = 0;
-			mtmp->mpeaceful = 0;
+			untame(mtmp, 0);
 			/* boost level */
 			mtmp->m_lev += 4;
 			mtmp->mhpmax += d(4, 8);
@@ -4121,8 +4118,7 @@ struct monst *mtmp;
 			}
 			set_template(mtmp, FRACTURED);
 			/* make hostile */
-			mtmp->mtame = 0;
-			mtmp->mpeaceful = 0;
+			untame(mtmp, 0);
 			/* boost level */
 			mtmp->m_lev += 4;
 			mtmp->mhpmax += d(4, 8);

--- a/src/muse.c
+++ b/src/muse.c
@@ -2233,21 +2233,19 @@ museamnesia:
 		if(!otmp->cursed){
 			if (vismon) pline("%s looks more tranquil.", Monnam(mtmp));
 			if(!otmp->blessed){
-				mtmp->mtame = 0;
+				untame(mtmp, 1);
 				mtmp->mferal = 0;
-				mtmp->mpeaceful = 1;
 			}
 			mtmp->mcrazed = 0;
 			mtmp->mberserk = 0;
 			mtmp->mdisrobe = 0;
 		} else {
 			if (vismon) pline("%s looks angry and confused!", Monnam(mtmp));
+			untame(mtmp, 0);
 			mtmp->mcrazed = 1;
 			mtmp->mberserk = 1;
 			mtmp->mconf = 1;
-			mtmp->mtame = 0;
 			mtmp->mferal = 0;
-			mtmp->mpeaceful = 0;
 		}
 		if (!otmp->oartifact)
 			m_useup(mtmp, otmp);

--- a/src/pray.c
+++ b/src/pray.c
@@ -722,8 +722,7 @@ int ga_num;
 		struct monst *mtmp;
 		for(mtmp = migrating_mons; mtmp; mtmp = mtmp->nmon){
 			if(mtmp->mux == u.uz.dnum && mtmp->muy == u.uz.dlevel && (mtmp->mtyp == PM_BLESSED || mtmp->mtyp == PM_MOUTH_OF_THE_GOAT)){
-				mtmp->mpeaceful = 0;
-				mtmp->mtame = 0;
+				untame(mtmp, 0);
 				//Does not re-set alignment value (as if you attacked a peaceful)
 			}
 		}

--- a/src/priest.c
+++ b/src/priest.c
@@ -828,7 +828,7 @@ register struct monst *roamer;
 	        return;
 
 	if(EPRI(roamer)->shralign != u.ualign.type) {
-	    roamer->mpeaceful = roamer->mtame = 0;
+		untame(roamer, 0);
 	    set_malign(roamer);
 	}
 	newsym(roamer->mx, roamer->my);

--- a/src/restore.c
+++ b/src/restore.c
@@ -1105,7 +1105,7 @@ boolean ghostly;
 	if (ghostly && get_ox(otmp, OX_EMON)) {
 	    struct monst *mtmp = EMON(otmp);
 	    mtmp->m_id = 0;
-	    mtmp->mpeaceful = mtmp->mtame = 0;	/* pet's owner died! */
+		untame(mtmp, 0);/* pet's owner died! */
 	}
 	if (ghostly && get_ox(otmp, OX_EMID)) {
 		oldid = otmp->oextra_p->emid_p[0];

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -1040,7 +1040,7 @@ asGuardian:
 				mtmp->mnotlaugh = 1; mtmp->mlaughing = 0;
 				mtmp->msleeping = 0;
 				mtmp->mstun = 0; mtmp->mconf = 0;
-				mtmp->mpeaceful = 0; mtmp->mtame = 0;
+				untame(mtmp, 0);
 				
 				u.ustdy = mtmp->m_lev;
 				pline_msg = "ends its prayer.";
@@ -1690,7 +1690,7 @@ asGuardian:
 				if(tmpm->mtame > 10){
 					tmpm->mtame -= 10;
 					tmpm->mflee = 1;
-				} else tmpm->mtame = 0;
+				} else untame(mtmp, 1);
 			}
 		}
 	break;

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -567,7 +567,8 @@ nasty(mcast)
 							bypos.x, bypos.y, NO_MM_FLAGS);
 				if(!mtmp) /* makemon still failed, abort */
 					return count;
-				mtmp->msleeping = mtmp->mpeaceful = mtmp->mtame = 0;
+				mtmp->msleeping = 0;
+				untame(mtmp, 0);
 				set_malign(mtmp);
 				count++;
 				break;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -14867,8 +14867,7 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 							mndx = monsndx(mtmp->data);
 							if (mndx <= PM_QUINON && mndx >= PM_MONOTON && mtmp->mpeaceful){
 								pline("%s gets angry...", Amonnam(mtmp));
-								mtmp->mpeaceful = 0;
-								mtmp->mtame = 0;
+								untame(mtmp, 0);
 							}
 						}
 					}

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1927,7 +1927,7 @@ boolean vis;
 				if(mdef->mtame && (mdef->isminion || !(EDOG(mdef)->loyal))){//note: won't check loyal if the target is a minion
 					if(mdef->mtame > dmg)
 						mdef->mtame -= dmg;
-					else mdef->mtame = 0;
+					else untame(mdef, 1);
 				}
 				if(mdef->mcrazed && rnd(20) < dmg){
 					mdef->mcrazed = 0;

--- a/src/zap.c
+++ b/src/zap.c
@@ -4663,8 +4663,7 @@ int type;
 		mon->mhp = min(mon->mhp, mon->mhpmax);
 	}
 	set_template(mon, DELOUSED);
-	mon->mtame = 0;
-	mon->mpeaceful = 1;
+	untame(mtmp, 1);
 	mon->mcanmove = 1;
 	return mon;
 }


### PR DESCRIPTION
Fixes an impossible() when trying to retame an untamed creature, because the old MX_EDOG was never removed. The vanilla method was to just stop looking at the extra data allocated with the monster and rewrite overtop of it when retaming.