### PR TITLE
Move the player out of the way when generating levels

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1209,6 +1209,7 @@ int portal;
 	if (Punished) unplacebc();
 	u.utrap = 0;				/* needed in level_tele */
 	fill_pit(u.ux, u.uy);
+	u.ux = u.uy = 0;			/* temporary */
 	u.ustuck = 0;				/* idem */
 	u.uinwater = 0;
 	u.usubwater = 0;


### PR DESCRIPTION
This was actually potentially a major very-game-disrupting bug -- if your quest portal happened to spawn on the very x-y coord of your quest leader, they might not spawn at all!
At the very least, I tested that the Oracle and Axus could easily be zooped out of existance by careful placement and levelportation.