### PR TITLE
Prevent cursed offhands slipping when weldproof

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1584,15 +1584,14 @@ register struct obj *otmp;
 	/* welded two-handed weapon interferes with some armor removal */
 	if (otmp == uwep && bimanual(uwep,youracedata)) reset_remarm();
 	/* rules at top of wield.c state that twoweapon cannot be done
-	   with cursed alternate weapon */
-	if (otmp == uswapwep && u.twoweap)
+	   with cursed alternate weapon (unless you're weldproof) */
+	if (otmp == uswapwep && u.twoweap && !Weldproof)
 	    drop_uswapwep();
 	if (otmp == uarm && otmp->otyp == STRAITJACKET){
-		struct obj *o;
 		reset_remarm();
 		if(u.twoweap && uswapwep) drop_uswapwep();
 		if(uwep){
-			o = uwep;
+			struct obj *o = uwep;
 			setuwep((struct obj *)0);
 			dropx(o);
 		}

--- a/src/wield.c
+++ b/src/wield.c
@@ -35,7 +35,7 @@
  *     a convenience to swap with the main weapon.
  * 5.  Never conveys intrinsics.
  * 6.  Cursed items never weld (see #3 for reasons), but they also
- *     prevent two-weapon combat.
+ *     prevent two-weapon combat. (unless you're weldproof)
  *
  * The quiver (uquiver):
  * 1.  Is filled by the (Q)uiver command.
@@ -603,8 +603,6 @@ test_twoweapon()
 int
 starting_twoweapon()
 {
-	struct obj *otmp;
-
 	if (!test_twoweapon())
 		; //NoOp, test_twoweapon prints output :/
 	else if (!uarmg && !Stone_resistance && (uswapwep && uswapwep->otyp == CORPSE &&
@@ -615,8 +613,8 @@ starting_twoweapon()
 		    mons[uswapwep->corpsenm].mname, body_part(HAND));
 		Sprintf(kbuf, "%s corpse", an(mons[uswapwep->corpsenm].mname));
 		instapetrify(kbuf);
-	} else if (uswapwep && (Glib || uswapwep->cursed)) {
-		if (!Glib)
+	} else if (uswapwep && (Glib || (uswapwep->cursed && !Weldproof))) {
+		if (!Glib && !Weldproof)
 			uswapwep->bknown = TRUE;
 		drop_uswapwep();
 	} else


### PR DESCRIPTION
When starting twoweaponing with the offhand cursed, or when the
offhand weapon becomes cursed whilst already twoweaponing, it no
longer drops to the ground.

The only case not considered here is losing the weldproof effect whilst
already twoweaponing, by e.g. curing lycanthropy

One can imagine that you already have a really tight grip on the weapon
knowing that you'd otherwise lose it - this is the little-known strategy
'using your imagination to avoid fixing edge cases'

Removes an unused variable and reduces scope for another one

Closes #1453 