### PR TITLE
Fix off-by-one error when identifying randomly-generated maze rooms

### DIFF
--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -206,7 +206,7 @@ int depth;
 	move(&x,&y,dir);
 	if(!maze_inbounds(x, y))
 		return(FALSE);
-	if((depth < 3) && (levl[x][y].roomno - ROOMOFFSET > level.flags.sp_lev_nroom))	/* if we're early, we can bust through randomly-placed rooms */
+	if((depth < 3) && (levl[x][y].roomno - ROOMOFFSET >= level.flags.sp_lev_nroom))	/* if we're early, we can bust through randomly-placed rooms */
 		return(TRUE);
 	if(levl[x][y].typ != 0)
 		return(FALSE);
@@ -1108,7 +1108,7 @@ int careful;
 				}
 				else
 				{// will only make paths into rooms that were randomly placed prior to mazewalking
-					if (levl[dx2][dy2].roomno - ROOMOFFSET > level.flags.sp_lev_nroom)
+					if (levl[dx2][dy2].roomno - ROOMOFFSET >= level.flags.sp_lev_nroom)
 						dirok[idx++] = dir;
 				}
 				idx2++;
@@ -1539,7 +1539,7 @@ int x,y,depth;
 			levl[x][y].typ = ROOM;
 #endif
 			move(&x, &y, dir);
-			if (levl[x][y].roomno - ROOMOFFSET > level.flags.sp_lev_nroom)
+			if (levl[x][y].roomno - ROOMOFFSET >= level.flags.sp_lev_nroom)
 				maze_remove_room(levl[x][y].roomno - ROOMOFFSET);
 			pos++;
 			if (pos > CELLS)
@@ -1576,7 +1576,7 @@ int x,y,depth;
 		if(!q) return;
 		dir = dirs[rn2(q)];
 		move(&x,&y,dir);
-		if (levl[x][y].roomno - ROOMOFFSET > level.flags.sp_lev_nroom)
+		if (levl[x][y].roomno - ROOMOFFSET >= level.flags.sp_lev_nroom)
 			maze_remove_room(levl[x][y].roomno - ROOMOFFSET);
 #ifndef WALLIFIED_MAZE
 		levl[x][y].typ = CORR;

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2873,7 +2873,7 @@ dlb *fd;
 	    dir = walklist[nwalk].dir;
 
 		/* adding rooms may have placed a room overtop of the wallwalk start */
-		if (levl[x][y].roomno - ROOMOFFSET > level.flags.sp_lev_nroom)
+		if (levl[x][y].roomno - ROOMOFFSET >= level.flags.sp_lev_nroom)
 			maze_remove_room(levl[x][y].roomno - ROOMOFFSET);
 
 	    /* don't use move() - it doesn't use W_NORTH, etc. */


### PR DESCRIPTION
The 1st randomly-generated maze room has an ID of `level.flags.sp_lev_nroom+ROOMOFFSET`, so check if `>=`.

Could rarely result in some maze levels not generating correctly if mazewalk was blocked by a room.