### PR TITLE
Fix poison spray tombstone message

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -4089,6 +4089,7 @@ struct zapdata * zapdata;
 				if (youdef) {
 					domsg();
 					pline_The("poison was deadly...");
+					killer_format = NO_KILLER_PREFIX;
 					done(POISONING);
 					return MM_DEF_LSVD;
 				}


### PR DESCRIPTION
Not "poisoned by a poisoned". Just once is fine.