### PR TITLE
Fix logic in choosing item to goatbless

### DIFF
--- a/src/pray.c
+++ b/src/pray.c
@@ -3672,12 +3672,13 @@ int eatflag;
 	    /* The player can gain an artifact */
 	    /* The chance goes down as the number of artifacts goes up */
 		/* Priests now only count gifts in this calculation, found artifacts are excluded */
+		/* deliberately can affect artifact weapons */
 		struct obj *otmp = (struct obj *)0;
-		if (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || uwep->oartifact) && !check_oprop(uwep, OPROP_ACIDW) && !check_oprop(uwep, OPROP_GOATW))
+		if (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && !check_oprop(uwep, OPROP_ACIDW) && !check_oprop(uwep, OPROP_GOATW))
 			otmp = uwep;
-		else if (uarmg && !uwep && u.umartial && !check_oprop(uarmg, OPROP_ACIDW) && !check_oprop(uwep, OPROP_GOATW))
+		else if (uarmg && !uwep && u.umartial && !check_oprop(uarmg, OPROP_ACIDW) && !check_oprop(uarmg, OPROP_GOATW))
 			otmp = uarmg;
-		else if (uarmf && !uarmg && !uwep && u.umartial && !check_oprop(uarmf, OPROP_ACIDW) && !check_oprop(uwep, OPROP_GOATW))
+		else if (uarmf && !uarmg && !uwep && u.umartial && !check_oprop(uarmf, OPROP_ACIDW) && !check_oprop(uarmf, OPROP_GOATW))
 			otmp = uarmf;
 			
 	    if(u.ulevel > 2 && u.uluck >= 0 && (!flags.made_know || otmp) && maybe_god_gives_gift()){


### PR DESCRIPTION
Was causing gloves to be re-blessed, preventing gifting of the Red Word.

Also, remove bug that would allow goatblessing of any artifact if wielded, including total non-weapons. I believe the intent was that artifacts were not disallowed (in contrast to the lesser goat-gives-benefit of `OPROP_LESSER_ACIDW`, which cannot affect artifacts).