### PR TITLE
Re-set potion colour after changing potion->otyp

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -2362,6 +2362,7 @@ boolean amnesia;
 			if (obj->otyp == POT_STARLIGHT)
 				end_burn(obj, FALSE);
 			obj->otyp = POT_WATER;
+			set_object_color(obj);
 		} else obj->odiluted++;
 		used = TRUE;
 		break;
@@ -2781,7 +2782,7 @@ dodip()
 			pline_The("mixture looks %s.",
 				hcolor(OBJ_DESCR(objects[obj->otyp])));
 		}
-
+		set_object_color(obj);
 		useup(potion);
 		return(1);
 	}

--- a/src/trap.c
+++ b/src/trap.c
@@ -3286,11 +3286,13 @@ struct monst *owner;
 			    else if (obj->otyp != POT_AMNESIA) {
 				obj->otyp = POT_WATER;
 				obj->odiluted = 0;
+				set_object_color(obj);
 			    }
 			} else if (obj->odiluted || obj->otyp == POT_AMNESIA) {
 				obj->otyp = POT_WATER;
 				obj->blessed = obj->cursed = 0;
 				obj->odiluted = 0;
+				set_object_color(obj);
 			} else if (obj->otyp != POT_WATER)
 				obj->odiluted++;
 			break;

--- a/src/zap.c
+++ b/src/zap.c
@@ -1123,6 +1123,7 @@ register struct obj *obj;
 			obj->otyp = POT_WATER;
 			obj->odiluted = 0; /* same as any other water */
 		}
+		set_object_color(obj);
 		break;
 	    }
 	}
@@ -1526,6 +1527,7 @@ poly_obj(obj, id)
 		} else if(obj->otyp == POT_WATER || obj->otyp == POT_AMNESIA){
 			if(obj->otyp == POT_AMNESIA){
 				obj->otyp = POT_WATER;
+				set_object_color(obj);
 			}
 			if(!rn2(3)){
 				obj->blessed = 0;


### PR DESCRIPTION
Note that constantly resetting obj->color is *not* okay in some cases right now -- that should probably get changed so that they are MOD obj->oid and not rn2()