### PR TITLE
Dynamic artifacts, randarts!

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -313,8 +313,8 @@ struct artinstance{
 #define get_artifact(o) \
 		(((o)&&(o)->oartifact) ? &artilist[(o)->oartifact] : 0)
 
-extern struct artinstance artinstance[];
-extern struct artifact artilist[];
+extern struct artinstance * artinstance;
+extern struct artifact * artilist;
 
 /* invoked properties with special powers */
 #define TAMING		(LAST_PROP+1)

--- a/include/extern.h
+++ b/include/extern.h
@@ -1467,6 +1467,7 @@ E int FDECL(bcsign, (struct obj *));
 E void FDECL(set_obj_size, (struct obj *, int));
 E void FDECL(set_obj_quan, (struct obj *, int));
 E void FDECL(maybe_set_material, (struct obj *, int));
+E void FDECL(rand_interesting_obj_material, (struct obj *));
 E void FDECL(set_material, (struct obj *, int));
 E void FDECL(set_material_gm, (struct obj *, int));
 E int FDECL(weight, (struct obj *));

--- a/include/extern.h
+++ b/include/extern.h
@@ -80,6 +80,7 @@ E int NDECL(n_artifacts);
 E struct artifact * NDECL(add_artifact);
 E const char *FDECL(artiname, (int));
 E int FDECL(arti_value, (struct obj *));
+E struct obj *FDECL(mk_randart, (struct obj *));
 E struct obj *FDECL(mk_artifact, (struct obj *,ALIGNTYP_P));
 E struct obj *FDECL(mk_special, (struct obj *));
 E struct obj *FDECL(mk_vault_special, (struct obj *, int));

--- a/include/extern.h
+++ b/include/extern.h
@@ -76,6 +76,8 @@ E void NDECL(init_artifacts);
 E void NDECL(hack_artifacts);
 E void FDECL(save_artifacts, (int));
 E void FDECL(restore_artifacts, (int));
+E int NDECL(n_artifacts);
+E struct artifact * NDECL(add_artifact);
 E const char *FDECL(artiname, (int));
 E int FDECL(arti_value, (struct obj *));
 E struct obj *FDECL(mk_artifact, (struct obj *,ALIGNTYP_P));

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -78,9 +78,13 @@ STATIC_DCL int artidisco[NROFARTIFACTS];
 STATIC_OVL int spec_dbon_applies = 0;
 
 /* flags including which artifacts have already been created */
-struct artinstance artinstance[1+NROFARTIFACTS+1];
+struct artinstance * artinstance;
 /* and a discovery list for them (no dummy first entry here) */
-STATIC_OVL int artidisco[NROFARTIFACTS];
+STATIC_OVL int * artidisco;
+/* and a counter for how many artifacts we have */
+int nrofartifacts;
+/* and a pointer to space for randarts' names */
+char ** artiextranames;
 
 STATIC_DCL boolean FDECL(attacks, (int,struct obj *));
 
@@ -333,8 +337,16 @@ hack_artifacts()
 void
 init_artifacts()
 {
-	(void) memset((genericptr_t) artinstance, 0, sizeof artinstance);
-	(void) memset((genericptr_t) artidisco, 0, sizeof artidisco);
+	extern struct artifact base_artilist[];
+
+	nrofartifacts = NROFARTIFACTS;
+	artinstance = malloc(sizeof(struct artinstance) * (1+nrofartifacts+1));
+	artidisco = malloc(sizeof(int) * (nrofartifacts));
+	artilist = malloc(sizeof(struct artifact) * (1+nrofartifacts+1));
+	
+	(void) memset((genericptr_t) artinstance, 0, sizeof(struct artinstance) * (1+nrofartifacts+1));
+	(void) memset((genericptr_t) artidisco, 0, sizeof(int) * (nrofartifacts));
+	memcpy(artilist, base_artilist, sizeof(struct artifact) * (1+nrofartifacts+1));
 	hack_artifacts();
 }
 
@@ -342,24 +354,103 @@ void
 save_artifacts(fd)
 int fd;
 {
-	bwrite(fd, (genericptr_t) artinstance, sizeof artinstance);
-	bwrite(fd, (genericptr_t) artidisco, sizeof artidisco);
+	bwrite(fd, (genericptr_t) &nrofartifacts, sizeof(int));
+	bwrite(fd, (genericptr_t) artinstance, sizeof(struct artinstance) * (1+nrofartifacts+1));
+	bwrite(fd, (genericptr_t) artidisco, sizeof(int) * (nrofartifacts));
+	bwrite(fd, (genericptr_t) artilist, sizeof(struct artifact) * (1+nrofartifacts+1));
+	if(nrofartifacts > NROFARTIFACTS) {
+		bwrite(fd, (genericptr_t) artiextranames, sizeof(char)*PL_PSIZ*(nrofartifacts - NROFARTIFACTS));
+	}
 }
 
 void
 restore_artifacts(fd)
 int fd;
 {
-	mread(fd, (genericptr_t) artinstance, sizeof artinstance);
-	mread(fd, (genericptr_t) artidisco, sizeof artidisco);
-	hack_artifacts();	/* redo non-saved special cases */
+	mread(fd, (genericptr_t) &nrofartifacts, sizeof(int));
+
+	artinstance = malloc(sizeof(struct artinstance) * (1+nrofartifacts+1));
+	artidisco = malloc(sizeof(int) * (nrofartifacts));
+	artilist = malloc(sizeof(struct artifact) * (1+nrofartifacts+1));
+	mread(fd, (genericptr_t) artinstance, sizeof(struct artinstance) * (1+nrofartifacts+1));
+	mread(fd, (genericptr_t) artidisco, sizeof(int) * (nrofartifacts));
+	mread(fd, (genericptr_t) artilist, sizeof(struct artifact) * (1+nrofartifacts+1));
+	if(nrofartifacts > NROFARTIFACTS) {
+		artiextranames = malloc(sizeof(char*)*(nrofartifacts - NROFARTIFACTS));
+		int i, j;
+		for(i=NROFARTIFACTS, j=0; i < nrofartifacts; i++, j++) {
+			artiextranames[j] = malloc(sizeof(char)*PL_PSIZ);
+			mread(fd, (genericptr_t) artiextranames[j], sizeof(char)*PL_PSIZ);
+			artilist[i+1].name = artiextranames[j];
+		}
+	}
+}
+
+int
+n_artifacts()
+{
+	return nrofartifacts;
+}
+
+struct artifact *
+add_artifact()
+{
+	int old_narts = nrofartifacts;
+	int i;
+	nrofartifacts++;
+
+	/* allocate new memory, slightly larger */
+	void * tmp_artinstance = malloc(sizeof(struct artinstance) * (1+nrofartifacts+1));	// same indices as artilist
+	void * tmp_artidisco = malloc(sizeof(int) * (nrofartifacts));						// only need 1 per artifact
+	void * tmp_artilist = malloc(sizeof(struct artifact) * (1+nrofartifacts+1));		// dummy + artifacts + terminator
+	void ** tmp_artiextranames = malloc(sizeof(char*)*(nrofartifacts - NROFARTIFACTS));
+	
+	/* copy old data to new memory */
+	memcpy(tmp_artinstance, artinstance, (sizeof(struct artinstance) * (1+old_narts+1)));
+	memcpy(tmp_artidisco, artidisco, (sizeof(int) * (old_narts)));
+	memcpy(tmp_artilist, artilist, (sizeof(struct artifact) * (old_narts+1)));
+	
+	/* free old memory */
+	free(artinstance);
+	free(artidisco);
+	free(artilist);
+
+	/* reassign pointers */
+	artinstance = tmp_artinstance;
+	artidisco = tmp_artidisco;
+	artilist = tmp_artilist;
+	
+	/* repeat, with loop, for artiextranames */
+	for (i = 0; i < nrofartifacts - NROFARTIFACTS; i++) {
+		tmp_artiextranames[i] = malloc(sizeof(char)*PL_PSIZ);
+		if (i == old_narts - NROFARTIFACTS) continue;	// copy&free 1 fewer than created
+		Strcpy(tmp_artiextranames[i], artiextranames[i]);
+		free(artiextranames[i]);
+	}
+	if (old_narts != NROFARTIFACTS)
+		free(artiextranames);
+	artiextranames = (char **)tmp_artiextranames;
+	for (i = 0; i < nrofartifacts - NROFARTIFACTS; i++) {
+		artilist[i+NROFARTIFACTS+1].name = artiextranames[i];
+	}
+
+	/* fill with default values */
+	memset((genericptr_t) &(artinstance[nrofartifacts]), 0, sizeof(struct artinstance));
+	artidisco[nrofartifacts-1] = 0;
+	memcpy((genericptr_t) &(artilist[nrofartifacts]), (genericptr_t)artilist, sizeof(struct artifact));
+	artilist[nrofartifacts].name = artiextranames[nrofartifacts-NROFARTIFACTS-1];
+	// name will be written front-forwards and we don't have to worry about old data
+	/* re-zero terminator */
+	memset((genericptr_t) &(artilist[nrofartifacts+1]), 0, sizeof(struct artifact));
+
+	return &(artilist[nrofartifacts]);
 }
 
 const char *
 artiname(artinum)
 int artinum;
 {
-	if (artinum <= 0 || artinum > NROFARTIFACTS) return("");
+	if (artinum <= 0 || artinum > nrofartifacts) return("");
 	return(artilist[artinum].name);
 }
 
@@ -486,7 +577,7 @@ aligntyp alignment;
 	int n = 0;					/* number of acceptable artifacts, reset every attempt at selecting */
 	int attempts = 0;			/* attempts made creating a list of artifacts */
 	int condition;
-	int eligible[NROFARTIFACTS];
+	int eligible[nrofartifacts];
 
 	/* Pirates quite purposefully can only get the Marauder's Map */
 	if (Role_if(PM_PIRATE))
@@ -575,7 +666,7 @@ struct obj * otmp;
 	const struct artifact * a;	/* artifact pointer, being looped */
 	int m;						/* artifact index, being looped */
 	int n = 0;					/* number of acceptable artifacts, reset every attempt at selecting */
-	int eligible[NROFARTIFACTS];
+	int eligible[nrofartifacts];
 
 	for (m = 1, a = artilist + 1; a->otyp; a++, m++)
 	{
@@ -1408,7 +1499,7 @@ boolean
 art_already_exists(artinum)
 int artinum;
 {
-	if(artinum < 1 || artinum > NROFARTIFACTS) {
+	if(artinum < 1 || artinum > nrofartifacts) {
 		impossible("bad artifact number %d", artinum);
 		return 0;
 	}
@@ -1485,7 +1576,7 @@ int oartifact;
 boolean while_carried;
 {
 	/* quick safety check */
-	if (oartifact < 1 || oartifact > NROFARTIFACTS)
+	if (oartifact < 1 || oartifact > nrofartifacts)
 	{
 		property_list[0] = 0;
 		return;
@@ -2700,7 +2791,7 @@ int m;
 
     /* look for this artifact in the discoveries list;
        if we hit an empty slot then it's not present, so add it */
-    for (i = 0; i < NROFARTIFACTS; i++)
+    for (i = 0; i < nrofartifacts; i++)
 	if (artidisco[i] == 0 || artidisco[i] == m) {
 	    artidisco[i] = m;
 	    return;
@@ -2718,7 +2809,7 @@ int m;
 	boolean found = FALSE;
 	/* look for this artifact in the discoveries list;
        if we hit an empty slot then it's not present, so add it */
-	for (i = 0; i < NROFARTIFACTS - 1 && artidisco[i]; i++) {
+	for (i = 0; i < nrofartifacts - 1 && artidisco[i]; i++) {
 		if (artidisco[i] == m) {
 			found = TRUE;
 		}
@@ -2737,7 +2828,7 @@ int m;
 
     /* look for this artifact in the discoveries list;
        if we hit an empty slot then it's undiscovered */
-    for (i = 0; i < NROFARTIFACTS; i++)
+    for (i = 0; i < nrofartifacts; i++)
 	if (artidisco[i] == m)
 	    return FALSE;
 	else if (artidisco[i] == 0)
@@ -2753,7 +2844,7 @@ winid tmpwin;		/* supplied by dodiscover() */
     int i, m, otyp;
     char buf[BUFSZ];
 
-    for (i = 0; i < NROFARTIFACTS; i++) {
+    for (i = 0; i < nrofartifacts; i++) {
 	if (artidisco[i] == 0) break;	/* empty slot implies end of list */
 	if (i == 0) putstr(tmpwin, iflags.menu_headings, "Artifacts");
 	m = artidisco[i];

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -538,7 +538,7 @@ struct obj *otmp;	/* existing object; NOT ignored even if alignment specified */
 		a->accuracy = max(1, rn2(5)*5);
 		a->damage = rn2(3)*10;
 
-		if (is_ammo(otmp) || throwing_weapon(otmp))
+		if (objects[otmp->otyp].oc_merge)
 			a->damage /= 2;
 		else {
 			if (a->adtyp > AD_MAGM && rn2(3))
@@ -568,7 +568,7 @@ struct obj *otmp;	/* existing object; NOT ignored even if alignment specified */
 		if (!rn2(60))
 			a->aflags |= ARTA_EXPLELEC;
 		
-		if (!rn2(90) && !(is_ammo(otmp) || throwing_weapon(otmp)))
+		if (!rn2(90) && !(objects[otmp->otyp].oc_merge))
 			a->iflags |= ARTI_BLOODTHRST;
 		if (!rn2(90))
 			a->aflags |= ARTA_VORPAL;
@@ -625,8 +625,8 @@ struct obj *otmp;	/* existing object; NOT ignored even if alignment specified */
 
 	otmp = oname(otmp, a->name);
 
-	if (is_ammo(otmp) || throwing_weapon(otmp)) {
-		set_obj_quan(otmp, 20);
+	if (objects[otmp->otyp].oc_merge) {
+		set_obj_quan(otmp, is_ammo(otmp) ? 20 : 10);
 	}
 
 	return otmp;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -538,17 +538,62 @@ struct obj *otmp;	/* existing object; NOT ignored even if alignment specified */
 		a->accuracy = max(1, rn2(5)*5);
 		a->damage = rn2(3)*10;
 
-		if (a->adtyp > AD_MAGM && rn2(3))
-			a->wprops[w++] = a->adtyp-1;	//assumes adtyp-1 == x_res, which is true from AD_FIRE to AD_ACID
-		if (!rn2(20) && w<8)
-			a->wprops[w++] = FAST;
-		if (!rn2(40) && w<8)
-			a->wprops[w++] = FREE_ACTION;
-	}
+		if (is_ammo(otmp) || throwing_weapon(otmp))
+			a->damage /= 2;
+		else {
+			if (a->adtyp > AD_MAGM && rn2(3))
+				a->wprops[w++] = a->adtyp-1;	//assumes adtyp-1 == x_res, which is true from AD_FIRE to AD_ACID
+			if (!rn2(30) && w<8)
+				a->wprops[w++] = FAST;
+			if (!rn2(60) && w<8)
+				a->wprops[w++] = FREE_ACTION;
+		}
 
-	if (otmp->oclass == ARMOR_CLASS) {
+		if (!rn2(20))
+			a->aflags |= ARTA_DEXPL;
+		else if (!rn2(20))
+			a->aflags |= ARTA_DLUCK;
+
+		if (!rn2(20) && a->alignment != A_LAWFUL)
+			a->aflags |= ARTA_POIS;
+		if (!rn2(40) && a->alignment == A_LAWFUL)
+			a->aflags |= ARTA_BRIGHT|ARTA_BLIND;
+		if (!rn2(60) && a->alignment != A_LAWFUL)
+			a->aflags |= ARTA_DRAIN;
+
+		if (!rn2(60))
+			a->aflags |= ARTA_EXPLFIRE;
+		if (!rn2(60))
+			a->aflags |= ARTA_EXPLCOLD;
+		if (!rn2(60))
+			a->aflags |= ARTA_EXPLELEC;
+		
+		if (!rn2(90) && !(is_ammo(otmp) || throwing_weapon(otmp)))
+			a->iflags |= ARTI_BLOODTHRST;
+		if (!rn2(90))
+			a->aflags |= ARTA_VORPAL;
+	}
+	else if ((is_gloves(otmp) && rn2(4)) ||	// 3/4 gloves
+			(is_boots(otmp) && !rn2(3))) {	// 1/3 boots
+		/* mix of offense (for unarmed) and defense */
+		a->adtyp = AD_PHYS;
+		a->accuracy = max(1, rn2(5)*3);
+		a->damage = rn2(3)*6;
+		/* some resistances, and maybe re-elementing the damage */
+		for (; w < rnd(3); w++) {
+			a->wprops[w++] = rnd(18);	/* FIRE_RES to TELEPORT_CONTROL */
+			if (a->wprops[w-1] == FIRE_RES || a->wprops[w-1] == COLD_RES ||
+				a->wprops[w-1] == ACID_RES || a->wprops[w-1] == SHOCK_RES) {
+				a->adtyp = a->wprops[w-1] + 1; //assumes x_res+1 == adtyp, which is true from AD_FIRE to AD_ACID
+				if (a->damage) a->damage += 4;
+			}
+		}
+		if (rn2(10))
+			a->iflags |= ARTI_PLUSSEV;
+	}
+	else if (otmp->oclass == ARMOR_CLASS) {
 		/* some resistances */
-		for (; w < rnd(4); w++) {
+		for (; w < (objects[otmp->otyp].oc_magic ? rnd(3) : rnd(4)+1); w++) {
 			a->wprops[w++] = rnd(18);	/* FIRE_RES to TELEPORT_CONTROL */
 		}
 		if (!rn2(10) && w<8)
@@ -559,9 +604,32 @@ struct obj *otmp;	/* existing object; NOT ignored even if alignment specified */
 			a->wprops[w++] = HALLUC_RES;
 		if (!rn2(20) && w<8)
 			a->wprops[w++] = FREE_ACTION;
+		if (!rn2(60) && w<8)
+			a->wprops[w++] = ENERGY_REGENERATION;
+		if (!rn2(60) && w<8)
+			a->wprops[w++] = HALF_SPDAM;
+		if (!rn2(60) && w<8)
+			a->wprops[w++] = HALF_PHDAM;
+
+		if (rn2(20))
+			a->iflags |= ARTI_PLUSSEV;
+
+		if (!rn2(30))
+			a->iflags |= ARTI_LUCK;
 	}
 
-	return oname(otmp, a->name);;
+	if (!rn2(3)) {
+		rand_interesting_obj_material(otmp);
+		a->material = otmp->obj_material;
+	}
+
+	otmp = oname(otmp, a->name);
+
+	if (is_ammo(otmp) || throwing_weapon(otmp)) {
+		set_obj_quan(otmp, 20);
+	}
+
+	return otmp;
 }
 
 /*

--- a/src/artilist.c
+++ b/src/artilist.c
@@ -45,8 +45,8 @@ static const char *artifact_names[] = {
 	 wpr, wfl, \
 	 cpr, cfl, \
 	 inv, ifl }
-
-NEARDATA struct artifact artilist[] = {
+struct artifact * artilist;
+NEARDATA struct artifact base_artilist[] = {
 #endif	/* MAKEDEFS_C */
 
 /* Artifact cost rationale:

--- a/src/bones.c
+++ b/src/bones.c
@@ -72,6 +72,11 @@ boolean restore;
 
 		if (restore && get_ox(otmp, OX_ENAM))
 			sanitize_name(ONAME(otmp));
+
+		if (!restore && otmp->oartifact > NROFARTIFACTS) {
+			/* randarts get cleared in bonesfiles */
+			otmp->oartifact = 0;
+		}
 		
 		if (((otmp->otyp != CORPSE || otmp->corpsenm < SPECIAL_PM)
 			&& otmp->otyp != STATUE)

--- a/src/invent.c
+++ b/src/invent.c
@@ -2976,19 +2976,46 @@ winid *datawin;
 				OBJPUTSTR(buf2);
 			}
 			/* other stuff
-			 * commented out because artifacts don't get any behaviours more interesting
-			 * than bonus damage (such as Vorpal Blade being vorpal)
 			 */
-//			buf[0] = '\0';
-//			ADDCLASSPROP((check_oprop(obj, OPROP_DEEPW && obj->spe < 8), "telepathically lashes out");
-//			ADDCLASSPROP((check_oprop(obj, OPROP_VORPW), "beheads creatures");
-//			ADDCLASSPROP((check_oprop(obj, OPROP_MORGW), "inflicts unhealing wounds while cursed");
-//			ADDCLASSPROP((check_oprop(obj, OPROP_FLAYW), "destroys armor");
-//			if (buf[0] != '\0')
-//			{
-//				Sprintf(buf2, "It %s.", buf);
-//				OBJPUTSTR(buf2);
-//			}
+			buf[0] = '\0';
+			ADDCLASSPROP((check_oprop(obj, OPROP_DEEPW && obj->spe < 8)), "telepathically lashes out");
+			ADDCLASSPROP((check_oprop(obj, OPROP_VORPW)), "is vorpal");
+			ADDCLASSPROP((check_oprop(obj, OPROP_MORGW)), "inflicts unhealing wounds while cursed");
+			ADDCLASSPROP((check_oprop(obj, OPROP_FLAYW)), "destroys armor");
+			if (buf[0] != '\0')
+			{
+				Sprintf(buf2, "It %s.", buf);
+				OBJPUTSTR(buf2);
+			}
+		}
+		/* other artifact weapon effects */
+		if (oartifact) {
+			register const struct artifact *oart = &artilist[oartifact];
+			buf[0] = '\0';
+			//ADDCLASSPROP((oart->aflags&ARTA_DEXPL), "weapon dice explode");
+			ADDCLASSPROP((oart->aflags&ARTA_DLUCK), "luck-biased");
+			ADDCLASSPROP((oart->aflags&ARTA_POIS), "always poisoned");
+			ADDCLASSPROP((oart->aflags&ARTA_SILVER), "silvered");
+			ADDCLASSPROP((oart->aflags&ARTA_VORPAL), "vorpal");
+			ADDCLASSPROP((oart->aflags&ARTA_CANCEL), "canceling");
+			ADDCLASSPROP((oart->aflags&ARTA_MAGIC), "magic-flourishing");
+			ADDCLASSPROP((oart->aflags&ARTA_DRAIN), "draining");
+			//ADDCLASSPROP((oart->aflags&ARTA_BRIGHT), " /* turns gremlins to dust and trolls to stone */");
+			ADDCLASSPROP((oart->aflags&ARTA_BLIND), "blinding");
+			ADDCLASSPROP((oart->aflags&ARTA_SHINING), "armor-phasing");
+			ADDCLASSPROP((oart->aflags&ARTA_SHATTER), "shattering");
+			ADDCLASSPROP((oart->aflags&ARTA_DISARM), "disarming");
+			ADDCLASSPROP((oart->aflags&ARTA_STEAL), "theiving");
+			//ADDCLASSPROP((oart->aflags&ARTA_HASTE), " /* hitting defender grants movement to attacker */");
+			ADDCLASSPROP((oart->aflags&(ARTA_EXPLFIRE|ARTA_EXPLFIREX)), " fire exploding");
+			ADDCLASSPROP((oart->aflags&(ARTA_EXPLCOLD|ARTA_EXPLCOLDX)), " cold exploding");
+			ADDCLASSPROP((oart->aflags&(ARTA_EXPLELEC|ARTA_EXPLELECX)), " shock exploding");
+			ADDCLASSPROP((oart->aflags&(ARTA_KNOCKBACK|ARTA_KNOCKBACKX)), "kinetic");
+			if (buf[0] != '\0')
+			{
+				Sprintf(buf2, "Attacks are %s.", buf);
+				OBJPUTSTR(buf2);
+			}
 		}
 		/* other weapon special effects */
 		if(obj){

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2006,6 +2006,35 @@ struct obj* obj;
 	return;
 }
 
+/* attempts to randomly give obj a rare material */
+void
+rand_interesting_obj_material(obj)
+struct obj * obj;
+{
+	const struct icp* random_mat_list;
+	int tries = 0;
+	int original_mat;
+
+	init_obj_material(obj);
+	original_mat = obj->obj_material;
+
+	/* randomized materials */
+	do {
+		random_mat_list = material_list(obj);
+		if (random_mat_list) {
+			int i = rnd(1000);
+			while (i > 0) {
+				if (i <= random_mat_list->iprob)
+					break;
+				i -= random_mat_list->iprob;
+				random_mat_list++;
+			}
+			if (random_mat_list->iclass) /* a 0 indicates to use default material */
+				set_material_gm(obj, random_mat_list->iclass);
+		}
+	} while (obj->obj_material == original_mat && ++tries<40);
+}
+
 /* "Game Master"-facing set material function.
  *  Should do the absolute minimum to make sure that obj is not in an inconsistent state after mat is set.
  *  In particular, it should never change the base object type.

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2559,7 +2559,7 @@ const char *str;
 
 			// This will catch all artifacts listed in artilist.h whose coded names begin with "The "
 			int i;
-			for (i = 1; i < NROFARTIFACTS && !insert_the; i++)
+			for (i = 1; i < n_artifacts() && !insert_the; i++)
 			{
 				if (!strncmp(artilist[i].name, "The ", 4) &&
 					((l = strlen(str)) >= strlen(artilist[i].name) - 4) &&

--- a/src/restore.c
+++ b/src/restore.c
@@ -500,6 +500,7 @@ unsigned int *stuckid, *steedid;	/* STEED */
 	}
 
 	/* this stuff comes after potential aborted restore attempts */
+	restore_artifacts(fd);
 	invent = restobjchn(fd, FALSE, FALSE);
 	bc_obj = restobjchn(fd, FALSE, FALSE);
 	while (bc_obj) {
@@ -549,7 +550,6 @@ unsigned int *stuckid, *steedid;	/* STEED */
 	ffruit = loadfruitchn(fd);
 
 	restnames(fd);
-	restore_artifacts(fd);
 	restore_waterlevel(fd);
 #ifdef RECORD_ACHIEVE
 	mread(fd, (genericptr_t) &achieve, sizeof achieve);

--- a/src/save.c
+++ b/src/save.c
@@ -334,6 +334,7 @@ register int fd, mode;
 		uball->nobj = bc_objs;
 		bc_objs = uball;
 	}
+	save_artifacts(fd);
 	saveobjchn(fd, invent, mode);
 	saveobjchn(fd, bc_objs, mode);
 	for(i=0;i<10;i++){
@@ -371,7 +372,6 @@ register int fd, mode;
 	bwrite(fd, (genericptr_t) &current_fruit, sizeof current_fruit);
 	savefruitchn(fd, mode);
 	savenames(fd, mode);
-	save_artifacts(fd);
 	save_waterlevel(fd, mode);
 #ifdef RECORD_ACHIEVE
 	bwrite(fd, (genericptr_t) &achieve, sizeof achieve);


### PR DESCRIPTION
Dynamically resizes the artifact arrays as needed to add new artifacts at will during a game!
Randarts can have names up to 63 characters long (`PL_PSIZ`). 
Randarts are de-artifact-ed when making bones.

The randart-generating function is a work-in-progress, is not called anywhere, and is just as much there to stress-test the functionality of the dynamic-artifact code than it is expected to generate real artifacts in a real game. I expect that the function will see significant changes and improvements before the code is accessible in a normal game.