### PR TITLE
Add quick check-and-abort to priest_talk() if mon isn't a real priest

### DIFF
--- a/src/priest.c
+++ b/src/priest.c
@@ -558,6 +558,11 @@ void
 priest_talk(priest)
 register struct monst *priest;
 {
+	if (!get_mx(priest, MX_EPRI)) {
+		verbalize("Would thou likest to repent?");
+		return;
+	}
+
 	boolean coaligned = p_coaligned(priest);
 	boolean strayed = (u.ualign.record < 0);
 	char class_list[MAXOCLASSES+2];


### PR DESCRIPTION
Notably, The Stranger currently has the MS_PRIEST sound, which causes a crash if you try to talk to it.