### PR TITLE
Apparently we had monsters with ispriest or isminion flag and no mx

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -877,7 +877,7 @@ boolean called;
 	}
 
 	/* priests and minions: don't even use this function */
-	if ((mtmp->ispriest || mtmp->isminion) && mtmp->mtyp != PM_BLASPHEMOUS_LURKER) {
+	if ((get_mx(mtmp, MX_EPRI) || get_mx(mtmp, MX_EMIN)) && mtmp->mtyp != PM_BLASPHEMOUS_LURKER) {
 	    char priestnambuf[BUFSZ];
 	    char *name;
 	    long save_prop = EHalluc_resistance;

--- a/src/priest.c
+++ b/src/priest.c
@@ -343,7 +343,7 @@ register struct monst *mon;
 char *pname;		/* caller-supplied output buffer */
 {
 	const char *what = Hallucination ? rndmonnam() : mon->data->mname;
-	int align = (mon->ispriest ? EPRI(mon)->shralign : mon->isminion ? EMIN(mon)->min_align : 0);
+	int align = (get_mx(mon, MX_EPRI) ? EPRI(mon)->shralign : get_mx(mon, MX_EMIN) ? EMIN(mon)->min_align : 0);
 
 	Strcpy(pname, "the ");
 	if (mon->minvis) Strcat(pname, "invisible ");


### PR DESCRIPTION
Bandaid: only call name function if we have data for it.