### PR TITLE
Allow reading of anti-clockwise metamorphosis glyphs

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -692,7 +692,7 @@ struct obj *scroll;
 		}
 		u.uvaul_duration += duration;
 		if(!scroll->cursed) u.uvaul++;
-	} else if(scroll->otyp >= CLOCKWISE_METAMORPHOSIS_GLYPH && scroll->otyp <= BEAST_S_EMBRACE_GLYPH) {
+	} else if(scroll->otyp >= ANTI_CLOCKWISE_METAMORPHOSIS_G && scroll->otyp <= BEAST_S_EMBRACE_GLYPH) {
 		thought = otyp_to_thought(scroll->otyp);
 
 		/* maybe_give_thought checks requirements, returns FALSE if it didn't work */


### PR DESCRIPTION
The read.c check was not treating them as valid, due to an off-by-one error on the starting index of the glyphs.