### PR TITLE
Monsters initiate targeting of offensive wands/potions

### DIFF
--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -130,7 +130,8 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 		(mon_attacktype(magr, AT_LNCK)) ||
 		(mon_attacktype(magr, AT_5SQR)) ||
 		(mon_attacktype(magr, AT_5SBT)) ||
-		(is_commander(magr->data))
+		(is_commander(magr->data)) ||
+		(find_offensive(magr))
 		))
 		return (struct monst *)0;
 
@@ -222,7 +223,8 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 				(mon_attacktype(magr, AT_SPIT)) ||
 				(mon_attacktype(magr, AT_ARRW)) ||
 				(mon_attacktype(magr, AT_WEAP) && mrwep && !is_pole(mrwep)) ||
-				(mon_attacktype(magr, AT_DEVA) && mrwep && !is_pole(mrwep))
+				(mon_attacktype(magr, AT_DEVA) && mrwep && !is_pole(mrwep)) ||
+				(find_offensive(magr))
 			))
 			||
 			/* attacks that are on a line that are ALWAYS SAFE */


### PR DESCRIPTION
Bug was that a monster wouldn't realize it had a ranged option (in the form of a wand/potion) if it had no other ranged options (like a dagger to throw)