### PR TITLE
Remove false Nessus stairs once you attempt to descend them

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -912,7 +912,12 @@ dodown()
 			} else if(uarmg && is_pick(uarmg)){
 				return use_pick_axe2(uarmg);
 			} else {
-				if(levl[u.ux][u.uy].typ == STAIRS) pline("These stairs don't go down!");
+				if(levl[u.ux][u.uy].typ == STAIRS){
+					if (Is_hell3(&u.uz) && !(u.ux == xupstair && u.uy == yupstair)){
+						pline("These stairs are fake!");
+						levl[u.ux][u.uy].typ = ROOM;
+					} else pline("These stairs don't go down!");
+				}
 				else You_cant("go down here.");
 				return(0);
 			}


### PR DESCRIPTION
Assumes there will never be any other `STAIR`s on Nessus other than false downstairs, the true downstair, and the true upstair. I think this is a relatively safe assumption but just to point this out if like, a branchport power that creates temporary staircases is used. 