### PR TITLE
Special case the artifact iron ball at pickup

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1082,7 +1082,8 @@ int *wt_before, *wt_after;
     *wt_before = iw;
     *wt_after  = wt;
 
-    if (wt < 0)
+    /* special case the iron ball here, it actually improves carrycap */
+    if (wt < 0 || obj->oartifact == ART_IRON_BALL_OF_LEVITATION)
 	return count;
 
     /* see how many we can lift */
@@ -1237,7 +1238,8 @@ boolean telekinesis;
 	if (prev_encumbr < flags.pickup_burden)
 		prev_encumbr = flags.pickup_burden;
 	next_encumbr = calc_capacity(new_wt - old_wt);
-	if (next_encumbr > prev_encumbr) {
+	/* Special case iron ball because in principle one can always pick it up */
+	if (next_encumbr > prev_encumbr && obj->oartifact != ART_IRON_BALL_OF_LEVITATION) {
 	    if (telekinesis) {
 		result = 0;	/* don't lift */
 	    } else {


### PR DESCRIPTION
The artifact iron ball of levitation actually improves your carrycap by
its weight whilst carried.

If you have limited carry capacity for any reason, say you're a gnome
or you've read scrolls of punishment, you may not be able to pick it up
to benefit from that effect.

This special cases the check in the number of objects you can pick up,
as well as the guard for warning about encumberance

Closes #1412 