### PR TITLE
ID and mitigate potential corruptions of monster movement loop

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2198,6 +2198,15 @@ movemon()
 	
 	//Current Movement Loop///////////////////////////////////////////////////
     for(mtmp = fmon; mtmp; mtmp = nmtmp) {
+	/* check that mtmp wasn't migrated by previous mtmp's actions */
+	if (!(mtmp->mx || mtmp->my)) {
+		/* uh oh -- restart loop at fmon. This will let already-handled very fast
+		 * monsters expend movement points to act out of turn, but will not result in anyone gaining
+		 * or losing turns, or worse, this loop affecting anyone in the migrating_mons chain */
+		mtmp = fmon;
+		if (!mtmp)
+			break;	/* exit current movement loop, there is no one left at all */
+	}
 	nmtmp = mtmp->nmon;
 	/* Find a monster that we have not treated yet.	 */
 	if(DEADMONSTER(mtmp))


### PR DESCRIPTION
If a monster's actions cause the next monster in the fmon chain to be moved to the migrating_mons chain, the `nmtmp` pointer will cause the loop to go through the migrating_mons chain -- this is BAD.
Check that each new mtmp in the loop is on the level (by checking mx and my).

If the monster is migrating, we cannot use its `->nmon`. We also cannot trust the previous mtmp to still be on the level, even if we had a pointer back to it. For a perfect solution, we would need a list of every monster handled by the loop so far.
Instead, we will restart the loop at fmon again.
This will double-process any monsters that were already handled AND have >=12 movepoints remaining, letting them get their second move earlier than expected (in relation to other creatures' movements) this global turn. I think that this is minor enough to be unnoticable, especially with how rare the trigger event is in the first place.

I have tested this and it appears to work. (ie, I can reproduce the weeping-angel levelports monster causing panic without patch, and then attempting to reproduce it with the patch fails)