### PR TITLE
Prevent "bless wielded item" from modifying spe of non-weapons

### DIFF
--- a/src/sounds.c
+++ b/src/sounds.c
@@ -2783,7 +2783,7 @@ int dz;
 					money2none(cost);
 #endif
 					bless(uwep);
-					if(uwep->spe < 3)
+					if((uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && uwep->spe < 3)
 						uwep->spe++;
 				break;
 				case UNSTERILIZE:


### PR DESCRIPTION
Was a neat feature to un-cancel the magic lamp from elsewhere in the neutral quest, but utterly busted with rings of wishes, and open to abuse with other things (containers, statues, anything else that uses spe in an odd way).

Perhaps should be opened to armor and other chargable rings; perhaps we should first make a global "otyp's spe is used for enchantment" macro.