### PR TITLE
Snuff some lightsources when stoning mon

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -4779,11 +4779,12 @@ register struct monst *mdef;
      (obj->otyp == STATUE && mons[obj->corpsenm].msize >= mdef->data->msize) ||
 #endif
 				obj_resists(obj, 0, 0)) {
-			if (flooreffects(obj, x, y, "fall")) continue;
-			place_object(obj, x, y);
+				if (flooreffects(obj, x, y, "fall")) continue;
+				place_object(obj, x, y);
 		    } else {
-			obj->nobj = oldminvent;
-			oldminvent = obj;
+				if (obj_is_burning(obj)) end_burn(obj, TRUE);
+				obj->nobj = oldminvent;
+				oldminvent = obj;
 		    }
 		}
 		/* defer statue creation until after inventory removal


### PR DESCRIPTION
Lamps, lightsabers, torches, and other snuffable lightsources should be hit by `end_burn()` when a monster is turned to stone.
This correctly excludes permanent lightsources like the Arkenstone.