### PR TITLE
Short-circuit mm_aggression() if magr and mdef are distant

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -3412,6 +3412,10 @@ struct monst * mdef;	/* another monster which is next to it */
 	if(mdef->entangled == SHACKLES) {
 		return 0L;
 	}
+	// must be in range to attack mdef
+	if (distmin(magr->mx, magr->my, mdef->mx, mdef->my) > BOLT_LIM) {
+		return 0L;
+	}
 	// must be able to see mdef -- note that this has a 1/8 chance when adjacent even when totally blind!
 	if (!mon_can_see_mon(magr, mdef)) {
 		return 0L;


### PR DESCRIPTION
Improves efficiency of mfind_target() and reduces calls to mon_can_see_mon().

No ranged attacks were being made if magr was that far away from mdef, anyways; those were already checking vs BOLT_LIM.