### PR TITLE
Crowning gifts are gifted

### DIFF
--- a/src/crown.c
+++ b/src/crown.c
@@ -442,6 +442,7 @@ gcrownu()
 				dropy(obj);
 			}
 			u.ugifts++;
+			obj->gifted = Align2gangr(u.ualign.type);
 			discover_artifact(arti);
 		}
 		else if (uwep && uwep->oartifact == arti) {


### PR DESCRIPTION
And cannot be safely abandoned to a priest of an unknown god.
If your god cares about you giving away their Hammerfeet, they'll care about you giving away their Stormbringer!
Closes #1450 