### PR TITLE
Fix double percent in description of Naen and Krau.

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -3196,7 +3196,7 @@ winid *datawin;
 		break;
 		case SYLLABLE_OF_POWER__KRAU:
 			OBJPUTSTR("Read to gain temporary and permanent bonuses.");
-			OBJPUTSTR("Temporarily empower damaging magic to 150%% of normal strength.");
+			OBJPUTSTR("Temporarily empower damaging magic to 150\% of normal strength.");
 			OBJPUTSTR("Permanently increases spell damage bonus by 1/3rd point.");
 		break;
 		case SYLLABLE_OF_LIFE__HOON:
@@ -3211,7 +3211,7 @@ winid *datawin;
 		break;
 		case SYLLABLE_OF_THOUGHT__NAEN:
 			OBJPUTSTR("Read to gain temporary and permanent bonuses.");
-			OBJPUTSTR("Temporarily regenerate an additional 10 power per turn and 0%% spell failure.");
+			OBJPUTSTR("Temporarily regenerate an additional 10 power per turn and 0\% spell failure.");
 			OBJPUTSTR("Permanently increase natural power regeneration by 1 point per 90 turns.");
 		break;
 		case SYLLABLE_OF_SPIRIT__VAUL:


### PR DESCRIPTION
Currently descriptions the syllable descriptions with % in them display it twice. "Temporarily regenerate an additional 10 power per turn and 0%% spell failure." I don't know why "%%" isn't working but "\%" appears to be so, cool.

This was the commit that "fixed" the percentage issue from before where it wouldn't show a percent at all.
https://github.com/Chris-plus-alphanumericgibberish/dNAO/commit/8e31b58bf2127c9f715d7216524f87a82e7b7e12