### PR TITLE
Monster Blindfold Patch With Blindness

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -38,9 +38,16 @@
 
 #define resists_confusion(ptr)	(((ptr)->geno&G_UNIQ) || is_weeping(ptr) || is_yochlol(ptr))
 
-#define is_blind(mon)		(!((mon)->mcansee) || (darksight((mon)->data) && !(\
-													(!levl[(mon)->mx][(mon)->my].lit && !(viz_array[(mon)->my][(mon)->mx]&TEMP_LIT1 && !(viz_array[(mon)->my][(mon)->mx]&TEMP_DRK1)))\
-													|| (levl[(mon)->mx][(mon)->my].lit &&  (viz_array[(mon)->my][(mon)->mx]&TEMP_DRK1 && !(viz_array[(mon)->my][(mon)->mx]&TEMP_LIT1))))))
+#define is_blindfolded(mon) (mon->misc_worn_check&W_TOOL && is_opaque_worn_tool(which_armor(mon,W_TOOL)))
+
+#define is_blind(mon)		(!((mon)->mcansee) \
+				|| (darksight((mon)->data) && !(\
+									(!levl[(mon)->mx][(mon)->my].lit && !(viz_array[(mon)->my][(mon)->mx]&TEMP_LIT1 && !(viz_array[(mon)->my][(mon)->mx]&TEMP_DRK1)))\
+									|| (levl[(mon)->mx][(mon)->my].lit &&  (viz_array[(mon)->my][(mon)->mx]&TEMP_DRK1 && !(viz_array[(mon)->my][(mon)->mx]&TEMP_LIT1)))\
+								)\
+				   )\
+				|| is_blindfolded(mon))
+
 #define is_deaf(mon)		(!((mon)->mcanhear) ||\
 							  (mon)->mtyp == PM_NUPPERIBO ||\
 							  (mon)->mtyp == PM_ALABASTER_ELF ||\

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -575,6 +575,7 @@
 		((ptr->mflagsb&MB_BODYTYPEMASK) == (obj->bodytypeflag&MB_BODYTYPEMASK)))
 #define can_wear_gloves(ptr)	(!nohands(ptr))
 #define can_wear_amulet(ptr)	(has_head(ptr) || (ptr->mflagsb&MB_CAN_AMULET))
+#define can_wear_blindf(ptr)	(has_head(ptr))
 #define can_wear_boots(ptr)	((humanoid(ptr) || humanoid_feet(ptr)) && !nofeet(ptr) && !nolimbs(ptr))
 #define shirt_match(ptr,obj)	((obj->otyp != BODYGLOVE && upper_body_match(ptr,obj)) || \
 								full_body_match(ptr,obj))

--- a/include/obj.h
+++ b/include/obj.h
@@ -505,7 +505,7 @@ struct obj {
 #define is_worn_tool(o)	((o)->otyp == BLINDFOLD || (o)->otyp == ANDROID_VISOR || \
 							 (o)->otyp == TOWEL || (o)->otyp == LENSES || (o)->otyp == SUNGLASSES || \
 							 (o)->otyp == LIVING_MASK || (o)->otyp == MASK || (o)->otyp == R_LYEHIAN_FACEPLATE)
-#define is_opaque_worn_tool(o)	((o)->otyp == BLINDFOLD || (o)->otyp == TOWEL || (o)->otyp == R_LYEHIAN_FACEPLATE)
+#define is_opaque_worn_tool(o)	((o) && ((o)->otyp == BLINDFOLD || (o)->otyp == TOWEL || (o)->otyp == R_LYEHIAN_FACEPLATE))
 #define is_instrument(o)	((o)->otyp >= FLUTE && \
 			 (o)->otyp <= DRUM_OF_EARTHQUAKE)
 #define is_mummy_wrap(o)	((o)->otyp == MUMMY_WRAPPING || \

--- a/include/obj.h
+++ b/include/obj.h
@@ -505,6 +505,7 @@ struct obj {
 #define is_worn_tool(o)	((o)->otyp == BLINDFOLD || (o)->otyp == ANDROID_VISOR || \
 							 (o)->otyp == TOWEL || (o)->otyp == LENSES || (o)->otyp == SUNGLASSES || \
 							 (o)->otyp == LIVING_MASK || (o)->otyp == MASK || (o)->otyp == R_LYEHIAN_FACEPLATE)
+#define is_opaque_worn_tool(o)	((o)->otyp == BLINDFOLD || (o)->otyp == TOWEL || (o)->otyp == R_LYEHIAN_FACEPLATE)
 #define is_instrument(o)	((o)->otyp >= FLUTE && \
 			 (o)->otyp <= DRUM_OF_EARTHQUAKE)
 #define is_mummy_wrap(o)	((o)->otyp == MUMMY_WRAPPING || \

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -181,7 +181,7 @@
 #define HBlind_res		u.uprops[BLIND_RES].intrinsic
 #define EBlind_res		u.uprops[BLIND_RES].extrinsic
 #define Blind_res		(HBlind_res || EBlind_res)
-#define Blindfolded		((ublindf && ublindf->otyp != LENSES && ublindf->otyp != SUNGLASSES && ublindf->otyp != MASK && ublindf->otyp != ANDROID_VISOR && ublindf->otyp != LIVING_MASK) ||\
+#define Blindfolded		((ublindf && is_opaque_worn_tool(ublindf)) ||\
 						(uarmh && uarmh->otyp == PLASTEEL_HELM && uarmh->obj_material != objects[uarmh->otyp].oc_material && is_opaque(uarmh)) ||\
 						(uarmh && uarmh->otyp == CRYSTAL_HELM && is_opaque(uarmh)))
 		/* ...means blind because of a cover */

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -135,7 +135,7 @@ boolean check_if_better;
 		    would_prefer_rwep(mtmp, otmp))) ||
 	    /* useful masks */
 	     (otmp->otyp == MASK && mtmp->mtyp == PM_LILLEND) ||
-	     (is_worn_tool(otmp) && has_head_mon(mtmp)) ||
+	     (is_worn_tool(otmp) && can_wear_blindf(mtmp->data)) ||
 	    /* better armor */
 	     (otmp->oclass == ARMOR_CLASS &&
 	      (!check_if_better || is_better_armor(mtmp, otmp))) ||

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -135,6 +135,7 @@ boolean check_if_better;
 		    would_prefer_rwep(mtmp, otmp))) ||
 	    /* useful masks */
 	     (otmp->otyp == MASK && mtmp->mtyp == PM_LILLEND) ||
+	     (is_worn_tool(otmp) && has_head_mon(mtmp)) ||
 	    /* better armor */
 	     (otmp->oclass == ARMOR_CLASS &&
 	      (!check_if_better || is_better_armor(mtmp, otmp))) ||

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1996,6 +1996,8 @@ dopetequip()
 			flag = W_ARMF;
 		} else if(is_suit(otmp)){
 			flag = W_ARM;
+		} else if(is_worn_tool(otmp)){
+			flag = W_TOOL;
 		} else {
 			pline("Error: Unknown monster armor type!?");
 			return 0;
@@ -2769,6 +2771,8 @@ struct monst *mon;
 			} else if(is_boots(otmp) && !(mon->misc_worn_check&W_ARMF) && otmp->objsize == mon->data->msize && can_wear_boots(mon->data)){
 				addArmorMenuOption
 			} else if(is_suit(otmp) && !(mon->misc_worn_check&W_ARM) && arm_match(mon->data, otmp) && arm_size_fits(mon->data, otmp)){
+				addArmorMenuOption
+			} else if(is_worn_tool(otmp) && !(mon->misc_worn_check&W_TOOL) && can_wear_blindf(mon->data)){
 				addArmorMenuOption
 			}
 		}

--- a/src/pline.c
+++ b/src/pline.c
@@ -543,7 +543,7 @@ register struct monst *mtmp;
 	if (mtmp->mconf)	  Strcat(info, ", confused");
 	if (mtmp->mcrazed)	  Strcat(info, ", crazed");
 	if (mtmp->mberserk)	  Strcat(info, ", berserk");
-	if (mtmp->mblinded || !mtmp->mcansee)
+	if (mtmp->mblinded || !mtmp->mcansee || is_blindfolded(mtmp))
 				  Strcat(info, ", blind");
 	else if(is_blind(mtmp)) Strcat(info, ", dazzled");
 	if (mtmp->mstun)	  Strcat(info, ", stunned");

--- a/src/worn.c
+++ b/src/worn.c
@@ -1392,8 +1392,8 @@ boolean racialexception;
 				continue;
 		    break;
 		case W_TOOL:
-		    if(!can_wear_blindf(mon->data)) continue;
-
+		    if(!is_worn_tool(obj)) continue;
+		    if(!can_wear_blindf(mon->data) || (is_opaque_worn_tool(obj) && !(obj->otyp == R_LYEHIAN_FACEPLATE && is_mind_flayer(mon->data))) ) continue;
 		    break;
 	    }
 	    if (obj->owornmask) continue;
@@ -1765,6 +1765,16 @@ struct obj *obj;
 	case ALCHEMY_SMOCK:
 		if (!species_resists_acid(mon) || !species_resists_poison(mon))
 			return 5;
+		break;
+	case LIVING_MASK:
+		return 3;
+		break;
+	case SUNGLASSES:
+		return 2;
+		break;
+	case ANDROID_VISOR:
+		if(is_android(mon)) return 4;
+		return 1;
 		break;
 	case MUMMY_WRAPPING:
 	case PRAYER_WARDED_WRAPPING:

--- a/src/worn.c
+++ b/src/worn.c
@@ -1311,6 +1311,7 @@ boolean creation;
 	m_dowear_type(mon, W_ARMG, creation, FALSE);
 	m_dowear_type(mon, W_ARMF, creation, FALSE);
 	m_dowear_type(mon, W_ARM, creation, FALSE);
+	m_dowear_type(mon, W_TOOL, creation, FALSE);
 }
 
 STATIC_OVL void
@@ -1389,6 +1390,10 @@ boolean racialexception;
 				break;
 		    if (!is_suit(obj) || !arm_match(mon->data, obj) || !arm_size_fits(mon->data, obj))
 				continue;
+		    break;
+		case W_TOOL:
+		    if(!can_wear_blindf(mon->data)) continue;
+
 		    break;
 	    }
 	    if (obj->owornmask) continue;


### PR DESCRIPTION
This is a potential addition to the Monster Blindfold Patch that comes at an unknown tradeoff. This implements opaque blindfold items actually blinding monsters. This is problematic currently because we do not have mon->blindf or any other non weapon worn object pointers for monsters yet.

This means every single Is_blind check done has to do an O(n) traversal of the monster's inventory. This sounds very unideal and I have no idea how this affects performance. Playtesting seems fine but this may be a good time for someone to profile with and without the change.

This doesn't check things like opaque crystal helmets but it easily could be modified to in the future.