### PR TITLE
Lillends cannot transmit lycanthropy via mask

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -4979,6 +4979,7 @@ boolean ranged;
 					&& !Protection_from_shape_changers
 					&& !arti_worn_prop(uwep, ARTP_NOWERE)
 					&& !umechanoid
+					&& is_were(pa)	/* or else Lillends can transmit lycanthropy via mask */
 					) {
 					You_feel("feverish.");
 					exercise(A_CON, FALSE);


### PR DESCRIPTION
All creatures with an AD_WERE attack also need to be MA_WERE.