### PR TITLE
Anti summon abuse

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -1680,7 +1680,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))], diesize;
 
-	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp)
+	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	if (difficulty > 7 && !rn2(35)) return WAN_DEATH;
@@ -1719,7 +1719,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp)
+	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	if (difficulty > 7 && !rn2(35)) return rnd(20) > 10 ? WAN_DRAINING : WAN_DEATH;
@@ -1769,7 +1769,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp)
+	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	switch (rnd(6)) {
@@ -1791,7 +1791,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp)
+	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	switch (rnd(6)) {
@@ -1813,7 +1813,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp)
+	if(is_animal(pm) || attacktype(pm, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	switch (rnd(16)) {

--- a/src/potion.c
+++ b/src/potion.c
@@ -1029,7 +1029,8 @@ peffects(otmp)
 		You_feel("better.");
         enhanced = uarmg && uarmg->oartifact == ART_GAUNTLETS_OF_THE_HEALING_H;
 		healup(d((enhanced ? 2 : 1) * (6 + 2 * bcsign(otmp)), 4),
-		       ((enhanced ? 2 : 1) * (!otmp->cursed ? 1 : 0)), !!otmp->blessed, !otmp->cursed);
+		       !(get_ox(otmp, OX_ESUM)) * ((enhanced ? 2 : 1) * (!otmp->cursed ? 1 : 0)),
+			   !!otmp->blessed, !otmp->cursed);
 		exercise(A_CON, TRUE);
 		break;
 	case POT_EXTRA_HEALING:
@@ -1037,7 +1038,7 @@ as_extra_healing:
 		You_feel("much better.");
         enhanced = uarmg && uarmg->oartifact == ART_GAUNTLETS_OF_THE_HEALING_H;
 		healup(d((enhanced ? 2 : 1) * (6 + 2 * bcsign(otmp)), 8),
-		       (enhanced ? 2 : 1) * (otmp->blessed ? 5 : !otmp->cursed ? 2 : 0),
+		       !(get_ox(otmp, OX_ESUM)) * (enhanced ? 2 : 1) * (otmp->blessed ? 5 : !otmp->cursed ? 2 : 0),
 		       !otmp->cursed, TRUE);
 		(void) make_hallucinated(0L,TRUE,0L);
 		exercise(A_CON, TRUE);
@@ -1046,7 +1047,9 @@ as_extra_healing:
 	case POT_FULL_HEALING:
 		You_feel("completely healed.");
         enhanced = uarmg && uarmg->oartifact == ART_GAUNTLETS_OF_THE_HEALING_H;
-		healup(enhanced ? 800 : 400, (enhanced ? 2 : 1) * (4+4*bcsign(otmp)), !otmp->cursed, TRUE);
+		healup(enhanced ? 800 : 400, 
+				!(get_ox(otmp, OX_ESUM)) * (enhanced ? 2 : 1) * (4+4*bcsign(otmp)),
+				!otmp->cursed, TRUE);
 		/* Restore one lost level if blessed */
 		if (otmp->blessed && u.ulevel < u.ulevelmax) {
 		    ///* when multiple levels have been lost, drinking
@@ -1080,7 +1083,9 @@ as_extra_healing:
 				"spoiled milk", TRUE, SICK_VOMITABLE);
 			break;
 		} else {
-			healup(enhanced ? 800 : 400, (enhanced ? 2 : 1) * (4+4*bcsign(otmp)), TRUE, TRUE);
+			healup(enhanced ? 800 : 400, 
+					!(get_ox(otmp, OX_ESUM)) * (enhanced ? 2 : 1) * (4+4*bcsign(otmp)),
+					TRUE, TRUE);
 		}
 		/* Restore lost levels */
 		if (u.ulevel < u.ulevelmax) {

--- a/src/spell.c
+++ b/src/spell.c
@@ -2746,7 +2746,7 @@ spiriteffects(power, atme)
 			You("dance and shape the wind.");
 			for(i=dsize; i > 0; i--){
 				do pm = &mons[rn2(PM_LONG_WORM_TAIL)];
-				while( (pm->geno & (G_UNIQ|G_NOGEN)) || pm->mlevel >= u.ulevel+5);
+				while( (pm->geno & (G_UNIQ|G_NOGEN)) || pm->mlevel >= u.ulevel+5 || (pm->mflagsg & (MG_NOWISH|MG_NOTAME|MG_FUTURE_WISH)));
 				mon = makemon(pm, u.ux, u.uy, MM_EDOG|MM_ADJACENTOK|MM_NOCOUNTBIRTH|MM_ESUM);
 				if(mon){
 					initedog(mon);


### PR DESCRIPTION
A handful of small changes that should make repeatable tame summons (particularly "Shape the Wind", "Crystal Memories") less abusable.