### PR TITLE
You cannot load armed grenades into the mass-shadow pistol

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2646,6 +2646,9 @@ pick_bullet()
 	add_menu(tmpwin, NO_GLYPH, &any, 0, 0, ATR_BOLD, buf, MENU_UNSELECTED);
 	for(otmp = invent; otmp; otmp = otmp->nobj){
 		if((otmp->otyp >= MAGICITE_CRYSTAL && otmp->otyp <= ROCK) || (otmp->otyp >= BULLET && otmp->otyp <= GAS_GRENADE)){
+			if (is_grenade(otmp) && otmp->oarmed)
+				continue;
+
 			Sprintf1(buf, doname(otmp));
 			any.a_char = otmp->invlet;	/* must be non-zero */
 			add_menu(tmpwin, NO_GLYPH, &any,


### PR DESCRIPTION
Otherwise, it explodes while still inside the gun. Which makes a segfault-gun.