### PR TITLE
Nerf Octetsabers

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -626,9 +626,9 @@ int otyp;
 
 	case SEISMIC_HAMMER:		if (chrgd){ ocd *= 3; } break;
 	case ACID_VENOM:			if (obj&&obj->ovar1){ ocn = 0; flat = obj->ovar1; } else{ add(6); } break;
-	case LIGHTSABER:			spe_mult = 3; ocn += 2; if(obj&&obj->altmode){ plus(3,3); spe_mult += 3;} break;	// external special case: lightsaber forms
-	case BEAMSWORD:				spe_mult = 3; ocn += 2; if(obj&&obj->altmode){ plus(3,3); spe_mult += 3;} break;	// external special case: Atma Weapon, lightsaber forms
-	case DOUBLE_LIGHTSABER:		spe_mult = 3; ocn += 2; if(obj&&obj->altmode){ ocn+=3; spe_mult += 3; } break;		// external special case: lightsaber forms
+	case LIGHTSABER:			spe_mult *= 3; ocn *= 3; if(obj&&obj->altmode){ plus(3,3); spe_mult *= 2;} break;	// external special case: lightsaber forms
+	case BEAMSWORD:				spe_mult *= 3; ocn *= 3; if(obj&&obj->altmode){ plus(3,3); spe_mult *= 2;} break;	// external special case: Atma Weapon, lightsaber forms
+	case DOUBLE_LIGHTSABER:		spe_mult *= 3; ocn *= 3; if(obj&&obj->altmode){ ocn*=2;    spe_mult *= 2;} break;	// external special case: lightsaber forms
 	}
 #undef plus_base
 #undef plus
@@ -640,15 +640,12 @@ int otyp;
 	if (obj && (otyp == LIGHTSABER || otyp == BEAMSWORD || otyp == DOUBLE_LIGHTSABER) && !litsaber(obj))
 	{
 		spe_mult = 1;
-		if(obj->oartifact == ART_FLUORITE_OCTAHEDRON){
-			ocn = 1;
-			ocd = 8;
-		} else {
-			ocn = 1;
-			ocd = 2;
-		}
+		ocn = 1;
+		ocd = 2;
 		bonn = 0;
 		bond = 0;
+		exploding = FALSE;
+		lucky = FALSE;
 	}
 	/* kamerel vajra */
 	if (obj && otyp == KAMEREL_VAJRA)
@@ -717,6 +714,13 @@ int otyp;
 			ocn = 2;
 		}
 	}
+	/* lightsabers with the Fluorite Octet socketed */
+	if (obj && obj->oartifact == ART_FLUORITE_OCTAHEDRON && litsaber(obj)) {
+		/* Fluorite Octet overrides the number of dice -- only 1 per blade, not 3 */
+		ocn /= 3;
+		/* but keep spe_mult */
+	}
+
 	/* the Tentacle Rod gets no damage from enchantment */
 	if (obj && obj->oartifact == ART_TENTACLE_ROD)
 		spe_mult = 0;


### PR DESCRIPTION
Consider the other lightsaber artifacts: they don't really make the lightsaber much stronger, even the Annulus.
An octetsaber, at max luck, was over 2x damage compared to an unsocketed lightsaber (at max enchantment. more like 4x damage when comparing at +0).

Post-nerf, an octetsaber at max luck will be a bit more damage than an unsocketed lightsaber (average of +5 flat per hit; doubled for doublesabers).

Removes unlit octetsabers entirely. An Octahedron shouldn't boost damage if it isn't actually being used as the weapon -- putting an Octahedron into a sack won't make you deal 1d8 expl-lucky when swinging the sack around, so it shouldn't affect a lightsaber that isn't actively using its focusing gem!