### PR TITLE
Fix shades being hit by any projectile

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3238,6 +3238,7 @@ E boolean FDECL(obj_silver_searing, (struct obj *));
 E boolean FDECL(obj_jade_searing, (struct obj *));
 E int FDECL(hatesobjdmg, (struct monst *, struct obj *));
 E int FDECL(hits_insubstantial, (struct monst *, struct monst *, struct attack *, struct obj *));
+E boolean FDECL(miss_via_insubstantial, (struct monst *, struct monst *, struct attack *, struct obj *, int));
 E int FDECL(destroy_item, (struct monst *, int, int));
 E boolean FDECL(wearing_dragon_armor, (struct monst *, int));
 

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1004,7 +1004,7 @@ boolean forcedestroy;			/* TRUE if projectile should be forced to be destroyed a
 	/* Set up the visibility of action */
 	if (youagr || youdef || ((!magr || cansee(x(magr), y(magr))) && cansee(x(mdef), y(mdef))))
 	{
-		if (youagr || (magr && cansee(x(magr), y(magr)) && canseemon(magr)))
+		if (youagr || (magr && cansee(x(magr), y(magr)) && canseemon(magr)) || (trap && cansee(trap->tx, trap->ty)))
 			vis |= VIS_MAGR;
 		if (youdef || (cansee(x(mdef), y(mdef)) && canseemon(mdef)))
 			vis |= VIS_MDEF;
@@ -1221,7 +1221,10 @@ boolean forcedestroy;			/* TRUE if projectile should be forced to be destroyed a
 
 	accuracy = tohitval(magr, mdef, attkp, thrownobj, vpointer, hmoncode, 0);
 
-	if (accuracy > dieroll)
+	if (miss_via_insubstantial(magr, mdef, attkp, thrownobj, vis)) {
+		/* message already printed by miss_via_insubstantial */;
+	}
+	else if (accuracy > dieroll)
 	{
 		/* hit */
 		/* (player-only) exercise dex */

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -3334,6 +3334,10 @@ int flat_acc;
 	{
 		vdef_acc += 20;
 	}
+	/* Shades (and other insubstantial creatures) edge-case handler */
+	/* generally, miss_via_insubstantial() should do this, but some edge cases (like rolling boulder traps) are missed */
+	if (insubstantial(pd) && !hits_insubstantial(magr, mdef, attk, weapon))
+		vdef_acc -= 2000;
 
 	/* weapon accuracy -- only applies for a weapon attack OR a properly-thrown object */
 	if ((attk && weapon_aatyp(attk->aatyp))
@@ -3593,47 +3597,9 @@ boolean ranged;
 		vis = getvis(magr, mdef, 0, 0);
 	
 	/* Some things cause immediate misses */
-	/* monster displacement */
-	if (!youdef &&
-		mon_resistance(mdef, DISPLACED) &&
-		!(youagr && u.ustuck && u.ustuck == mdef) &&
-		!(youagr && u.uswallow) &&
-		!(has_passthrough_displacement(pd) && hits_insubstantial(magr, mdef, attk, weapon)) &&
-		rn2(2)
-		) {
-		if (has_passthrough_displacement(pd)){
-			if (vis&VIS_MAGR) {
-				pline("%s attack passes harmlessly through %s!",
-					(youagr ? "Your" : s_suffix(Monnam(magr))),
-					the(mon_nam(mdef)));
-			}
-		}
-		else {
-			if (vis&VIS_MAGR) {
-				pline("%s attack%s %s displaced image!",
-					(youagr ? "You" : Monnam(magr)),
-					(youagr ? "" : "s"),
-					(youagr ? "a" : s_suffix(mon_nam(mdef)))
-					);
-			}
-		}
-		domissmsg = FALSE;
+	if (miss_via_insubstantial(magr, mdef, attk, weapon, vis)) {
 		miss = TRUE;
-	}
-	/* insubstantial (shade-type) immunity to being hit */
-	if (!miss && insubstantial(pd) && !hits_insubstantial(magr, mdef, attk, weapon)) {
-		/* Print message */
-		if (vis&VIS_MAGR) {
-			Sprintf(buf, "%s", ((!weapon || valid_weapon(weapon)) ? "attack" : cxname(weapon)));
-			pline("%s %s %s harmlessly through %s.",
-				(youagr ? "Your" : s_suffix(Monnam(magr))),
-				buf,
-				vtense(buf, "pass"),
-				(youdef ? "you" : mon_nam(mdef))
-				);
-		}
 		domissmsg = FALSE;
-		miss = TRUE;
 	}
 	/* Otiax protects you from being hit (1/5) */
 	if (youdef && u.sealsActive&SEAL_OTIAX && !rn2(5))


### PR DESCRIPTION
Ranged attacks weren't checking insubstantial/displacement at all; fixed.
Also, double-check insubstantial in tohitval, to prevent shades from being hit by rolling boulder traps and other things that I'm too lazy to do full insubstantial checking on.