### PR TITLE
Fix stealing from outside shop with grappling hook

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2500,7 +2500,7 @@ E void FDECL(replshk, (struct monst *));
 E void FDECL(restshk, (struct monst *,BOOLEAN_P));
 E char FDECL(inside_shop, (XCHAR_P,XCHAR_P));
 E void FDECL(u_left_shop, (char *,BOOLEAN_P));
-E void FDECL(remote_burglary, (XCHAR_P,XCHAR_P));
+E void FDECL(remote_burglary, (struct obj *));
 E void FDECL(u_entered_shop, (char *));
 E boolean FDECL(same_price, (struct obj *,struct obj *));
 E void NDECL(shopper_financial_report);

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1468,8 +1468,9 @@ struct obj *otmp;
 		}
 	    Strcpy(u.ushops, saveushops);
 	    /* if you're outside the shop, make shk notice */
-	    if (!index(u.ushops, *fakeshop))
-		remote_burglary(otmp->ox, otmp->oy);
+	    if (!index(u.ushops, *fakeshop)) {
+			remote_burglary(otmp);
+		}
 	}
 	if (otmp->no_charge)	/* only applies to objects outside invent */
 	    otmp->no_charge = 0;


### PR DESCRIPTION
The stolen object wasn't being found by the code that should have been setting/clearing shop-related matters