### PR TITLE
Increase maxweight for player sizes above medium

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -3128,6 +3128,9 @@ int wep_type;
 			case P_MASTER:			maxweight = 50; break;
 			case P_GRAND_MASTER:	maxweight = 60; break;
 		}
+		if (youracedata->msize > MZ_MEDIUM)
+			maxweight *= 1+(youracedata->msize - MZ_MEDIUM);
+
 		if (wep_type == P_BARE_HANDED_COMBAT) {
 			bonus -= abs(bonus * 2 / 3);
 		}
@@ -3424,6 +3427,9 @@ int wep_type;
 			case P_MASTER:		 maxweight = 50; break;	 /* war hammer */
 			case P_GRAND_MASTER: maxweight = 60; break;	 /* axe */
 		}
+		if (youracedata->msize > MZ_MEDIUM)
+			maxweight *= 1+(youracedata->msize - MZ_MEDIUM);
+
 		if (wep_type == P_BARE_HANDED_COMBAT) {
 			bonus -= (skill * 2 / 3);
 		}


### PR DESCRIPTION
Since weapon weights are doubled and beyond, it makes sense you should be able to use appropriately sized items.