### PR TITLE
Prevent artifact weapons from being set to shell

### DIFF
--- a/src/shknam.c
+++ b/src/shknam.c
@@ -548,7 +548,8 @@ int sx, sy;
 					struct obj * newobj = mksobj_at(garden_weapons[rn2(SIZE(garden_weapons))], sx, sy, MKOBJ_ARTIF);
 					if (newobj) {
 						newobj->shopOwned = TRUE;
-						set_material_gm(newobj, SHELL_MAT);
+						if (!newobj->oartifact)
+							set_material_gm(newobj, SHELL_MAT);
 						newobj->opoisoned = rn2(3) ? OPOISON_BASIC : OPOISON_ACID;
 
 						/* replace curobj with newobj */


### PR DESCRIPTION
Elshava shops did not properly check artifact status before overwriting the material of a weapon. Armors were okay.