### PR TITLE
Desummon_obj needs to handle obj->ocarry's weapon pointers.

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -2501,6 +2501,11 @@ long timeout;
 		start_timer(9999, TIMER_OBJECT, DESUMMON_OBJ, arg);
 		return;
 	}
+	/* clean up some pointers that obj_extract_self and obfree don't catch. UGH. */
+	if (otmp->where == OBJ_MINVENT) {
+		if (otmp == MON_WEP(otmp->ocarry)) MON_NOWEP(otmp->ocarry);
+		if (otmp == MON_SWEP(otmp->ocarry)) MON_NOSWEP(otmp->ocarry);
+	}
 	obj_extract_self(otmp);
 	newsym(otmp->ox, otmp->oy);
 	obfree(otmp, (struct obj *)0);


### PR DESCRIPTION
Because obj_extract_self() doesn't, yuck.

It would be quite inefficient to add to obfree() the same pointer-catching that is done for the players' equip slots -- yes, let's loop through all monsters to see if one of them was wielding this weapon. No we can't use obj->ocarry to avoid looping through all monsters because obj's location was set to OBJ_FREE when it was extracted.