### PR TITLE
Add a level-generation test

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -274,6 +274,7 @@ E int NDECL(wiz_where);
 E int NDECL(wiz_wish);
 # endif /* WIZARD */
 #endif /* USE_TRAMPOLI */
+E int NDECL(wiz_makemap);
 E void NDECL(reset_occupations);
 E void FDECL(set_occupation, (int (*)(void),const char *,int));
 #ifdef REDO

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -137,7 +137,7 @@ STATIC_PTR int NDECL(wiz_mk_mapglyphdump);
 STATIC_PTR int NDECL(wiz_wish);
 STATIC_PTR int NDECL(wiz_identify);
 STATIC_PTR int NDECL(wiz_map);
-STATIC_PTR int NDECL(wiz_makemap);
+//STATIC_PTR int NDECL(wiz_makemap);
 STATIC_PTR int NDECL(wiz_genesis);
 STATIC_PTR int NDECL(wiz_where);
 STATIC_PTR int NDECL(wiz_detect);
@@ -1120,7 +1120,7 @@ wiz_identify()
 
 
 /* #wizmakemap - discard current dungeon level and replace with a new one */
-STATIC_PTR int
+int
 wiz_makemap(VOID_ARGS)
 {
     if (wizard) {


### PR DESCRIPTION
It sends the player to every level in every dungeon and calls `wiz_makemap()` repeatedly.
It does not check the endgame, nor ludios if the portal didn't spawn, and it can only check the selected Chaos quest for that game.