### PR TITLE
Monsters can only summon a demon/devil if they've found you

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -3936,9 +3936,10 @@ int tary;
 		return MM_HIT;
 
 	case SUMMON_DEVIL:
-		if (!youdef || u.summonMonster) {
+		if (!youdef || u.summonMonster || !foundem) {
 			/* only mvu allowed */
 			/* only one summon spell per global turn allowed */
+			/* since it always summons adjacent to player, only allow casting if they've found you */
 			return cast_spell(magr, mdef, attk, (foundem ? OPEN_WOUNDS : CURE_SELF), tarx, tary);
 		}
 		else if (is_alienist(magr->data)) {


### PR DESCRIPTION
The monster-creation function always makes the monster at your location, so we can't allow enemies to make the summon happen at some tarx-tary that isn't you.