### PR TITLE
Check that monsters aren't dead yet before drowning them

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -1287,6 +1287,9 @@ int
 minliquid(mtmp)
 register struct monst *mtmp;
 {
+	/* mtmp must be alive */
+	if (!mtmp || DEADMONSTER(mtmp))
+		return 1;	/* mon is already dead */
 	boolean inpool, inlava, infountain, inshallow;
 
 	inpool = is_3dwater(mtmp->mx, mtmp->my) || (is_pool(mtmp->mx, mtmp->my, FALSE) &&


### PR DESCRIPTION
Fixes double-dmonsfree when killing a monster in water that got its water-surviving-trait from worn equipment