### PR TITLE
Call uwepgone() when appropriate

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -12157,9 +12157,13 @@ int vis;						/* True if action is at all visible to the player */
 					if (otmp == uwep) uwepgone();
 					freeinv(otmp);
 				}
-				else {
+				else if (magr) {
 					if (otmp == MON_WEP(magr)) MON_WEP(magr) = (struct obj *)0;
 					m_freeinv(otmp);
+				}
+				else {
+					impossible("how to free potion?");
+					obj_extract_self(otmp);
 				}
 			}
 

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -12153,10 +12153,14 @@ int vis;						/* True if action is at all visible to the player */
 				*weapon_p = NULL;
 			}
 			if (otmp->where != OBJ_FREE) {
-				if (youagr)
+				if (youagr) {
+					if (otmp == uwep) uwepgone();
 					freeinv(otmp);
-				else
+				}
+				else {
+					if (otmp == MON_WEP(magr)) MON_WEP(magr) = (struct obj *)0;
 					m_freeinv(otmp);
+				}
 			}
 
 			if (!weapon) {


### PR DESCRIPTION
Because for SOME REASON freeinv() doesn't, and I'm not sure changing freeinv() to do so won't cause even more bugs >_>