### PR TITLE
Move (m/o)extra tables into their .c files (from .h)

### DIFF
--- a/include/mextra.h
+++ b/include/mextra.h
@@ -30,19 +30,4 @@ union mextra {
 	};
 };
 
-struct mx_table {
-	int indexnum;
-	int s_size;
-};
-
-static struct mx_table mx_list[] = {
-	{MX_EDOG, sizeof(struct edog)},
-	{MX_EHOR, sizeof(struct ehor)},
-	{MX_EMIN, sizeof(struct emin)},
-	{MX_ENAM, -1},	/* variable; actual size is stored in structure. 1st item is an int containing size */
-	{MX_EPRI, sizeof(struct epri)},
-	{MX_ESHK, sizeof(struct eshk)},
-	{MX_EVGD, sizeof(struct evgd)}
-};
-
 #endif /* MEXTRA_H */

--- a/include/oextra.h
+++ b/include/oextra.h
@@ -22,15 +22,4 @@ union oextra {
 	};
 };
 
-struct ox_table {
-	int indexnum;
-	int s_size;
-};
-
-static struct ox_table ox_list[] = {
-	{OX_ENAM, -1},	/* variable; actual size is stored in structure. 1st item is an int containing size */
-	{OX_EMON, -1},	/* variable; actual size is stored in structure. 1st item is an int containing size */
-	{OX_EMID, sizeof(int)}
-};
-
 #endif /* OEXTRA_H */

--- a/src/mextra.c
+++ b/src/mextra.c
@@ -3,8 +3,20 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "hack.h"
-
 #include "lev.h"
+
+struct mx_table {
+	int indexnum;
+	int s_size;
+} mx_list[] = {
+	{MX_EDOG, sizeof(struct edog)},
+	{MX_EHOR, sizeof(struct ehor)},
+	{MX_EMIN, sizeof(struct emin)},
+	{MX_ENAM, -1},	/* variable; actual size is stored in structure. 1st item is a long containing size */
+	{MX_EPRI, sizeof(struct epri)},
+	{MX_ESHK, sizeof(struct eshk)},
+	{MX_EVGD, sizeof(struct evgd)}
+};
 
 /* add one component to mon */
 /* automatically finds size of component */

--- a/src/oextra.c
+++ b/src/oextra.c
@@ -3,8 +3,16 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "hack.h"
-#include "oextra.h"
 #include "lev.h"
+
+struct ox_table {
+	int indexnum;
+	int s_size;
+} ox_list[] = {
+	{OX_ENAM, -1},	/* variable; actual size is stored in structure. 1st item is a long containing size */
+	{OX_EMON, -1},	/* variable; actual size is stored in structure. 1st item is a long containing size */
+	{OX_EMID, sizeof(int)}
+};
 
 /* add one component to obj */
 /* automatically finds size of component */


### PR DESCRIPTION
They are only used in their individual .c's. Other files do not and should not need to know what the tables look like.