### PR TITLE
Add guard for mstoning macro's corpsenm usage

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2368,7 +2368,7 @@ movemon()
 #ifdef OVLB
 
 #define mstoning(obj)	(ofood(obj) && \
-					(touch_petrifies(&mons[(obj)->corpsenm]) || \
+					((obj)->corpsenm >= LOW_PM && touch_petrifies(&mons[(obj)->corpsenm]) || \
 					(obj)->corpsenm == PM_MEDUSA))
 
 /*


### PR DESCRIPTION
In the case where a metallivore eats a tin of spinach, this will perform
a left-side out of bounds buffer read without this