### PR TITLE
Tobiume now tases enemies

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -341,7 +341,7 @@ extern struct artifact artilist[];
 #define PLUTO	(LAST_PROP+23)
 #define SPEED_BANKAI	(LAST_PROP+24)
 #define ICE_SHIKAI	(LAST_PROP+25)
-#define FIRE_SHIKAI	(LAST_PROP+26)
+#define TOBIUME_SHIKAI	(LAST_PROP+26)
 #define MANDALA	(LAST_PROP+27)
 #define DRAIN_MEMORIES	(LAST_PROP+28)
 #define SLAY_LIVING	(LAST_PROP+29)

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -5019,7 +5019,7 @@ arti_invoke(obj)
     if(oart->inv_prop > LAST_PROP) {
 	/* It's a special power, not "just" a property */
 	if(obj->age > monstermoves && 
-		oart->inv_prop != FIRE_SHIKAI && 
+		oart->inv_prop != TOBIUME_SHIKAI &&
 		oart->inv_prop != SEVENFOLD && 
 		oart->inv_prop != ANNUL && 
 		oart->inv_prop != ALTMODE && 
@@ -5041,7 +5041,7 @@ arti_invoke(obj)
 	    return partial_action();
 	}
 	if( /* some properties can be used as often as desired, or track cooldowns in a different way */
-		oart->inv_prop != FIRE_SHIKAI &&
+		oart->inv_prop != TOBIUME_SHIKAI &&
 		oart->inv_prop != ICE_SHIKAI &&
 		oart->inv_prop != NECRONOMICON &&
 		oart->inv_prop != SPIRITNAMES &&
@@ -5675,7 +5675,7 @@ arti_invoke(obj)
 			}
 		}
 	break;
- 	case FIRE_SHIKAI:
+	case TOBIUME_SHIKAI:
 		{
 			boolean toosoon = monstermoves < obj->age;
 			if ( !(uwep && uwep == obj) ) {
@@ -5687,15 +5687,13 @@ arti_invoke(obj)
 				int role_skill;
 				struct obj *pseudo;
 				coord cc;
+				pseudo = mksobj(SPE_FIREBALL, MKOBJ_NOINIT); // create here for the skill check
 
 				energy = toosoon ? 25 : 15;
-				pseudo = mksobj(SPE_FIREBALL, MKOBJ_NOINIT);
-				pseudo->blessed = pseudo->cursed = 0;
-				pseudo->quan = 20L;			/* do not let useup get it */
 				role_skill = max(P_SKILL(uwep_skill_type()), P_SKILL(spell_skilltype(pseudo->otyp)) );
 				if (role_skill >= P_SKILLED && yn("Use advanced technique?") == 'y'){
 					if(energy > u.uen) {
-						You("don't have enough energy to use this technique");
+						You("don't have enough energy to use this technique.");
 						if(!toosoon) obj->age = 0;
 	break;
 					}
@@ -5704,17 +5702,21 @@ arti_invoke(obj)
 					    cc.x=u.dx;cc.y=u.dy;
 					    n=rnd(role_skill*2)+role_skill*2;
 					    while(n--) {
+							pseudo = mksobj((rn2(2)) ? SPE_FIREBALL : SPE_LIGHTNING_BOLT, MKOBJ_NOINIT);
+							pseudo->blessed = pseudo->cursed = 0;
+							pseudo->quan = 20L; /* do not let useup get it */
+
 							if(!u.dx && !u.dy && !u.dz) {
 							    if ((damage = zapyourself(pseudo, TRUE)) != 0) {
 									char buf[BUFSZ];
-									Sprintf(buf, "blasted %sself with a fireball", uhim());
+									Sprintf(buf, "blasted %sself with a %s", uhim(), (pseudo->otyp == SPE_FIREBALL) ? "fireball" : "ball of lightning");
 									losehp(damage + obj->spe, buf, NO_KILLER_PREFIX);
 							    }
 							} else {
 							    explode(u.dx, u.dy,
 								    spell_adtype(pseudo->otyp), 0,
 								    u.ulevel/2 + 10 + obj->spe,
-									EXPL_FIERY, 1);
+									(pseudo->otyp == SPE_FIREBALL) ? EXPL_FIERY : EXPL_MAGICAL, 1);
 							}
 							u.dx = cc.x+rnd(5)-3; u.dy = cc.y+rnd(5)-3;
 							if (!isok(u.dx,u.dy) || !cansee(u.dx,u.dy) ||
@@ -5729,7 +5731,7 @@ arti_invoke(obj)
 				else{
 					if (role_skill >= P_SKILLED) energy = toosoon ? 15 : 5;
 					if(energy > u.uen) {
-						You("don't have enough energy to use this technique");
+						You("don't have enough energy to use this technique.");
 						if(!toosoon) obj->age = 0;
 	break;
 					}
@@ -5739,6 +5741,11 @@ arti_invoke(obj)
 	break;
 					}
 					pline("Snap, %s!", ONAME(obj));
+
+					pseudo = mksobj((rn2(2)) ? SPE_FIREBALL : SPE_LIGHTNING_BOLT, MKOBJ_NOINIT);
+					pseudo->blessed = pseudo->cursed = 0;
+					pseudo->quan = 20L; /* do not let useup get it */
+
 					if(!u.dx && !u.dy && !u.dz) {
 					    if ((damage = zapyourself(pseudo, TRUE)) != 0) {
 							char buf[BUFSZ];

--- a/src/artilist.c
+++ b/src/artilist.c
@@ -698,9 +698,9 @@ A("Tobiume",			LONG_SWORD,						"three-branched %s",
 	A_CHAOTIC, NON_PM, NON_PM, TIER_C, (ARTG_GIFT | ARTG_INHER),
 	NO_MONS(),
 	ATTK(AD_FIRE, 1, 1), (ARTA_DISARM),
-	PROPS(FIRE_RES), NOFLAG,
+	PROPS(FIRE_RES, SHOCK_RES), NOFLAG,
 	PROPS(), NOFLAG,
-	FIRE_SHIKAI, NOFLAG
+	TOBIUME_SHIKAI, NOFLAG
 	),
 
 A("The Lance of Longinus",		SPEAR,					(const char *)0,

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -13977,6 +13977,11 @@ int vis;						/* True if action is at all visible to the player */
 			elemdmg += 6 + weapon->spe;
 			totldmg += 6 + weapon->spe;
 		}
+	} else if(weapon && weapon->oartifact == ART_TOBIUME && !Shock_res(mdef)){
+		if((*hp(mdef) - totldmg) <= (6 + weapon->spe)){
+			elemdmg += 6 + weapon->spe;
+			totldmg += 6 + weapon->spe;
+		}
 	}
 	/* Is the damage lethal? */
 	lethaldamage = (totldmg >= *hp(mdef));
@@ -14012,11 +14017,20 @@ int vis;						/* True if action is at all visible to the player */
 			hurtle(dx, dy, BOLT_LIM, FALSE, TRUE);
 		else
 			mhurtle(mdef, dx, dy, BOLT_LIM, FALSE);
-		
-		if(x(mdef)) explode(x(mdef), y(mdef),
-			AD_FIRE, 0,
-			d(6, 6),
-			EXPL_FIERY, 1);
+
+		// default to a fiery explosion - only use shock if fire is not applicable
+		if (Shock_res(mdef) || (!Fire_res(mdef) && rn2(2))){
+			if(x(mdef)) explode(x(mdef), y(mdef),
+				AD_FIRE, 0,
+				d(6, 6),
+				EXPL_FIERY, 1);
+		} else {
+			if(x(mdef)) explode(x(mdef), y(mdef),
+				AD_ELEC, 0,
+				d(6, 6),
+				EXPL_MAGICAL, 1);
+		}
+
 	}
 	/* PRINT HIT MESSAGE. MAYBE. */
 	if (dohitmsg && vis){


### PR DESCRIPTION
Tobiume still deals +1 fire damage, but the on-death explosions and invoke now deal a combination of fire and shock explosions. It also gives both fire and shock resistance when wielded, up from just fire.

If the unskilled invoke is used (single beam), the damage type is chosen randomly. If the skilled invoke is used (cluster of explosions), the damage type is chosen randomly and independently for each explosion.

For the on-death explosions:
* If the monster resists fire but not shock, it will use a shocking explosion
* If the monster resists shock but not fire, it will use a fiery explosion
* If the monster resists neither fire nor shock, it will use either one with a 50% chance each
* If the monster resists both, it will use a fiery explosion

Also fixes a minor missing period if the player does not have enough energy to use the shikai.