### PR TITLE
New artifact: "Mask of Many Faces"

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -399,6 +399,7 @@ extern struct artifact artilist[];
 #define RINGED_ARMOR    (LAST_PROP+81)
 #define BLOODLETTER     (LAST_PROP+82)
 #define SEVEN_LEAGUE_STEP   (LAST_PROP+83)
+#define MANY_FACES      (LAST_PROP+84)
 
 
 #define MASTERY_ARTIFACT_LEVEL 20

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -548,7 +548,7 @@ you_calc_movement()
 	if (uwep && uwep->oartifact == ART_TENSA_ZANGETSU){
 		moveamt += NORMAL_SPEED;
 		if(artinstance[ART_TENSA_ZANGETSU].ZangetsuSafe-- < 1){
-			if(ublindf && ublindf->otyp == MASK && is_undead(&mons[ublindf->corpsenm])){
+			if(ublindf && ublindf->otyp == MASK && ublindf->corpsenm != NON_PM && is_undead(&mons[ublindf->corpsenm])){
 				artinstance[ART_TENSA_ZANGETSU].ZangetsuSafe = mons[ublindf->corpsenm].mlevel;
 				if(ublindf->oeroded3>=3){
 					Your("mask shatters!");
@@ -4469,7 +4469,7 @@ struct monst *mon;
 			return;
 		for(otmp = level.objects[xlocale][ylocale]; otmp; otmp = otmp2){
 			otmp2 = otmp->nexthere;
-			if(otmp->otyp == MASK && !otmp->oartifact && !(mons[otmp->corpsenm].geno&G_UNIQ)){
+			if(otmp->otyp == MASK && otmp->corpsenm != NON_PM && !otmp->oartifact && !(mons[otmp->corpsenm].geno&G_UNIQ)){
 				obj_extract_self(otmp);
 				/* unblock point after extract, before pickup */
 				if (is_boulder(otmp)) /*Shouldn't be a boulder, but who knows if a huge mask will get invented*/
@@ -4479,7 +4479,7 @@ struct monst *mon;
 			}
 		}
 		for(otmp = mon->minvent; otmp; otmp = otmp->nobj){
-			if(otmp->otyp == MASK && !otmp->oartifact && !(mons[otmp->corpsenm].geno&G_UNIQ)){
+			if(otmp->otyp == MASK && otmp->corpsenm != NON_PM && !otmp->oartifact && !(mons[otmp->corpsenm].geno&G_UNIQ)){
 				for(mtmp = migrating_mons; mtmp; mtmp = mtmp2) {
 					mtmp2 = mtmp->nmon;
 					if (mtmp == mon) {

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -5586,12 +5586,13 @@ arti_invoke(obj)
 
     if(oart->inv_prop > LAST_PROP) {
 	/* It's a special power, not "just" a property */
-	if(obj->age > monstermoves && 
-		oart->inv_prop != FIRE_SHIKAI && 
-		oart->inv_prop != SEVENFOLD && 
-		oart->inv_prop != ANNUL && 
-		oart->inv_prop != ALTMODE && 
-		oart->inv_prop != LORDLY
+	if(obj->age > monstermoves && !(
+		oart->inv_prop == FIRE_SHIKAI ||
+		oart->inv_prop == SEVENFOLD ||
+		oart->inv_prop == ANNUL ||
+		oart->inv_prop == ALTMODE || 
+		oart->inv_prop == LORDLY ||
+		(oart->inv_prop == MANY_FACES && obj == uskin))
 	) {
 	    /* the artifact is tired :-) */
 		if(obj->oartifact == ART_FIELD_MARSHAL_S_BATON){
@@ -5608,17 +5609,18 @@ arti_invoke(obj)
 		obj->age += Role_if(PM_PRIEST) ? (long) d(1,20) : (long) d(3,10);
 	    return partial_action();
 	}
-	if( /* some properties can be used as often as desired, or track cooldowns in a different way */
-		oart->inv_prop != FIRE_SHIKAI &&
-		oart->inv_prop != ICE_SHIKAI &&
-		oart->inv_prop != NECRONOMICON &&
-		oart->inv_prop != SPIRITNAMES &&
-		oart->inv_prop != ALTMODE &&
-		oart->inv_prop != LORDLY &&
-		oart->inv_prop != ANNUL &&
-		oart->inv_prop != VOID_CHIME &&
-		oart->inv_prop != SEVENFOLD
-	)obj->age = monstermoves + (long)(rnz(100)*(Role_if(PM_PRIEST) ? .8 : 1));
+	if(!( /* some properties can be used as often as desired, or track cooldowns in a different way */
+		oart->inv_prop == FIRE_SHIKAI ||
+		oart->inv_prop == ICE_SHIKAI ||
+		oart->inv_prop == NECRONOMICON ||
+		oart->inv_prop == SPIRITNAMES ||
+		oart->inv_prop == ALTMODE ||
+		oart->inv_prop == LORDLY ||
+		oart->inv_prop == ANNUL ||
+		oart->inv_prop == VOID_CHIME ||
+		oart->inv_prop == SEVENFOLD
+	))
+		obj->age = monstermoves + (long)(rnz(100)*(Role_if(PM_PRIEST) ? .8 : 1));
 
 	if(oart->inv_prop == VOID_CHIME) obj->age = monstermoves + 125L;
 
@@ -8505,6 +8507,53 @@ arti_invoke(obj)
 		case SEVEN_LEAGUE_STEP:
 			You("click your heels together and take a step... ");
 			jump(15);
+			break;
+		case MANY_FACES:
+			if(obj != ublindf && obj != uskin && obj != uwep) {
+				You_feel("that you should be holding %s.", the(xname(obj)));
+				obj->age = monstermoves;
+				return(0);
+			}
+			if(Upolyd && obj == uskin) {
+				/* revert */
+				rehumanize();
+			}
+			else if (Unchanging) {
+				You_feel("the mask's magic be blocked by something.");
+				return partial_action();
+			}
+			else {
+				/* steal a face */
+				if(getdir((char *)0)) {
+					struct monst *mtmp = m_at(u.ux+u.dx, u.uy+u.dy);
+					if (mtmp && !DEADMONSTER(mtmp)) {
+						/* attempt to take monster */
+						int threshold = mtmp->mhpmax / 3 + u.ulevel;
+
+						if (resists_poly(mtmp->data)) threshold /= 2;
+						if (is_rider(mtmp->data)) threshold = 0;
+
+						if (mtmp->mhp < threshold) {
+							/* take the monster */
+							xkilled(mtmp, 3);
+							obj->corpsenm = mtmp->mtyp;
+							/* keep consistent with on-wear code in do_wear.c */
+							if (obj == ublindf) {
+								polymon(obj->corpsenm);
+								u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[obj->corpsenm].mlevel - u.ulevel);
+								if (!polyok(&mons[obj->corpsenm])) u.mtimedone /= 3;
+								uskin = obj;
+								ublindf = (struct obj *)0;
+								uskin->owornmask |= W_SKIN;
+							}
+						}
+						else {
+							/* resisted */
+							pline("%s resists!", Monnam(mtmp));
+						}
+					}
+				}
+			}
 			break;
 		default: pline("Program in dissorder.  Artifact invoke property not recognized");
 		break;

--- a/src/artilist.c
+++ b/src/artilist.c
@@ -1222,6 +1222,16 @@ A("Apotheosis Veil",				CRYSTAL_HELM,			(const char *)0,
 	ENLIGHTENING, (ARTI_PLUSSEV)
 	),
 
+A("The Mask of Many Faces",			MASK,					(const char *)0,
+	2500L, SILVER, MZ_DEFAULT, WT_DEFAULT,
+	A_NEUTRAL, NON_PM, NON_PM, TIER_B, NOFLAG,
+	NO_MONS(),
+	NO_ATTK(), NOFLAG,
+	PROPS(), NOFLAG,
+	PROPS(), NOFLAG,
+	MANY_FACES, NOFLAG
+	),
+
 A("Hellrider's Saddle",				SADDLE,					(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_NONE, NON_PM, NON_PM, TIER_A, NOFLAG,

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -648,6 +648,8 @@ const char *name;
 			obj->corpsenm = PM_DWARF;
 		if (obj->oartifact == ART_MASK_OF_TLALOC)
 			obj->corpsenm = PM_GOD;
+		if (obj->oartifact == ART_MASK_OF_MANY_FACES)
+			obj->corpsenm = NON_PM;
 		
 		/* weight */
 		if (obj->oartifact == ART_GREEN_DRAGON_CRESCENT_BLAD)

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -848,6 +848,10 @@ Amulet_on()
 		    Slimed = 0;
 		    flags.botl = 1;
 		}
+		if (Upolyd && uskin && uskin->oartifact == ART_MASK_OF_MANY_FACES) {
+			You("shudder!");
+			rehumanize();
+		}
 		break;
 	case AMULET_OF_CHANGE:
 	    {
@@ -1212,6 +1216,15 @@ register struct obj *otmp;
 	    vision_full_recalc = 1;	/* recalc vision limits */
 	    flags.botl = 1;
 	}
+	if (otmp->otyp == MASK && otmp->oartifact == ART_MASK_OF_MANY_FACES && otmp->corpsenm != NON_PM) {
+		/* keep consistent with on-invoke code in artifact.c */
+		polymon(otmp->corpsenm);
+		u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[otmp->corpsenm].mlevel - u.ulevel);
+		if (!polyok(&mons[otmp->corpsenm])) u.mtimedone /= 3;
+		uskin = otmp;
+		ublindf = (struct obj *)0;
+		uskin->owornmask |= W_SKIN;
+	}
 }
 
 void
@@ -1356,7 +1369,7 @@ dotakeoff()
 	}
 	if (!armorpieces) {
 	     /* assert( GRAY_DRAGON_SCALES > YELLOW_DRAGON_SCALE_MAIL ); */
-		if (uskin)
+		if (uskin && uskin->oclass == ARMOR_CLASS)
 		    pline_The("%s merged with your skin!",
 				uskin->otyp == LEO_NEMAEUS_HIDE ? 
 				"lion skin is" : 

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -905,9 +905,20 @@ Amulet_off()
 	case AMULET_OF_DRAIN_RESISTANCE:
 	case AMULET_OF_REFLECTION:
 	case AMULET_OF_CHANGE:
-	case AMULET_OF_UNCHANGING:
 	case FAKE_AMULET_OF_YENDOR:
 		break;
+	case AMULET_OF_UNCHANGING:
+		setworn((struct obj *)0, W_AMUL);
+		if (!Unchanging && ublindf && ublindf->otyp == MASK && ublindf->oartifact == ART_MASK_OF_MANY_FACES && ublindf->corpsenm != NON_PM) {
+			/* keep consistent with on-invoke code in artifact.c */
+			polymon(ublindf->corpsenm);
+			u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[ublindf->corpsenm].mlevel - u.ulevel);
+			if (!polyok(&mons[ublindf->corpsenm])) u.mtimedone /= 3;
+			uskin = ublindf;
+			ublindf = (struct obj *)0;
+			uskin->owornmask |= W_SKIN;
+		}
+		return;
 	case AMULET_OF_MAGICAL_BREATHING:
 		if (Underwater) {
 		    /* HMagical_breathing must be set off
@@ -1216,7 +1227,7 @@ register struct obj *otmp;
 	    vision_full_recalc = 1;	/* recalc vision limits */
 	    flags.botl = 1;
 	}
-	if (otmp->otyp == MASK && otmp->oartifact == ART_MASK_OF_MANY_FACES && otmp->corpsenm != NON_PM) {
+	if (!Unchanging && otmp->otyp == MASK && otmp->oartifact == ART_MASK_OF_MANY_FACES && otmp->corpsenm != NON_PM) {
 		/* keep consistent with on-invoke code in artifact.c */
 		polymon(otmp->corpsenm);
 		u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[otmp->corpsenm].mlevel - u.ulevel);

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -137,7 +137,7 @@ boolean check_if_better;
 		    would_prefer_hwep(mtmp, otmp) ||
 		    would_prefer_rwep(mtmp, otmp))) ||
 	    /* useful masks */
-	     (otmp->otyp == MASK && mtmp->mtyp == PM_LILLEND) ||
+	     (otmp->otyp == MASK && otmp->corpsenm != NON_PM && mtmp->mtyp == PM_LILLEND) ||
 	     (is_worn_tool(otmp) && can_wear_blindf(mtmp->data)) ||
 	    /* better armor */
 	     (otmp->oclass == ARMOR_CLASS &&

--- a/src/end.c
+++ b/src/end.c
@@ -886,6 +886,10 @@ int how;
 					is_undead(youracedata)
 				)) {
 				You_feel("a curse fall upon your soul!");
+				if (Upolyd && uskin && uskin->oartifact == ART_MASK_OF_MANY_FACES) {
+					pline("Your mask falls to pieces!");
+					useup(uskin);
+				}
 				polymon(PM_DEATH_KNIGHT);
 				HUnchanging |= FROMOUTSIDE;
 				lsvd = LSVD_DTHK;

--- a/src/muse.c
+++ b/src/muse.c
@@ -1008,7 +1008,7 @@ struct permonst *
 find_mask(mtmp)
 struct monst *mtmp;
 {
-#define validmask(obj) ((obj)->otyp == MASK && !is_horror(&mons[(int)((obj)->corpsenm)]))
+#define validmask(obj) ((obj)->otyp == MASK && (obj)->corpsenm != NON_PM && !is_horror(&mons[(int)((obj)->corpsenm)]))
 	register struct obj *obj;
 	int maskno = 0;
 	for(obj = mtmp->minvent; obj; obj = obj->nobj){
@@ -1957,7 +1957,7 @@ struct monst *mtmp;
 			m.has_misc = MUSE_POT_GAIN_LEVEL;
 		}
 		nomore(MUSE_MASK);
-		if(obj->otyp == MASK && mtmp->mtyp == PM_POLYPOID_BEING
+		if(obj->otyp == MASK && obj->corpsenm != NON_PM && mtmp->mtyp == PM_POLYPOID_BEING
 			&& !(mons[obj->corpsenm].geno&G_UNIQ)
 			&& !(is_horror(&mons[obj->corpsenm]))
 			&& !obj->oartifact) {

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1526,9 +1526,14 @@ add_type_words(obj, buf)
 struct obj *obj;
 char *buf;
 {
-	if (obj->otyp == MASK){
-		Strcat(buf, mons[obj->corpsenm].mname);
-		Strcat(buf, " ");
+	if (obj->otyp == MASK && obj->oartifact != ART_MASK_OF_MANY_FACES){
+		if (obj->corpsenm != NON_PM) {
+			Strcat(buf, mons[obj->corpsenm].mname);
+			Strcat(buf, " ");
+		}
+		else {
+			Strcat(buf, "blank ");
+		}
 	}
 	if (obj->otyp == CORPSE) {
 		if (!(mons[obj->corpsenm].geno & G_UNIQ)) {
@@ -2073,12 +2078,16 @@ weapon:
 			}
 			break;
 		case TOOL_CLASS:
+			if (obj->oartifact == ART_MASK_OF_MANY_FACES)
+				Sprintf(eos(buf), " (%s)", obj->corpsenm != NON_PM ? mons[obj->corpsenm].mname : "blank");
 			if (obj->owornmask & (W_TOOL /* blindfold */
 #ifdef STEED
 				| W_SADDLE
 #endif
 				)) {
-				Strcat(buf, " (being worn)");
+				Strcat(buf, (obj == uskin) ? " (embedded in your skin)" :
+				" (being worn)");
+
 				break;
 			}
 			if (obj->otyp == LEASH && obj->leashmon != 0) {

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1171,7 +1171,10 @@ dodemonpet()
 	i = (!is_demon(youracedata) || !rn2(6)) 
 	     ? ndemon(u.ualign.type) : NON_PM;
 	pm = i != NON_PM ? &mons[i] : youracedata;
-	if(pm->mtyp == PM_ANCIENT_OF_ICE || pm->mtyp == PM_ANCIENT_OF_DEATH) {
+	if(pm->geno&G_UNIQ) {
+		pm = &mons[ndemon(A_NONE)];
+	}
+	if(is_ancient(pm)) {
 	    pm = rn2(4) ? &mons[PM_METAMORPHOSED_NUPPERIBO] : &mons[PM_ANCIENT_NUPPERIBO];
 	}
 	if ((dtmp = makemon(pm, u.ux, u.uy, MM_ESUM)) != 0) {


### PR DESCRIPTION
Neutral mask
Invoke while wielded or worn against a target adjacent creature.
If the creature is below 1/3rd hp (1/6th for uniques), kills them leaving no corpse. The Mask then assumes the shape of the slain monster.
When worn (or immediately, if it was invoked while worn), the player is polymorphed into the form of the Mask, including for no-poly monsters.
The duration of the polymorph is dependent on the relative level of the player to the monster, reduced significantly for no-poly monsters. Unchanging cannot be used to make the effect permanent.
While poly'd, the mask can be re-invoked to end the effect early.