### PR TITLE
Add sanity statuses (and suffocation status) to curses status line

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -551,7 +551,7 @@ nh_timeout()
 	if(Golded) golded_dialogue();
 	if(Slimed) slime_dialogue();
 	if(Vomiting) vomiting_dialogue();
-	if(Strangled && !Breathless) choke_dialogue();
+	if((Strangled || FrozenAir || BloodDrown) && !Breathless) choke_dialogue();
 	if(u.mtimedone && !--u.mtimedone) {
 		if (Unchanging)
 			u.mtimedone = rnd(100*youmonst.data->mlevel + 1);

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -93,6 +93,13 @@ static const struct statcolor default_colors[] = {
     {"Ill", CLR_BRIGHT_MAGENTA},
     {"FoodPois", CLR_BRIGHT_MAGENTA},
     {"Slime", CLR_BRIGHT_MAGENTA},
+    {"Sufct", CLR_BRIGHT_MAGENTA},
+    {"Panic", CLR_BRIGHT_CYAN},
+    {"Stmblng", CLR_BRIGHT_CYAN},
+    {"Stggrng", CLR_BRIGHT_CYAN},
+    {"Babble", CLR_BRIGHT_CYAN},
+    {"Scream", CLR_BRIGHT_CYAN},
+    {"Faint", CLR_BRIGHT_CYAN},
     {NULL, NO_COLOR},
 };
 
@@ -891,6 +898,14 @@ curses_add_statuses(WINDOW *win, boolean align_right,
     statprob("Ill",      (u.usick_type & SICK_NONVOMITABLE));
     statprob("FoodPois", (u.usick_type & SICK_VOMITABLE));
     statprob("Slime",    Slimed);
+    statprob("Sufct",    (FrozenAir || Strangled || BloodDrown));
+    /* Insanity subtroubles */
+    statprob("Panic",    Panicking);
+    statprob("Stmblng",  StumbleBlind);
+    statprob("Stggrng",  StaggerShock);
+    statprob("Babble",   Babble);
+    statprob("Scream",   Screaming);
+    statprob("Faint",    FaintingFits);
 
     /* Encumbrance */
     int enc = near_capacity();


### PR DESCRIPTION
Note: if the player has STATUSCOLORS enabled, they need to set colors for them in their rc file, or they will be gray.