### PR TITLE
Save player-as-a-lightsource

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -432,6 +432,8 @@ unsigned int *stuckid, *steedid;	/* STEED */
 #endif
 	mread(fd, (genericptr_t) &u, sizeof(struct you));
 	mread(fd, (genericptr_t) &youmonst, sizeof(struct monst));
+	if (youmonst.light)
+		rest_lightsource(LS_MONSTER, &youmonst, youmonst.light, fd, FALSE);
 	mread(fd, (genericptr_t) &god_list, sizeof(struct god_details)*MAX_GOD);
 	init_uasmon();
 #ifdef CLIPPING

--- a/src/save.c
+++ b/src/save.c
@@ -319,6 +319,8 @@ register int fd, mode;
 	bwrite(fd, (genericptr_t) &flags, sizeof(struct flag));
 	bwrite(fd, (genericptr_t) &u, sizeof(struct you));
 	bwrite(fd, (genericptr_t) &youmonst, sizeof(struct monst));
+	if (youmonst.light)
+		save_lightsource(youmonst.light, fd, mode);
 	bwrite(fd, (genericptr_t) &god_list, sizeof(struct god_details)*MAX_GOD);
 	
 	/* save random monsters*/


### PR DESCRIPTION
Or else `youmonst.light` will be a stale pointer after save/restore and cause a crash when rehumanizing, effectively killing the save.