### PR TITLE
Fix copying size

### DIFF
--- a/src/mextra.c
+++ b/src/mextra.c
@@ -134,7 +134,10 @@ int mx_id;
 	if ((mx_p1 = get_mx(mon1, mx_id))) {
 		mx_p2 = get_mx(mon2, mx_id);
 		if(!mx_p2)
-			add_mx_l(mon2, mx_id, siz_mx(mon1, mx_id)-sizeof(long));
+			if (mx_list[mx_id].s_size != -1)
+				add_mx(mon2, mx_id);
+			else
+				add_mx_l(mon2, mx_id, siz_mx(mon1, mx_id)-sizeof(long));
 		memcpy(get_mx(mon2, mx_id), mx_p1, siz_mx(mon1, mx_id));
 	}
 	return;

--- a/src/oextra.c
+++ b/src/oextra.c
@@ -130,7 +130,10 @@ int ox_id;
 	if ((ox_p1 = get_ox(obj1, ox_id))) {
 		ox_p2 = get_ox(obj2, ox_id);
 		if(!ox_p2)
-			add_ox_l(obj2, ox_id, siz_ox(obj1, ox_id)-sizeof(long));
+			if (ox_list[ox_id].s_size != -1)
+				add_mx(obj2, ox_id);
+			else
+				add_ox_l(obj2, ox_id, siz_ox(obj1, ox_id)-sizeof(long));
 		memcpy(get_ox(obj2, ox_id), ox_p1, siz_ox(obj1, ox_id));
 	}
 	return;


### PR DESCRIPTION
It was cutting short fixed-size extradatas by sizeof(long)