### PR TITLE
Suppress `rloc()`'s impossible in a safe circumstance

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -2003,10 +2003,14 @@ register int after;
 	if((mteleport(ptr)) && !rn2(5) && !mtmp->mcan &&
 	   !tele_restrict(mtmp) && !(noactions(mtmp))
 	) {
-	    if(mtmp->mhp < 7 || mtmp->mpeaceful || rn2(2))
-		(void) rloc(mtmp, FALSE);
+	    if(mtmp->mhp < 7 || mtmp->mpeaceful || rn2(2)) {
+			if (!rloc(mtmp, TRUE)) {
+				/* rloc failed, probably due to a full level; don't set mmoved=1 so can still attack later */
+				goto postmov;	
+			}
+		}
 	    else
-		mnexto(mtmp);
+			mnexto(mtmp);
 	    mmoved = 1;
 	    goto postmov;
 	}


### PR DESCRIPTION
A teleporting monster that already has a place on the map should not cause an `impossible()` when `rloc()` fails to find a new place for it. This can happen when the level is full, and the monster's current place is no longer acceptable (eg a boulder has been added to it). However, this is fine, since the monster remains in place.
Adjust behaviour appropriately: the monster that failed to teleport is still able to take other actions.