### PR TITLE
Recalculate vision on setworn()

### DIFF
--- a/src/worn.c
+++ b/src/worn.c
@@ -312,6 +312,7 @@ long mask;
 	    }
 	}
 	if(!restoring) {
+		vision_full_recalc = 1;
 		see_monsters(); //More objects than just artifacts grant warning now, and this is a convienient place to add a failsafe see_monsters check
 		update_inventory();
 	}


### PR DESCRIPTION
If any items/artifacts grant or block vision properties (LOWLIGHTSIGHT, CATSIGHT, EXTRAMISSION, etc), donning/doffing needs a full recalc. Slapping the recalc on all setworn() is good enough, no need to check if specific properties are being set/unset.