### PR TITLE
Prevent extinction of monsters from #wizmakemap

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1258,10 +1258,15 @@ wiz_makemap(VOID_ARGS)
 	rm_mapseen(ledger_no(&u.uz));
 
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
+	    int ndx = monsndx(mtmp->data);
 	    if (mtmp->isgd) {
 		mtmp->isgd = 0;
 		mongone(mtmp);
 	    }
+            if (mtmp->data->geno & G_UNIQ)
+                mvitals[ndx].mvflags &= ~(G_EXTINCT);
+            if (mvitals[ndx].born)
+                mvitals[ndx].born--;
 	    if (DEADMONSTER(mtmp))
 		continue;
 	    if (mtmp->isshk)


### PR DESCRIPTION
Recreating a level shouldn't exhaust all the monsters, and certainly
shouldn't prevent the unique monsters respawning.

Taken from the vanilla fix for the same problem