### PR TITLE
Fix mazes sometimes crashing on generation

### DIFF
--- a/src/mkmap.c
+++ b/src/mkmap.c
@@ -420,8 +420,8 @@ remove_room(roomno)
 	/* since maxroom moved, update affected level roomno values */
 	oroomno = nroom + ROOMOFFSET;
 	roomno += ROOMOFFSET;
-	for (i = croom->lx; i <= croom->hx; ++i)
-	    for (j = croom->ly; j <= croom->hy; ++j) {
+	for (i = croom->lx-1; i <= croom->hx+1; ++i)
+	    for (j = croom->ly-1; j <= croom->hy+1; ++j) {
 		if (levl[i][j].roomno == oroomno)
 		    levl[i][j].roomno = roomno;
 	    }

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -1127,7 +1127,7 @@ int careful;
 			move(&dx2, &dy2, dir);
 			move(&dx2, &dy2, dir);
 			if (levl[dx2][dy2].roomno != NO_ROOM) {
-				dodoor(dx, dy, &rooms[levl[dx2][dy2].roomno]);
+				dodoor(dx, dy, &rooms[levl[dx2][dy2].roomno - ROOMOFFSET]);
 			}
 			else {
 				levl[dx][dy].typ = floortyp;


### PR DESCRIPTION
The function that removed rooms wasn't renumbering the edge walls around a room when it shifted room numbering around.
This would cause some levl[x][y] locations to have bad `roomno` values corresponding to a room that no longer existed.