### PR TITLE
Replace "Antimagic Shield" with "Abjuration"

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1536,7 +1536,7 @@ SPELL(("teleport away",   "gold"),        P_ESCAPE_SPELL,			15, 6, 1, IMMEDIATE,
 SPELL(("create familiar", "glittering"),  P_CLERIC_SPELL,			10, 6, 1, NODIR,     CLR_WHITE),
 SPELL(("cancellation",    "shining"),     P_MATTER_SPELL,			15, 6, 1, IMMEDIATE, CLR_WHITE),
 SPELL(("protection",	     "dull"),        P_CLERIC_SPELL,			18, 1, 1, NODIR,     HI_PAPER),
-SPELL(("antimagic shield","ebony"),		P_CLERIC_SPELL,			10, 5, 1, IMMEDIATE, CLR_BLACK),
+SPELL(("abjuration","ebony"),		P_CLERIC_SPELL,			10, 5, 1, IMMEDIATE, CLR_BLACK),
 SPELL(("jumping",	     "thin"),        P_ESCAPE_SPELL,			20, 1, 1, IMMEDIATE, HI_PAPER),
 SPELL(("stone to flesh",	 "thick"),       P_HEALING_SPELL,		15, 3, 1, IMMEDIATE, HI_PAPER),
 #if 0	/* DEFERRED */

--- a/src/objects.c
+++ b/src/objects.c
@@ -1536,7 +1536,7 @@ SPELL(("teleport away",   "gold"),        P_ESCAPE_SPELL,			15, 6, 1, IMMEDIATE,
 SPELL(("create familiar", "glittering"),  P_CLERIC_SPELL,			10, 6, 1, NODIR,     CLR_WHITE),
 SPELL(("cancellation",    "shining"),     P_MATTER_SPELL,			15, 6, 1, IMMEDIATE, CLR_WHITE),
 SPELL(("protection",	     "dull"),        P_CLERIC_SPELL,			18, 1, 1, NODIR,     HI_PAPER),
-SPELL(("abjuration","ebony"),		P_CLERIC_SPELL,			10, 5, 1, IMMEDIATE, CLR_BLACK),
+SPELL(("abjuration","ebony"),		P_CLERIC_SPELL,			10, 7, 1, NODIR, CLR_BLACK),
 SPELL(("jumping",	     "thin"),        P_ESCAPE_SPELL,			20, 1, 1, IMMEDIATE, HI_PAPER),
 SPELL(("stone to flesh",	 "thick"),       P_HEALING_SPELL,		15, 3, 1, IMMEDIATE, HI_PAPER),
 #if 0	/* DEFERRED */

--- a/src/read.c
+++ b/src/read.c
@@ -2531,9 +2531,8 @@ struct obj	*sobj;
 		(void) create_gas_cloud(cc.x, cc.y, 3+bcsign(sobj), 8+4*bcsign(sobj), TRUE);
 		break;
 	}
-	case SPE_ANTIMAGIC_SHIELD:
 	case SCR_ANTIMAGIC:{
-		int amt = (sobj->otyp == SPE_ANTIMAGIC_SHIELD) ? 50 : 400;
+		int amt = 400;
 		if(confused && sobj->cursed){
 			//Confused
 			pline("Shimmering sparks shoot into your body!");

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -3089,7 +3089,8 @@ int amt;
 	if (!esum) return;
 	if (esum->permanent) return;
 	if (!(tm = get_timer(mon->timed, DESUMMON_MON))) return;
-	adjust_timer_duration(tm, -min(amt, monstermoves - tm->timeout - 1));
+	adjust_timer_duration(tm, -min(amt, tm->timeout - monstermoves));
+	run_timers();
 }
 /* when a summoner dies or changes levels, all of its summons disappear */
 void


### PR DESCRIPTION
No one used antimagic shield and the spell was kinda boring. Kick it to the curb and say hello to Abjuration!

It attempts to dispel all adjacent summoned monsters. If they fail their `resist()`, they vanish. If they succeed their `resist()`, if they were a temporary summon to begin with, their duration is reduced (permanent summons are fully immune when they resist).

I gave it a quick test, and was it ever effective against the nastiest spellcasters, so I bumped it up to being a level 7 spell.