### PR TITLE
Up the weight of a Chiropteran's starting heavy iron ball to 1600

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -2814,13 +2814,14 @@ newgame()
 		scatter_weapons();
 	docrt();
 #ifdef CONVICT
-       if (Role_if(PM_CONVICT)) {
-              setworn(mkobj(CHAIN_CLASS, TRUE), W_CHAIN);
-              setworn(mkobj(BALL_CLASS, TRUE), W_BALL);
-              uball->spe = 1;
-              placebc();
-              newsym(u.ux,u.uy);
-       }
+	if (Role_if(PM_CONVICT)) {
+		setworn(mkobj(CHAIN_CLASS, TRUE), W_CHAIN);
+		setworn(mkobj(BALL_CLASS, TRUE), W_BALL);
+		uball->spe = 1;
+		if (Race_if(PM_CHIROPTERAN)) uball->owt = 1600;
+		placebc();
+		newsym(u.ux,u.uy);
+	}
 #endif /* CONVICT */
 
 	if (flags.legacy) {


### PR DESCRIPTION
This is the max punishment can normally give you, and lowers their carrycap with the ball from around 2200 to around 1000. Makes it less negligible, but still not a huge hindrance in the early game. Ah well.

See #780.