### PR TITLE
Add menu option to `Z` and `+` to quiver spells to `f`ire

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2653,6 +2653,7 @@ E int NDECL(learn);
 #endif
 E int FDECL(study_book, (struct obj *));
 E int FDECL(further_study, (int));
+E int FDECL(spellid_to_spellno, (int));
 E boolean FDECL(spell_maintained, (int));
 E void FDECL(spell_maintain, (int));
 E void FDECL(spell_unmaintain, (int));

--- a/include/spell.h
+++ b/include/spell.h
@@ -6,6 +6,7 @@
 #define SPELL_H
 
 /* spellmenu arguments; 0 thru n-1 used as spl_book[] index when swapping */
+#define SPELLMENU_QUIVER (-6)
 #define SPELLMENU_PICK (-5)
 #define SPELLMENU_MAINTAIN (-4)
 #define SPELLMENU_DESCRIBE (-3)

--- a/include/you.h
+++ b/include/you.h
@@ -491,6 +491,7 @@ struct you {
 	uchar	sowdisc;		/* sowing discord (spirit special attack) */
 	unsigned long long int spells_maintained;
 	int maintained_en_debt;
+	int quivered_spell;
 	int	uhp, uhpmax, uhprolled, uhpmultiplier, uhpbonus, uhpmod;
 	int	uen, uenmax, uenrolled, uenmultiplier, uenbonus;			/* magical energy - M. Stephenson */
 	/*"Real" numbers for a WtWalk's non-mask-based HP*/

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -2026,6 +2026,9 @@ dofire()
 	shotlimit = (multi || save_cm) ? multi + 1 : 0;
 	multi = 0;		/* reset; it's been used up */
 
+	if (u.quivered_spell) {
+		return spelleffects(spellid_to_spellno(u.quivered_spell), FALSE, 0);
+	}
 
 	/* __ You have something ready to fire __ */
 	if (!notake(youracedata)) {

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -1551,6 +1551,7 @@ u_init()
 	u.wardsknown = 0;
 	u.spells_maintained = 0;
 	u.maintained_en_debt = 0;
+	u.quivered_spell = 0;
 	//u.wardsknown = ~0; //~0 should be all 1s, and is therefore debug mode.
 
 #if 0	/* documentation of more zero values as desirable */


### PR DESCRIPTION
If you have a spell quivered, it takes precedence over all other things to `f`ire. Attempting to `f`ire without enough pw will print the usual message and not take time.