### PR TITLE
Prevent enter key triggering movement in curses

### DIFF
--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -114,6 +114,8 @@ curses_init_nhwindows(int *argcp, char **argv)
 #endif
     noecho();
     raw();
+    nonl(); /* don't force ^M into newline (^J); input accepts them both
+              * but as a command, accidental <enter> won't run South */
     meta(stdscr, TRUE);
     orig_cursor = curs_set(0);
     keypad(stdscr, TRUE);


### PR DESCRIPTION
This prevents accidentally hitting enter sending your character
downwards (it is treated like ^J otherwise)

Taken from vanilla commit a64a2f85