### PR TITLE
Don't panic() when failing to relink summons to their summoner

### DIFF
--- a/src/mextra.c
+++ b/src/mextra.c
@@ -409,7 +409,13 @@ struct monst * specific_mtmp;
 				if (mtmp->mextra_p->esum_p->summoner) {
 					nid = mtmp->mextra_p->esum_p->sm_id;
 					mtmp->mextra_p->esum_p->summoner = (genericptr_t) (nid ? find_mid(nid, FM_EVERYWHERE) : &youmonst);
-					if (!mtmp->mextra_p->esum_p->summoner) panic("cant find m_id %d", nid);
+					if (!mtmp->mextra_p->esum_p->summoner) {
+						/* instead of panicking, just make the monster poof when timers get next run,
+						 * which is the intended behaviour if a summoned monster is separated from its summoner  */
+						//panic("cant find m_id %d", nid);
+						mtmp->mextra_p->esum_p->permanent = 0;
+						adjust_timer_duration(get_timer(mtmp->timed, DESUMMON_MON), -ESUMMON_PERMANENT);
+					}
 				}
 			}
 		}

--- a/src/oextra.c
+++ b/src/oextra.c
@@ -388,7 +388,13 @@ struct obj * specific_otmp;
 				if (otmp->oextra_p->esum_p->summoner) {
 					nid = otmp->oextra_p->esum_p->sm_id;
 					otmp->oextra_p->esum_p->summoner = (genericptr_t) (nid ? find_mid(nid, FM_EVERYWHERE) : &youmonst);
-					if (!otmp->oextra_p->esum_p->summoner) panic("cant find m_id %d", nid);
+					if (!otmp->oextra_p->esum_p->summoner) {
+						/* instead of panicking, just make the item poof when timers get next run,
+						 * which is the intended behaviour if a summoned item is separated from its summoner  */
+						//panic("cant find m_id %d", nid);
+						otmp->oextra_p->esum_p->permanent = 0;
+						adjust_timer_duration(get_timer(otmp->timed, DESUMMON_OBJ), -ESUMMON_PERMANENT);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
There is a clear expected behaviour when this occurs -- silently make them vanish.

Marked [major] as there were still some edge cases capable of causing this panic to happen.