### PR TITLE
The player is supposed to get their polyform's dodgeAC

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2208,7 +2208,7 @@ int base_uac()
 	int dexbonus = 0;
 	int uac = 10-mons[u.umonnum].nac;
 	
-	if(multi > 0)
+	if(multi >= 0)
 		dexbonus += mons[u.umonnum].dac;
 	
 	if((uright && uright->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN) || (uleft && uleft->oartifact == ART_SHARD_FROM_MORGOTH_S_CROWN)){


### PR DESCRIPTION
For reference:
multi < 0 :: flatfooted
multi = 0 :: normal movement
multi > 0 :: queued actions

This brings it in line with the player's own dodgeAC being applied if `!(multi < 0)`