### PR TITLE
Fix infinite loop in dungeon of ill regard generation

### DIFF
--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -2352,8 +2352,8 @@ fill_dungeon_of_ill_regard(){
 					i++;\
 					j++;\
 				} else {\
-					x = COLNO;\
-					y = ROWNO;\
+					x = COLNO/2;\
+					y = ROWNO/2;\
 					break;\
 				}\
 			}


### PR DESCRIPTION
If too many mons were gone/geno'd and `i` reached `=PM_LONG_WORM_TAIL`, the fallback condition was not exiting the loops but instead perpetuating (some of) them.