### PR TITLE
Split timers when cloning monsters

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2765,7 +2765,7 @@ E void FDECL(stop_all_timers, (timer_element *));
 E void NDECL(run_timers);
 E void FDECL(save_timers, (timer_element *,int,int));
 E void FDECL(rest_timers, (int,genericptr_t,timer_element *,int,BOOLEAN_P,long));
-E void FDECL(obj_split_timers, (struct obj *, struct obj *));
+E void FDECL(split_timers, (struct timer *, int, genericptr_t));
 #ifdef WIZARD
 E int NDECL(wiz_timeout_queue);
 E void NDECL(timer_sanity_check);

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -8351,6 +8351,12 @@ xchar x, y;	/* clone's preferred location or 0 (near mon) */
 	m2->mhp = mon->mhp / 2;
 	mon->mhp -= m2->mhp;
 
+	/* duplicate timers */
+	if (mon->timed) {
+		m2->timed = (struct timer *) 0;
+		split_timers(mon->timed, TIMER_MONSTER, (genericptr_t)m2);
+	}
+
 	/* place the monster -- we want to do this before any display things happen */
 	place_monster(m2, m2->mx, m2->my);
 

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -435,7 +435,7 @@ long num;
 		cpy_ox(obj, otmp, ox_id);
 		
 	if (obj->unpaid) splitbill(obj,otmp);
-	if (obj->timed) obj_split_timers(obj, otmp);
+	if (obj->timed) split_timers(obj->timed, TIMER_OBJECT, (genericptr_t)otmp);
 	if (obj_sheds_light(obj)) obj_split_light_source(obj, otmp);
 	return otmp;
 }

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -2567,6 +2567,9 @@ long timeout;
  *		timer would have gone off.  If no timer is found, return 0.
  *		If an object, decrement the object's timer count.
  *
+ *	void split_timers(struct timer *src_timer, int tmtype, genericptr_t dest)
+ *		Duplicate all timers on src and attach them to dest.
+ *
  *	void stop_all_timers(timer_element * tm)
  *		Stop all timers on the chain.
  *	void run_timers(void)
@@ -2580,9 +2583,6 @@ long timeout;
  *	void rest_timers(int tmtype, generic_ptr owner, timer_element * tm, int fd, boolean ghostly, long adjust)
  *		Restore chain of timers onto owner. If ghostly, adjust timers. 
  *
- * Object Specific:
- *	void obj_split_timers(struct obj *src, struct obj *dest)
- *		Duplicate all timers assigned to src and attach them to dest.
  */
 
 #ifdef WIZARD
@@ -3017,17 +3017,19 @@ short func;
 /* Specific timer functions */
 
 /*
- * Find all object timers and duplicate them for the new object "dest".
+ * Duplicate all timers on the given chain onto dest.
  */
 void
-obj_split_timers(src, dest)
-struct obj *src, *dest;
+split_timers(src_timer, tmtype, dest)
+timer_element *src_timer;
+int tmtype;
+genericptr_t dest;
 {
     timer_element *curr;
-	/* loop over obj's local chain, which is safe as we add to dest's chain and the processing loop */
-    for (curr = src->timed; curr; curr = curr->tnxt) {
-		(void) start_timer(curr->timeout-monstermoves, TIMER_OBJECT,
-					curr->func_index, (genericptr_t)dest);
+	/* loop over src's local chain, which is safe as we add to dest's chain and the processing loop */
+    for (curr = src_timer; curr; curr = curr->tnxt) {
+		(void) start_timer(curr->timeout-monstermoves, tmtype,
+					curr->func_index, dest);
     }
 }
 


### PR DESCRIPTION
Otherwise new mon will contain duplicate pointers to timers, bad!