### PR TITLE
Null-check cobj for mass shadow pistols

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -484,7 +484,7 @@ struct obj {
 			  (\
 			   (ltmp->otyp == BFG) ||\
 			   (ltmp->oartifact == ART_PEN_OF_THE_VOID && ltmp->ovar1&SEAL_EVE) ||\
-			   (ltmp->otyp == MASS_SHADOW_PISTOL && (otmp->otyp == ltmp->cobj->otyp)) ||\
+			   (ltmp->otyp == MASS_SHADOW_PISTOL && ltmp->cobj && (otmp->otyp == ltmp->cobj->otyp)) ||\
 			   (ltmp->otyp == ATLATL && is_spear(otmp)) ||\
 			   (\
 			    (otmp->objsize == (ltmp)->objsize || objects[(ltmp)->otyp].oc_skill == P_SLING) &&\

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -2051,7 +2051,7 @@ dofire()
 					struct obj * ammo = (struct obj *)0;
 
 					/* do we have enough charge to fire? */
-					if (!launcher->ovar1) {
+					if (!launcher->ovar1 || (launcher->otyp == MASS_SHADOW_PISTOL && !launcher->cobj)) {
 						if (launcher->otyp == RAYGUN) You("push the firing stud, but nothing happens.");
 						else pline("Nothing happens when you pull the trigger.");
 						/* nothing else happens */
@@ -2292,7 +2292,7 @@ struct obj * blaster;
 			ammo->oartifact = blaster->cobj->oartifact;
 		}
 		else
-			ammo = mksobj(ROCK, MKOBJ_NOINIT);
+			ammo = mksobj(ROCK, MKOBJ_NOINIT);	/* should not happen */
 		break;
 	case RAYGUN:
 		/* create fake ammo in order to calculate multishot correctly */


### PR DESCRIPTION
A mass shadow pistol with nothing in it ~~shoots rocks by default~~ _does not shoot_, and *does not segfault*.