### PR TITLE
Adjust Mitre/EotOW to be appropriately sized

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -186,14 +186,6 @@ hack_artifacts()
  	    artilist[ART_SINGING_SWORD].role = NON_PM;
 	}
 	
-	if(Role_if(PM_MONK)){
- 	    artilist[ART_EYES_OF_THE_OVERWORLD].size = youracedata->msize;
-	}
-	
-	if(Role_if(PM_PRIEST)){
- 	    artilist[ART_MITRE_OF_HOLINESS].size = youracedata->msize;
-	}
-	
 	if(Role_if(PM_ANACHRONONAUT)){
 		artilist[ART_CRESCENT_BLADE].race = NON_PM;
 		artilist[ART_CRESCENT_BLADE].alignment = A_NONE;
@@ -271,6 +263,12 @@ hack_artifacts()
 	
 	/* Fix up the quest artifact */
 	if(Pantheon_if(PM_NOBLEMAN) || Role_if(PM_NOBLEMAN)){
+		artilist[ART_MANTLE_OF_HEAVEN].size = (&mons[urace.malenum])->msize;
+		artilist[ART_VESTMENT_OF_HELL].size = (&mons[urace.malenum])->msize;
+
+		artilist[ART_CROWN_OF_THE_SAINT_KING].size = (&mons[urace.malenum])->msize;
+		artilist[ART_HELM_OF_THE_DARK_LORD].size = (&mons[urace.malenum])->msize;
+
 		if(Race_if(PM_VAMPIRE)){
 			urole.questarti = ART_VESTMENT_OF_HELL;
 			artilist[ART_HELM_OF_THE_DARK_LORD].alignment = alignmnt;
@@ -300,7 +298,14 @@ hack_artifacts()
 	    artilist[ART_GRANDMASTER_S_ROBE].alignment = alignmnt;
 	    artilist[ART_ROBE_OF_THE_ARCHMAGI].alignment = A_CHAOTIC;
 	    artilist[ART_ROBE_OF_THE_ARCHMAGI].role = Role_switch;
+
+	    artilist[ART_EYES_OF_THE_OVERWORLD].size = (&mons[urace.malenum])->msize;
 	}
+
+	if(Role_if(PM_PRIEST)){
+		artilist[ART_MITRE_OF_HOLINESS].size = (&mons[urace.malenum])->msize;
+	}
+
 	if (urole.questarti) {
 	    artilist[urole.questarti].alignment = alignmnt;
 	    artilist[urole.questarti].role = Role_switch;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -186,6 +186,14 @@ hack_artifacts()
  	    artilist[ART_SINGING_SWORD].role = NON_PM;
 	}
 	
+	if(Role_if(PM_MONK)){
+ 	    artilist[ART_EYES_OF_THE_OVERWORLD].size = youracedata->msize;
+	}
+	
+	if(Role_if(PM_PRIEST)){
+ 	    artilist[ART_MITRE_OF_HOLINESS].size = youracedata->msize;
+	}
+	
 	if(Role_if(PM_ANACHRONONAUT)){
 		artilist[ART_CRESCENT_BLADE].race = NON_PM;
 		artilist[ART_CRESCENT_BLADE].alignment = A_NONE;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -263,9 +263,6 @@ hack_artifacts()
 	
 	/* Fix up the quest artifact */
 	if(Pantheon_if(PM_NOBLEMAN) || Role_if(PM_NOBLEMAN)){
-		artilist[ART_MANTLE_OF_HEAVEN].size = (&mons[urace.malenum])->msize;
-		artilist[ART_VESTMENT_OF_HELL].size = (&mons[urace.malenum])->msize;
-
 		artilist[ART_CROWN_OF_THE_SAINT_KING].size = (&mons[urace.malenum])->msize;
 		artilist[ART_HELM_OF_THE_DARK_LORD].size = (&mons[urace.malenum])->msize;
 

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -597,6 +597,8 @@ const char *name;
 		if (is_malleable_artifact(&artilist[obj->oartifact])); //keep current/default body type
 		else if (Role_if(PM_PRIEST) && obj->oartifact == ART_MITRE_OF_HOLINESS)
 			obj->bodytypeflag = ((&mons[urace.malenum])->mflagsb&MB_HEADMODIMASK);
+		else if (Pantheon_if(PM_NOBLEMAN) && (obj->oartifact == ART_HELM_OF_THE_DARK_LORD || obj->oartifact == ART_CROWN_OF_THE_SAINT_KING))
+			obj->bodytypeflag = ((&mons[urace.malenum])->mflagsb&MB_HEADMODIMASK);
 		else obj->bodytypeflag = MB_HUMANOID;
 		
 		/* viperwhip heads */

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -595,6 +595,8 @@ const char *name;
 		
 		/* body type */
 		if (is_malleable_artifact(&artilist[obj->oartifact])); //keep current/default body type
+		else if (Role_if(PM_PRIEST) && obj->oartifact == ART_MITRE_OF_HOLINESS)
+			obj->bodytypeflag = ((&mons[urace.malenum])->mflagsb&MB_HEADMODIMASK);
 		else obj->bodytypeflag = MB_HUMANOID;
 		
 		/* viperwhip heads */

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -28,6 +28,7 @@ STATIC_DCL int FDECL(maid_clean, (struct monst *, struct obj *));
 						) && (														\
 						otmp->oclass == WEAPON_CLASS								\
 						|| (otmp->oclass == TOOL_CLASS && is_weptool(otmp))			\
+						|| (otmp->oclass == TOOL_CLASS && (otmp->otyp == LENSES || otmp->otyp == SUNGLASSES))	\
 						|| (otmp->oclass == ARMOR_CLASS && !Is_dragon_scales(otmp))	\
 						))
 
@@ -1967,12 +1968,12 @@ int mat;
 
 	if (obj->where == OBJ_INVENT) {
 		owner = &youmonst;
-		if (mask = obj->owornmask)
+		if ((mask = obj->owornmask))
 			setnotworn(obj);
 	}
 	if (obj->where == OBJ_MINVENT) {
 		owner = obj->ocarry;
-		if (mask = obj->owornmask)
+		if ((mask = obj->owornmask))
 			update_mon_intrinsics(owner, obj, FALSE, TRUE);
 	}
 	/* change otyp to be appropriate


### PR DESCRIPTION
As-is, the EotOW are completely unwearable on a chiropteran monk - since you can't resize lenses/sunglasses, and yet they only fit appropriately sized characters. The Mitre is better, but it still needs a resizing & a body plan (longhead & animaloid) adjustment.  The Noble crowning helms should probably be appropriately sized, even if they would fit anyway, with the body plan adjusted as well.

I only adjusted those since they are unusable in their current state (EotOW) without adjustments (Mitre, crowning helms). Other potential artifacts would be Itlachiayaque, the Veil of Latona, Hermes' Sandals or the noble quest artifacts. I don't really think they need to be poked - no clue about Latona but I think Hermes' Sandals would be sized for Hermes' (who apparently has a medium humanoid avatar), and Itlachiayaque is an ancient artifact and usable as-is anyway. Lastly, the noble cloaks aren't even obtainable as a funkily sized race right now - chiro/gnomes can't be nobles. Though I think chiro rangers, gnomish arcs, and gnomish healers might have poorly fitting artifacts right now.

Note that you can still get crowned with the noble pantheon as a Chiropteran to receive the helms, so they're added in here as well despite not being normally obtainable. Obviously this doesn't fly for the cloaks. Amusingly enough, before this, a Chiropteran priest crowned as a noble could have the helm put on directly, bypassing the standard body plan checks, but would be unable to put it back on without adjustment if doffed.

Also added lenses/sunglasses to the "sized equipment" bit of the mkobj.c code. That doesn't include artifacts, so it's mostly irrelevant, but could definitely be noticed.
