### PR TITLE
Re-identity the Mask of Many Faces to The Mirrored Mask

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -399,7 +399,7 @@ extern struct artifact artilist[];
 #define RINGED_ARMOR    (LAST_PROP+81)
 #define BLOODLETTER     (LAST_PROP+82)
 #define SEVEN_LEAGUE_STEP   (LAST_PROP+83)
-#define MANY_FACES      (LAST_PROP+84)
+#define CAPTURE_REFLECTION  (LAST_PROP+84)
 
 
 #define MASTERY_ARTIFACT_LEVEL 20

--- a/include/extern.h
+++ b/include/extern.h
@@ -160,6 +160,7 @@ E void NDECL(living_items);
 E int FDECL(oresist_disintegration, (struct obj *));
 E int FDECL(wrath_target, (struct obj *, struct monst *));
 E int FDECL(goat_weapon_damage_turn, (struct obj *));
+E void FDECL(activate_mirrored_mask, (struct obj *));
 
 /* ### astar.c ### */
 E boolean FDECL(path_exists, (int, int, int, int, long, int));

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2110,6 +2110,12 @@ touch_artifact(obj, mon, hypothetical)
 				pline("With that realization comes knowledge of the seal's final form!");
 				u.specialSealsKnown |= SEAL_NUDZIRATH;
 			}
+			else if(obj->oartifact == ART_MIRRORED_MASK && obj->corpsenm == NON_PM && !(u.specialSealsKnown&SEAL_NUDZIRATH)){
+				pline("The cracks on the otherwise-blank silver face form part of a seal.");
+				pline("In fact, you realize that all cracked and broken mirrors everywhere together are working towards writing this seal.");
+				pline("With that realization comes knowledge of the seal's final form!");
+				u.specialSealsKnown |= SEAL_NUDZIRATH;
+			}
 		}
 		if(oart->otyp == UNICORN_HORN){
 			badclass = TRUE; //always get blasted by unicorn horns.  
@@ -5592,7 +5598,7 @@ arti_invoke(obj)
 		oart->inv_prop == ANNUL ||
 		oart->inv_prop == ALTMODE || 
 		oart->inv_prop == LORDLY ||
-		(oart->inv_prop == MANY_FACES && obj == uskin))
+		(oart->inv_prop == CAPTURE_REFLECTION && obj == uskin))
 	) {
 	    /* the artifact is tired :-) */
 		if(obj->oartifact == ART_FIELD_MARSHAL_S_BATON){
@@ -8508,7 +8514,7 @@ arti_invoke(obj)
 			You("click your heels together and take a step... ");
 			jump(15);
 			break;
-		case MANY_FACES:
+		case CAPTURE_REFLECTION:
 			if(obj != ublindf && obj != uskin && obj != uwep) {
 				You_feel("that you should be holding %s.", the(xname(obj)));
 				obj->age = monstermoves;
@@ -8539,12 +8545,7 @@ arti_invoke(obj)
 							obj->corpsenm = mtmp->mtyp;
 							/* keep consistent with on-wear code in do_wear.c */
 							if (obj == ublindf) {
-								polymon(obj->corpsenm);
-								u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[obj->corpsenm].mlevel - u.ulevel);
-								if (!polyok(&mons[obj->corpsenm])) u.mtimedone /= 3;
-								uskin = obj;
-								ublindf = (struct obj *)0;
-								uskin->owornmask |= W_SKIN;
+								activate_mirrored_mask(obj);
 							}
 						}
 						else {
@@ -10994,6 +10995,18 @@ struct obj *obj;
 			}
 	}
 	return AD_EACD;
+}
+
+void
+activate_mirrored_mask(obj)
+struct obj * obj;
+{
+	polymon(obj->corpsenm);
+	u.mtimedone = (u.ulevel * 30) / max(1, 10 + mons[obj->corpsenm].mlevel - u.ulevel);
+	if (!polyok(&mons[obj->corpsenm])) u.mtimedone /= 3;
+	uskin = obj;
+	ublindf = (struct obj *)0;
+	uskin->owornmask |= W_SKIN;
 }
 
 /*artifact.c*/

--- a/src/artilist.c
+++ b/src/artilist.c
@@ -1222,16 +1222,6 @@ A("Apotheosis Veil",				CRYSTAL_HELM,			(const char *)0,
 	ENLIGHTENING, (ARTI_PLUSSEV)
 	),
 
-A("The Mask of Many Faces",			MASK,					(const char *)0,
-	2500L, SILVER, MZ_DEFAULT, WT_DEFAULT,
-	A_NEUTRAL, NON_PM, NON_PM, TIER_B, NOFLAG,
-	NO_MONS(),
-	NO_ATTK(), NOFLAG,
-	PROPS(), NOFLAG,
-	PROPS(), NOFLAG,
-	MANY_FACES, NOFLAG
-	),
-
 A("Hellrider's Saddle",				SADDLE,					(const char *)0,
 	4000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_NONE, NON_PM, NON_PM, TIER_A, NOFLAG,
@@ -1451,6 +1441,16 @@ A("The Staff of Twelve Mirrors",	KHAKKHARA,				(const char *)0,
 	PROPS(REFLECTING, DISPLACED), NOFLAG,
 	PROPS(), NOFLAG,
 	NOINVOKE, NOFLAG
+	),
+
+A("The Mirrored Mask",				MASK,					(const char *)0,
+	3000L, SILVER, MZ_DEFAULT, WT_DEFAULT,
+	A_NEUTRAL, NON_PM, NON_PM, TIER_A, (ARTG_NOGEN|ARTG_NOWISH),
+	NO_MONS(),
+	NO_ATTK(), NOFLAG,
+	PROPS(), NOFLAG,
+	PROPS(), NOFLAG,
+	CAPTURE_REFLECTION, NOFLAG
 	),
 
 /* reflects projectiles and counterattacks, and doubles your multishot when carried in swapwep or wielded */

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -648,7 +648,7 @@ const char *name;
 			obj->corpsenm = PM_DWARF;
 		if (obj->oartifact == ART_MASK_OF_TLALOC)
 			obj->corpsenm = PM_GOD;
-		if (obj->oartifact == ART_MASK_OF_MANY_FACES)
+		if (obj->oartifact == ART_MIRRORED_MASK)
 			obj->corpsenm = NON_PM;
 		
 		/* weight */

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -848,7 +848,7 @@ Amulet_on()
 		    Slimed = 0;
 		    flags.botl = 1;
 		}
-		if (Upolyd && uskin && uskin->oartifact == ART_MASK_OF_MANY_FACES) {
+		if (Upolyd && uskin && uskin->oartifact == ART_MIRRORED_MASK) {
 			You("shudder!");
 			rehumanize();
 		}
@@ -909,14 +909,8 @@ Amulet_off()
 		break;
 	case AMULET_OF_UNCHANGING:
 		setworn((struct obj *)0, W_AMUL);
-		if (!Unchanging && ublindf && ublindf->otyp == MASK && ublindf->oartifact == ART_MASK_OF_MANY_FACES && ublindf->corpsenm != NON_PM) {
-			/* keep consistent with on-invoke code in artifact.c */
-			polymon(ublindf->corpsenm);
-			u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[ublindf->corpsenm].mlevel - u.ulevel);
-			if (!polyok(&mons[ublindf->corpsenm])) u.mtimedone /= 3;
-			uskin = ublindf;
-			ublindf = (struct obj *)0;
-			uskin->owornmask |= W_SKIN;
+		if (!Unchanging && ublindf && ublindf->otyp == MASK && ublindf->oartifact == ART_MIRRORED_MASK && ublindf->corpsenm != NON_PM) {
+			activate_mirrored_mask(ublindf);
 		}
 		return;
 	case AMULET_OF_MAGICAL_BREATHING:
@@ -1227,14 +1221,8 @@ register struct obj *otmp;
 	    vision_full_recalc = 1;	/* recalc vision limits */
 	    flags.botl = 1;
 	}
-	if (!Unchanging && otmp->otyp == MASK && otmp->oartifact == ART_MASK_OF_MANY_FACES && otmp->corpsenm != NON_PM) {
-		/* keep consistent with on-invoke code in artifact.c */
-		polymon(otmp->corpsenm);
-		u.mtimedone = (u.ulevel * 20) / max(1, 10 + mons[otmp->corpsenm].mlevel - u.ulevel);
-		if (!polyok(&mons[otmp->corpsenm])) u.mtimedone /= 3;
-		uskin = otmp;
-		ublindf = (struct obj *)0;
-		uskin->owornmask |= W_SKIN;
+	if (!Unchanging && otmp->otyp == MASK && otmp->oartifact == ART_MIRRORED_MASK && otmp->corpsenm != NON_PM) {
+		activate_mirrored_mask(otmp);
 	}
 }
 

--- a/src/end.c
+++ b/src/end.c
@@ -886,7 +886,7 @@ int how;
 					is_undead(youracedata)
 				)) {
 				You_feel("a curse fall upon your soul!");
-				if (Upolyd && uskin && uskin->oartifact == ART_MASK_OF_MANY_FACES) {
+				if (Upolyd && uskin && uskin->oartifact == ART_MIRRORED_MASK) {
 					pline("Your mask falls to pieces!");
 					useup(uskin);
 				}

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -1623,46 +1623,33 @@ mkkamereltowers()
 			tries = 0;
 			otmp = 0;
 			while(!otmp){
-				if(!rn2(3)){
-					otmp = mksobj(DOUBLE_LIGHTSABER, MKOBJ_NOINIT);
-					otmp = oname(otmp, artiname(ART_INFINITY_S_MIRRORED_ARC));
-					if(otmp->oartifact){
+				switch(rn2(4)) {
+				case 0:
+					otmp = oname(mksobj(DOUBLE_LIGHTSABER, MKOBJ_NOINIT), artiname(ART_INFINITY_S_MIRRORED_ARC));
+					break;
+				case 1:
+					otmp = oname(mksobj(MIRRORBLADE, MKOBJ_NOINIT), artiname(ART_SANSARA_MIRROR));
+					break;
+				case 2:
+					otmp = oname(mksobj(KHAKKHARA, MKOBJ_NOINIT), artiname(ART_STAFF_OF_TWELVE_MIRRORS));
+					break;
+				case 3:
+					otmp = oname(mksobj(MASK, MKOBJ_NOINIT), artiname(ART_MIRRORED_MASK));
+					break;
+				}
+				if (otmp->oartifact) {
+					otmp->cursed = 0;
+					otmp->blessed = 0;
+					if (otmp->oclass == WEAPON_CLASS || is_weptool(otmp))
 						otmp->spe = 1;
-						otmp->cursed = 0;
-						otmp->blessed = 0;
+					if (is_lightsaber(otmp))
 						otmp->age = 0;
-						place_object(otmp, x, y);
-					} else {
-						obfree(otmp, (struct obj *)0);
-						otmp = 0;
-						continue;
-					}
-				} else if(rn2(2)){
-					otmp = mksobj(MIRRORBLADE, MKOBJ_NOINIT);
-					otmp = oname(otmp, artiname(ART_SANSARA_MIRROR));
-					if(otmp->oartifact || tries++ > 10){
-						otmp->spe = 1;
-						otmp->cursed = 0;
-						otmp->blessed = 0;
-						place_object(otmp, x, y);
-					} else {
-						obfree(otmp, (struct obj *)0);
-						otmp = 0;
-						continue;
-					}
-				} else {
-					otmp = mksobj(KHAKKHARA, MKOBJ_NOINIT);
-					otmp = oname(otmp, artiname(ART_STAFF_OF_TWELVE_MIRRORS));
-					if(otmp->oartifact || tries++ > 10){
-						otmp->spe = 1;
-						otmp->cursed = 0;
-						otmp->blessed = 0;
-						place_object(otmp, x, y);
-					} else {
-						obfree(otmp, (struct obj *)0);
-						otmp = 0;
-						continue;
-					}
+					place_object(otmp, x, y);
+				}
+				else {
+					obfree(otmp, (struct obj *)0);
+					otmp = 0;
+					continue;
 				}
 			}
 			//record central tower location
@@ -1737,46 +1724,33 @@ mkkamereltowers()
 			tries = 0;
 			otmp = 0;
 			while(!otmp){
-				if(!rn2(3)){
-					otmp = mksobj(DOUBLE_LIGHTSABER, MKOBJ_NOINIT);
-					otmp = oname(otmp, artiname(ART_INFINITY_S_MIRRORED_ARC));
-					if(otmp->oartifact){
+				switch(rn2(4)) {
+				case 0:
+					otmp = oname(mksobj(DOUBLE_LIGHTSABER, MKOBJ_NOINIT), artiname(ART_INFINITY_S_MIRRORED_ARC));
+					break;
+				case 1:
+					otmp = oname(mksobj(MIRRORBLADE, MKOBJ_NOINIT), artiname(ART_SANSARA_MIRROR));
+					break;
+				case 2:
+					otmp = oname(mksobj(KHAKKHARA, MKOBJ_NOINIT), artiname(ART_STAFF_OF_TWELVE_MIRRORS));
+					break;
+				case 3:
+					otmp = oname(mksobj(MASK, MKOBJ_NOINIT), artiname(ART_MIRRORED_MASK));
+					break;
+				}
+				if (otmp->oartifact) {
+					otmp->cursed = 0;
+					otmp->blessed = 0;
+					if (otmp->oclass == WEAPON_CLASS || is_weptool(otmp))
 						otmp->spe = 1;
-						otmp->cursed = 0;
-						otmp->blessed = 0;
+					if (is_lightsaber(otmp))
 						otmp->age = 0;
-						place_object(otmp, x, y);
-					} else {
-						obfree(otmp, (struct obj *)0);
-						otmp = 0;
-						continue;
-					}
-				} else if(rn2(2)){
-					otmp = mksobj(MIRRORBLADE, MKOBJ_NOINIT);
-					otmp = oname(otmp, artiname(ART_SANSARA_MIRROR));
-					if(otmp->oartifact || tries++ > 10){
-						otmp->spe = 1;
-						otmp->cursed = 0;
-						otmp->blessed = 0;
-						place_object(otmp, x, y);
-					} else {
-						obfree(otmp, (struct obj *)0);
-						otmp = 0;
-						continue;
-					}
-				} else {
-					otmp = mksobj(KHAKKHARA, MKOBJ_NOINIT);
-					otmp = oname(otmp, artiname(ART_STAFF_OF_TWELVE_MIRRORS));
-					if(otmp->oartifact || tries++ > 10){
-						otmp->spe = 1;
-						otmp->cursed = 0;
-						otmp->blessed = 0;
-						place_object(otmp, x, y);
-					} else {
-						obfree(otmp, (struct obj *)0);
-						otmp = 0;
-						continue;
-					}
+					place_object(otmp, x, y);
+				}
+				else {
+					obfree(otmp, (struct obj *)0);
+					otmp = 0;
+					continue;
 				}
 			}
 			//record central tower location

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1526,7 +1526,7 @@ add_type_words(obj, buf)
 struct obj *obj;
 char *buf;
 {
-	if (obj->otyp == MASK && obj->oartifact != ART_MASK_OF_MANY_FACES){
+	if (obj->otyp == MASK && obj->oartifact != ART_MIRRORED_MASK){
 		if (obj->corpsenm != NON_PM) {
 			Strcat(buf, mons[obj->corpsenm].mname);
 			Strcat(buf, " ");
@@ -2078,7 +2078,7 @@ weapon:
 			}
 			break;
 		case TOOL_CLASS:
-			if (obj->oartifact == ART_MASK_OF_MANY_FACES)
+			if (obj->oartifact == ART_MIRRORED_MASK)
 				Sprintf(eos(buf), " (%s)", obj->corpsenm != NON_PM ? mons[obj->corpsenm].mname : "blank");
 			if (obj->owornmask & (W_TOOL /* blindfold */
 #ifdef STEED

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1977,7 +1977,7 @@ boolean silently;
 		if(uskin->otyp == MASK) {
 			otmp_p = &ublindf;
 			msg = "Your mask unmelds from your face.";
-			if (uskin->oartifact == ART_MASK_OF_MANY_FACES) {
+			if (uskin->oartifact == ART_MIRRORED_MASK) {
 				uskin->corpsenm = NON_PM;
 				uskin->age = monstermoves + (long)(rnz(100)*(Role_if(PM_PRIEST) ? .8 : 1));
 			}


### PR DESCRIPTION
Now, it's a major Neutral mirror artifact, alongside the Sansara Mirror and Staff of Twelve Mirrors and Infinity's Mirrored Arc.

To compensate for being unwishable and not normally generated, the duration of the selfpoly was increased by 50% and tier (not that that does anything for non-gifted non-wished artis) raised from B -> A.