### PR TITLE
Double maxweight per size above medium

### DIFF
--- a/src/u_init.c
+++ b/src/u_init.c
@@ -2309,8 +2309,10 @@ u_init()
 			else if(isSignetRing(pobj->otyp)){
 				pobj->ohaluengr = TRUE;
 				pobj->oward = u.uhouse;
-				pobj->opoisoned = OPOISON_SLEEP;
-				pobj->opoisonchrgs = 30;
+				if(!Role_if(PM_EXILE)){
+					pobj->opoisoned = OPOISON_SLEEP;
+					pobj->opoisonchrgs = 30;
+				}
 			}
 			else if(is_poisonable(pobj)){
 				pobj->opoisoned = OPOISON_SLEEP;

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1346,7 +1346,7 @@ register struct monst *mtmp;
 	propellor = &zeroobj;
 	Oselect(EGG, W_QUIVER); /* cockatrice egg */
 	if(throws_rocks(mtmp->data))	/* ...boulders for giants */
-	if(otmp = oselectBoulder(mtmp))
+	if((otmp = oselectBoulder(mtmp)))
 		return otmp;
 
 	/* Select polearms first; they do more damage and aren't expendable */
@@ -3121,6 +3121,9 @@ int wep_type;
 			case P_MASTER:			maxweight = 50; break;
 			case P_GRAND_MASTER:	maxweight = 60; break;
 		}
+		if (youracedata->msize > MZ_MEDIUM)
+			maxweight *= 2*(youracedata->msize - MZ_MEDIUM);
+
 		if (wep_type == P_BARE_HANDED_COMBAT) {
 			bonus -= abs(bonus * 2 / 3);
 		}

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -3420,6 +3420,10 @@ int wep_type;
 			case P_MASTER:		 maxweight = 50; break;	 /* war hammer */
 			case P_GRAND_MASTER: maxweight = 60; break;	 /* axe */
 		}
+
+		if (youracedata->msize > MZ_MEDIUM)
+			maxweight *= 2*(youracedata->msize - MZ_MEDIUM);
+
 		if (wep_type == P_BARE_HANDED_COMBAT) {
 			bonus -= (skill * 2 / 3);
 		}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3253,6 +3253,10 @@ int flat_acc;
 				}
 			}
 		}
+		/* gnomes are especially accurate, with weapons or ranged or any other "proper" attacks... not a zombie's claw attack. */
+		if (magr && (youagr ? Race_if(PM_GNOME) : is_gnome(pa)))
+			wepn_acc += 2;
+
 		/* skill bonus (player-only; applies without a weapon as well) */
 		if (youagr) {
 			int wtype;

--- a/src/zap.c
+++ b/src/zap.c
@@ -1771,6 +1771,8 @@ poly_obj(obj, id)
 
 	/* update the weight */
 	otmp->owt = weight(otmp);
+	/* update the color */
+	set_object_color(otmp);
 
 	/* for now, take off worn items being polymorphed */
 	if (obj_location == OBJ_INVENT) {


### PR DESCRIPTION
Since weapon weights are doubled, it makes sense you should be able to use appropriately sized items.