### PR TITLE
Monster Blindfold Patch

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -575,6 +575,7 @@
 		((ptr->mflagsb&MB_BODYTYPEMASK) == (obj->bodytypeflag&MB_BODYTYPEMASK)))
 #define can_wear_gloves(ptr)	(!nohands(ptr))
 #define can_wear_amulet(ptr)	(has_head(ptr) || (ptr->mflagsb&MB_CAN_AMULET))
+#define can_wear_blindf(ptr)	(has_head(ptr))
 #define can_wear_boots(ptr)	((humanoid(ptr) || humanoid_feet(ptr)) && !nofeet(ptr) && !nolimbs(ptr))
 #define shirt_match(ptr,obj)	((obj->otyp != BODYGLOVE && upper_body_match(ptr,obj)) || \
 								full_body_match(ptr,obj))

--- a/include/obj.h
+++ b/include/obj.h
@@ -505,6 +505,7 @@ struct obj {
 #define is_worn_tool(o)	((o)->otyp == BLINDFOLD || (o)->otyp == ANDROID_VISOR || \
 							 (o)->otyp == TOWEL || (o)->otyp == LENSES || (o)->otyp == SUNGLASSES || \
 							 (o)->otyp == LIVING_MASK || (o)->otyp == MASK || (o)->otyp == R_LYEHIAN_FACEPLATE)
+#define is_opaque_worn_tool(o)	((o)->otyp == BLINDFOLD || (o)->otyp == TOWEL || (o)->otyp == R_LYEHIAN_FACEPLATE)
 #define is_instrument(o)	((o)->otyp >= FLUTE && \
 			 (o)->otyp <= DRUM_OF_EARTHQUAKE)
 #define is_mummy_wrap(o)	((o)->otyp == MUMMY_WRAPPING || \

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -181,7 +181,7 @@
 #define HBlind_res		u.uprops[BLIND_RES].intrinsic
 #define EBlind_res		u.uprops[BLIND_RES].extrinsic
 #define Blind_res		(HBlind_res || EBlind_res)
-#define Blindfolded		((ublindf && ublindf->otyp != LENSES && ublindf->otyp != SUNGLASSES && ublindf->otyp != MASK && ublindf->otyp != ANDROID_VISOR && ublindf->otyp != LIVING_MASK) ||\
+#define Blindfolded		((ublindf && is_opaque_worn_tool(ublindf)) ||\
 						(uarmh && uarmh->otyp == PLASTEEL_HELM && uarmh->obj_material != objects[uarmh->otyp].oc_material && is_opaque(uarmh)) ||\
 						(uarmh && uarmh->otyp == CRYSTAL_HELM && is_opaque(uarmh)))
 		/* ...means blind because of a cover */

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -135,7 +135,7 @@ boolean check_if_better;
 		    would_prefer_rwep(mtmp, otmp))) ||
 	    /* useful masks */
 	     (otmp->otyp == MASK && mtmp->mtyp == PM_LILLEND) ||
-	     (is_worn_tool(otmp) && has_head_mon(mtmp)) ||
+	     (is_worn_tool(otmp) && can_wear_blindf(mtmp->data)) ||
 	    /* better armor */
 	     (otmp->oclass == ARMOR_CLASS &&
 	      (!check_if_better || is_better_armor(mtmp, otmp))) ||

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -135,6 +135,7 @@ boolean check_if_better;
 		    would_prefer_rwep(mtmp, otmp))) ||
 	    /* useful masks */
 	     (otmp->otyp == MASK && mtmp->mtyp == PM_LILLEND) ||
+	     (is_worn_tool(otmp) && has_head_mon(mtmp)) ||
 	    /* better armor */
 	     (otmp->oclass == ARMOR_CLASS &&
 	      (!check_if_better || is_better_armor(mtmp, otmp))) ||

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1996,6 +1996,8 @@ dopetequip()
 			flag = W_ARMF;
 		} else if(is_suit(otmp)){
 			flag = W_ARM;
+		} else if(is_worn_tool(otmp)){
+			flag = W_TOOL;
 		} else {
 			pline("Error: Unknown monster armor type!?");
 			return 0;
@@ -2769,6 +2771,8 @@ struct monst *mon;
 			} else if(is_boots(otmp) && !(mon->misc_worn_check&W_ARMF) && otmp->objsize == mon->data->msize && can_wear_boots(mon->data)){
 				addArmorMenuOption
 			} else if(is_suit(otmp) && !(mon->misc_worn_check&W_ARM) && arm_match(mon->data, otmp) && arm_size_fits(mon->data, otmp)){
+				addArmorMenuOption
+			} else if(is_worn_tool(otmp) && !(mon->misc_worn_check&W_TOOL) && can_wear_blindf(mon->data)){
 				addArmorMenuOption
 			}
 		}

--- a/src/worn.c
+++ b/src/worn.c
@@ -1392,8 +1392,8 @@ boolean racialexception;
 				continue;
 		    break;
 		case W_TOOL:
-		    if(!can_wear_blindf(mon->data)) continue;
-
+		    if(!is_worn_tool(obj)) continue;
+		    if(!can_wear_blindf(mon->data) || (is_opaque_worn_tool(obj) && !(obj->otyp == R_LYEHIAN_FACEPLATE && is_mind_flayer(mon->data))) ) continue;
 		    break;
 	    }
 	    if (obj->owornmask) continue;
@@ -1765,6 +1765,16 @@ struct obj *obj;
 	case ALCHEMY_SMOCK:
 		if (!species_resists_acid(mon) || !species_resists_poison(mon))
 			return 5;
+		break;
+	case LIVING_MASK:
+		return 3;
+		break;
+	case SUNGLASSES:
+		return 2;
+		break;
+	case ANDROID_VISOR:
+		if(is_android(mon)) return 4;
+		return 1;
 		break;
 	case MUMMY_WRAPPING:
 	case PRAYER_WARDED_WRAPPING:

--- a/src/worn.c
+++ b/src/worn.c
@@ -1311,6 +1311,7 @@ boolean creation;
 	m_dowear_type(mon, W_ARMG, creation, FALSE);
 	m_dowear_type(mon, W_ARMF, creation, FALSE);
 	m_dowear_type(mon, W_ARM, creation, FALSE);
+	m_dowear_type(mon, W_TOOL, creation, FALSE);
 }
 
 STATIC_OVL void
@@ -1389,6 +1390,10 @@ boolean racialexception;
 				break;
 		    if (!is_suit(obj) || !arm_match(mon->data, obj) || !arm_size_fits(mon->data, obj))
 				continue;
+		    break;
+		case W_TOOL:
+		    if(!can_wear_blindf(mon->data)) continue;
+
 		    break;
 	    }
 	    if (obj->owornmask) continue;


### PR DESCRIPTION
Implement monsters wearing and picking up blindfold class items. Monsters will favor living masks, then sunglasses, then android visors.  I'm not sure any of these do anything for monsters yet other than living masks, and potentially sunglasses. 
Androids will prefer to wear android visors. Monsters will not put on blindfolds, towels, or ebon panes by default but they can be put onto them manually. Mind flayers will put on ebon panes. 

This implementation does not actually make worn opaque facial wear blind monsters. See "Monster Blindfold Patch With Blindness". 