### PR TITLE
Add  "Slimify" monster spell

### DIFF
--- a/include/monflag.h
+++ b/include/monflag.h
@@ -356,7 +356,8 @@
 #define MAKE_WEB               SUMMON_SPHERE+1
 #define DROP_BOULDER           MAKE_WEB+1
 #define EARTHQUAKE             DROP_BOULDER+1
-#define TURN_TO_STONE          EARTHQUAKE+1
+#define SLIMIFY                EARTHQUAKE+1
+#define TURN_TO_STONE          SLIMIFY+1
        /* unique monster spells */
 #define NIGHTMARE              TURN_TO_STONE+1
 //50

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -1614,38 +1614,39 @@ const char * spellname[] =
 	"DROP_BOULDER",
 	"EARTHQUAKE",
 	"TURN_TO_STONE",
-	"NIGHTMARE",
+	"SLIMIFY",
 	//50
+	"NIGHTMARE",
 	"FILTH",
 	"CLONE_WIZ",
 	"STRANGLE",
 	"MON_FIRA",
-	"MON_FIRAGA",
 	//55
+	"MON_FIRAGA",
 	"MON_BLIZZARA",
 	"MON_BLIZZAGA",
 	"MON_THUNDARA",
 	"MON_THUNDAGA",
-	"MON_FLARE",
 	//60
+	"MON_FLARE",
 	"MON_WARP",
 	"MON_POISON_GAS",
 	"MON_PROTECTION",
 	"SOLID_FOG",
-	"ACID_BLAST",
 	//65
+	"ACID_BLAST",
 	"PRISMATIC_SPRAY",
 	"SILVER_RAYS",
 	"GOLDEN_WAVE",
 	"VULNERABILITY",
-	"MASS_HASTE",
 	//70
+	"MASS_HASTE",
 	"MON_TIME_STOP",
 	"TIME_DUPLICATE",
 	"NAIL_TO_THE_SKY",
 	"STERILITY_CURSE"
-	"DISINT_RAY"
 	//75
+	"DISINT_RAY"
 };
 
 
@@ -3042,6 +3043,23 @@ int tary;
 					else You_feel("a momentary stiffness.");
 				}
 			}
+		}
+		return result;
+
+	case SLIMIFY:
+		/* needs direct target */
+		if (!foundem) {
+			impossible("slimify with no mdef?");
+			return MM_MISS;
+		}
+		else {
+			/* message player */
+			if (youdef && malediction)
+				verbalize(rn2(2) ? "Thou shalt quiver before me!" :
+				"Thy flesh shall be goo!");
+
+			static struct attack slimify = { AT_NONE, AD_SLIM, 0, 0 };
+			result = xmeleehurty(magr, mdef, &slimify, &slimify, (struct obj **)0, FALSE, 0, 0, -1, TRUE);
 		}
 		return result;
 
@@ -4873,6 +4891,7 @@ int spellnum;
 	case PLAGUE:
 	case FILTH:
 	case TURN_TO_STONE:
+	case SLIMIFY:
 	case STRANGLE:
 	case SILVER_RAYS:
 	case GOLDEN_WAVE:

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3838,8 +3838,9 @@ boolean ranged;
 	if (attk->aatyp == AT_GAZE || attk->aatyp == AT_WDGZ)
 		armuncancel = TRUE;
 	notmcan = (youagr || !magr->mcan);
-	uncancelled = notmcan && armuncancel;
-	
+	/* if we're called with attk->aatyp==AT_NONE, this is some kind of extra effect of magical origin that will bypass armuncancel */
+	uncancelled = notmcan && (armuncancel || attk->aatyp == AT_NONE);
+
 
 	/* Do stuff based on damage type 
 	 *  

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3955,6 +3955,10 @@ boolean ranged;
 	case AD_BLUD:	/* bloodied, phases (blade of blood) */
 	case AD_MERC:	/* poisoned, cold, phases (blade of mercury) */
 	case AD_GLSS:	/* silvered (mirror-shards) */
+
+		/* abort if called with AT_NONE -- the attack was meant to only do special effects of the adtype. */
+		if (attk->aatyp == AT_NONE)
+			return result;
 		
 		/* The Tentacle Rod has a unique hitmessage which will replace the usual hitmsg */
 		if (vis&VIS_MAGR && weapon && arti_tentRod(weapon) && dohitmsg) {


### PR DESCRIPTION
Turns target into slime. Delayed vs player, instant vs monsters (because they don't have any handling for these delayed things).
Not on any monsters' prefered spells lists, but can rarely be chosen by the Wizard of Yendor.