### PR TITLE
Most `rloc()` calls should suppress the impossible

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -4345,7 +4345,7 @@ struct monst *mon;
 		if(cansee(xlocale, ylocale)) pline("Dark waters swallow Nitocris!");
 		mtmp = revive(obj, FALSE);
 		if(mtmp)
-			rloc(mtmp, FALSE);
+			rloc(mtmp, TRUE);
 		return;//No further action.
 	}
 	if(!rn2(70)){
@@ -4456,7 +4456,7 @@ struct monst *mon;
 			if(cansee(xlocale, ylocale)) pline("Dark waters swallow Nitocris!");
 			mtmp = revive(obj, FALSE);
 			if(mtmp)
-				rloc(mtmp, FALSE);
+				rloc(mtmp, TRUE);
 		}
 		return;//No further action.
 	}

--- a/src/apply.c
+++ b/src/apply.c
@@ -1053,7 +1053,7 @@ struct obj *obj;
 		setnotworn(obj); /* in case mirror was wielded */
 		freeinv(obj);
 		(void) mpickobj(mtmp,obj);
-		if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+		if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 	} else if(!mtmp->mcan && !mtmp->minvis && is_weeping(mtmp->data)) {
 		if (vis)
 			pline ("%s stares at its reflection with a stony expression.", Monnam(mtmp));

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -710,7 +710,7 @@ register struct obj *obj;
 
 nopick:
 	if(!Blind) pline("%s", buf);
-	if (!tele_restrict(mon)) (void) rloc(mon, FALSE);
+	if (!tele_restrict(mon)) (void) rloc(mon, TRUE);
 	return(ret);
 }
 

--- a/src/minion.c
+++ b/src/minion.c
@@ -326,7 +326,7 @@ register struct monst *mtmp;
 	if (youracedata->mlet == S_DEMON) {	/* Won't blackmail their own. */
 	    pline("%s says, \"Good hunting, %s.\"",
 		  Amonnam(mtmp), flags.female ? "Sister" : "Brother");
-	    if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+	    if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 	    return(1);
 	}
 #ifndef GOLDOBJ

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -520,7 +520,7 @@ fixup_special()
 				for (y = 0; y<ROWNO; y++){
 					levl[x][y].lit = TRUE;
 					if (m_at(x, y) && !ACCESSIBLE(levl[x][y].typ))
-						rloc(m_at(x, y), FALSE);
+						rloc(m_at(x, y), TRUE);
 					if(OBJ_AT(x, y) && !ACCESSIBLE(levl[x][y].typ))
 						rlocos_at(x, y);
 					if(In_mithardir_desert(&u.uz) && IS_WALL(levl[x][y].typ)){
@@ -600,7 +600,7 @@ fixup_special()
 			for (x = 2; x <= x_maze_max; x++)
 			for (y = 2; y <= y_maze_max; y++){
 				if (m_at(x, y) && !ACCESSIBLE(levl[x][y].typ))
-					rloc(m_at(x, y), FALSE);
+					rloc(m_at(x, y), TRUE);
 			}
 		}
 		if (Is_sumall(&u.uz)){
@@ -608,7 +608,7 @@ fixup_special()
 			for (y = 2; y <= y_maze_max; y++){
 				if (levl[x][y].typ == STONE) levl[x][y].typ = HWALL;
 				if (levl[x][y].typ == ROOM) levl[x][y].lit = TRUE;
-				if (!ZAP_POS(levl[x][y].typ) && m_at(x, y)) rloc(m_at(x, y), FALSE);
+				if (!ZAP_POS(levl[x][y].typ) && m_at(x, y)) rloc(m_at(x, y), TRUE);
 			}
 			wallification(1, 1, COLNO - 1, ROWNO - 1);
 		}

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -5558,7 +5558,7 @@ register int edge; /* Allows room walls to intrude slightly into river. */
 	
 	if (typ!=TREE || (!edge && rn2(6))){
 		if(m_at(x, y))
-			rloc(m_at(x, y), FALSE);
+			rloc(m_at(x, y), TRUE);
 		levl[x][y].typ = MOAT;
 	}
 	// else if ((typ == SCORR || typ == CORR || IS_DOOR(typ)

--- a/src/mon.c
+++ b/src/mon.c
@@ -1440,7 +1440,7 @@ register struct monst *mtmp;
 	    if (mtmp->mhp > 0) {
 		(void) fire_damage(mtmp->minvent, FALSE, FALSE,
 						mtmp->mx, mtmp->my);
-		(void) rloc(mtmp, FALSE);
+		(void) rloc(mtmp, TRUE);
 		return 0;
 	    }
 	    return (1);
@@ -1468,7 +1468,7 @@ register struct monst *mtmp;
 	    }
 	    mondead(mtmp);
 	    if (mtmp->mhp > 0) {
-		(void) rloc(mtmp, FALSE);
+		(void) rloc(mtmp, TRUE);
 		water_damage(mtmp->minvent, FALSE, FALSE, level.flags.lethe, mtmp);
 		return 0;
 	    }

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1104,8 +1104,8 @@ register struct monst *mtmp;
 		&& !(noactions(mtmp))
 		&& !level.flags.noteleport
 	) {
-		(void) rloc(mtmp, FALSE);
-		return(0);
+		if (rloc(mtmp, TRUE))
+			return(0);
 	}
 	
 	if(mtmp->mtyp == PM_DRACAE_ELADRIN){
@@ -1118,7 +1118,7 @@ register struct monst *mtmp;
 			mtmp->mvar_dracaePregTimer += rnd(3);
 		} else if(!mtmp->mpeaceful){
 			int ox = mtmp->mx, oy = mtmp->my;
-			rloc(mtmp, FALSE);
+			rloc(mtmp, TRUE);
 			if(mtmp->mx != ox || mtmp->my != oy){
 				int type = mtmp->mvar_dracaePreg;
 				mtmp->mvar_dracaePreg = 0;
@@ -1506,7 +1506,7 @@ register struct monst *mtmp;
 
 			if (is_demon(youracedata)) {
 			  /* "Good hunting, brother" */
-			    if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+			    if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 			} else {
 			    mtmp->minvis = mtmp->perminvis = 0;
 			    /* Why?  For the same reason in real demon talk */
@@ -2507,8 +2507,8 @@ not_special:
 	} else {
 	    if(is_unicorn(ptr) && rn2(2) && !tele_restrict(mtmp) && !noactions(mtmp))
 		{
-			(void) rloc(mtmp, FALSE);
-			return(1);
+			if(rloc(mtmp, TRUE))
+				return(1);
 	    }
 	    if(mtmp->wormno) worm_nomove(mtmp);
 	}

--- a/src/muse.c
+++ b/src/muse.c
@@ -600,7 +600,7 @@ mon_tele:
 		    return 2;
 		}
 		if (oseen && how) makeknown(how);
-		(void) rloc(mtmp, FALSE);
+		(void) rloc(mtmp, TRUE);
 		return 2;
 	case MUSE_WAN_TELEPORTATION:
 		zap_oseen = oseen;
@@ -1280,7 +1280,7 @@ register struct monst *magr;
 			    mtmp->msleeping = 0;
 			    if(mtmp->m_ap_type) see_passive_mimic(mtmp);
 			} else if (!tele_restrict(mtmp))
-			    (void) rloc(mtmp, FALSE);
+			    (void) rloc(mtmp, TRUE);
 		}
 		break;
 	case WAN_CANCELLATION:

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3461,7 +3461,7 @@ tipmonster:
 				mtmp->mpeaceful = TRUE;
 				
 				if (!tele_restrict(mtmp)) {
-					(void)rloc(mtmp, FALSE);
+					(void)rloc(mtmp, TRUE);
 					if (canspotmon(mtmp))
 						pline("%s suddenly disappears!", Monnam(mtmp));
 				}

--- a/src/seduce.c
+++ b/src/seduce.c
@@ -219,7 +219,7 @@ struct monst * mon;
 		return 0;
 
 	/* teleport */
-	if (!tele_restrict(mon)) (void) rloc(mon, FALSE);
+	if (!tele_restrict(mon)) (void) rloc(mon, TRUE);
 
 	return 1;
 }
@@ -1001,7 +1001,7 @@ struct monst * mon;
 			break;
 	}
 	
-	if (!tele_restrict(mon)) (void) rloc(mon, FALSE);
+	if (!tele_restrict(mon)) (void) rloc(mon, TRUE);
 	return 1;
 }
 

--- a/src/steal.c
+++ b/src/steal.c
@@ -50,7 +50,7 @@ register struct monst *mtmp;
 	    pline("%s quickly snatches some gold from between your %s!",
 		    Monnam(mtmp), makeplural(body_part(FOOT)));
 	    if(!u.ugold || !rn2(5)) {
-		if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+		if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 		/* do not set mtmp->mavenge here; gold on the floor is fair game */
 		monflee(mtmp, 0, FALSE, FALSE);
 	    }
@@ -58,7 +58,7 @@ register struct monst *mtmp;
 	    u.ugold -= (tmp = somegold());
 	    Your("purse feels lighter.");
 	    mtmp->mgold += tmp;
-	if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+	if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 	    mtmp->mavenge = 1;
 	    monflee(mtmp, 0, FALSE, FALSE);
 	    flags.botl = 1;
@@ -119,7 +119,7 @@ register struct monst *mtmp;
 	    pline("%s quickly snatches some gold from between your %s!",
 		    Monnam(mtmp), makeplural(body_part(FOOT)));
 	    if(!ygold || !rn2(5)) {
-		if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+		if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 		monflee(mtmp, 0, FALSE, FALSE);
 	    }
 	} else if(ygold) {
@@ -130,7 +130,7 @@ register struct monst *mtmp;
             freeinv(ygold);
             add_to_minv(mtmp, ygold);
 	    Your("purse feels lighter.");
-	    if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+	    if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 	    monflee(mtmp, 0, FALSE, FALSE);
 	    flags.botl = 1;
 	}
@@ -162,7 +162,7 @@ stealarm(VOID_ARGS)
 			/* Implies seduction, "you gladly hand over ..."
 			   so we don't set mavenge bit here. */
 			monflee(mtmp, 0, FALSE, FALSE);
-			if (!tele_restrict(mtmp)) (void) rloc(mtmp, FALSE);
+			if (!tele_restrict(mtmp)) (void) rloc(mtmp, TRUE);
 			if(roll_madness(MAD_TALONS)){
 				You("panic after having your property stolen!!");
 				nomul(-1*rnd(6),"panic");
@@ -534,7 +534,7 @@ struct monst *mtmp;
 	(void) mpickobj(mtmp,otmp);	/* may merge and free otmp */
 	pline("%s stole %s!", Monnam(mtmp), doname(otmp));
 	if (mon_resistance(mtmp,TELEPORT) && !tele_restrict(mtmp))
-	    (void) rloc(mtmp, FALSE);
+	    (void) rloc(mtmp, TRUE);
     }
 }
 
@@ -578,7 +578,7 @@ struct monst *mtmp;
 	(void) mpickobj(mtmp,otmp);	/* may merge and free otmp */
 	pline("%s stole %s!", Monnam(mtmp), doname(otmp));
 	if (mon_resistance(mtmp,TELEPORT) && !tele_restrict(mtmp))
-	    (void) rloc(mtmp, FALSE);
+	    (void) rloc(mtmp, TRUE);
     }
 }
 

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1423,7 +1423,7 @@ struct monst *mtmp;
 		rloc_to(mtmp, c.x, c.y);
 		return;
 	}
-	(void) rloc(mtmp, FALSE);
+	(void) rloc(mtmp, TRUE);
 }
 
 boolean
@@ -1460,7 +1460,7 @@ int in_sight;
 	     * the guard isn't going to come for it...
 	     */
 	    if (trap->once) mvault_tele(mtmp);
-	    else (void) rloc(mtmp, FALSE);
+	    else (void) rloc(mtmp, TRUE);
 
 	    if (in_sight) {
 		if (canseemon(mtmp))

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -354,7 +354,7 @@ tactics(mtmp)
 			if(flags.stag && In_quest(&u.uz)){
 				if (In_W_tower(mtmp->mx, mtmp->my, &u.uz) ||
 					(mtmp->iswiz && !xdnstair && !mon_has_amulet(mtmp))) {
-					if (!rn2(3 + mtmp->mhp/10)) (void) rloc(mtmp, FALSE);
+					if (!rn2(3 + mtmp->mhp/10)) (void) rloc(mtmp, TRUE);
 				} else if (xdnstair &&
 					 (mtmp->mx != xdnstair || mtmp->my != ydnstair)) {
 					(void) mnearto(mtmp, xdnstair, ydnstair, TRUE);
@@ -362,7 +362,7 @@ tactics(mtmp)
 			} else {
 				if (In_W_tower(mtmp->mx, mtmp->my, &u.uz) ||
 					(mtmp->iswiz && !xupstair && !mon_has_amulet(mtmp))) {
-					if (!rn2(3 + mtmp->mhp/10)) (void) rloc(mtmp, FALSE);
+					if (!rn2(3 + mtmp->mhp/10)) (void) rloc(mtmp, TRUE);
 				} else if (xupstair &&
 					 (mtmp->mx != xupstair || mtmp->my != yupstair)) {
 					(void) mnearto(mtmp, xupstair, yupstair, TRUE);

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -6932,7 +6932,7 @@ boolean ranged;
 					pline("%s %s.", Monnam(magr), magr->minvent ?
 						"brags about the goods some dungeon explorer provided" :
 						"makes some remarks about how difficult theft is lately");
-					if (!tele_restrict(magr)) (void)rloc(magr, FALSE);
+					if (!tele_restrict(magr)) (void)rloc(magr, TRUE);
 					return MM_AGR_STOP;
 				}
 				else if (magr->mcan || engring || Chastity) {
@@ -6944,7 +6944,7 @@ boolean ranged;
 							(is_neuter(magr->data) || flags.female == magr->female) ? "unaffected" : "uninterested");
 					}
 					if (rn2(3)) {
-						if (!tele_restrict(magr)) (void)rloc(magr, FALSE);
+						if (!tele_restrict(magr)) (void)rloc(magr, TRUE);
 						return MM_AGR_STOP;
 					}
 					break;
@@ -6962,7 +6962,7 @@ boolean ranged;
 						return MM_AGR_STOP;
 					} else {
 						if (!tele_restrict(magr))
-							(void)rloc(magr, FALSE);
+							(void)rloc(magr, TRUE);
 						monflee(magr, 0, FALSE, FALSE);
 						return MM_AGR_STOP;
 					}
@@ -7039,7 +7039,7 @@ boolean ranged;
 					else if (magr->data->mlet == S_NYMPH &&
 						!tele_restrict(magr)
 					){
-						(void)rloc(magr, FALSE);
+						(void)rloc(magr, TRUE);
 						result |= MM_AGR_STOP;
 						if (vis && !canspotmon(magr))
 							pline("%s suddenly disappears!", buf);
@@ -7119,7 +7119,7 @@ boolean ranged;
 						pline("%s steals some gold from %s.", buf, mon_nam(mdef));
 					}
 					if (!tele_restrict(magr)) {
-						(void)rloc(magr, FALSE);
+						(void)rloc(magr, TRUE);
 						result |= MM_AGR_STOP;
 						if (vis && !canspotmon(magr))
 							pline("%s suddenly disappears!", Monnam(magr));
@@ -7239,7 +7239,7 @@ boolean ranged;
 				we'll get "it" in the suddenly disappears message */
 				if (vis) Strcpy(mdef_Monnam, Monnam(mdef));
 				mdef->mstrategy &= ~STRAT_WAITFORU;
-				(void)rloc(mdef, FALSE);
+				(void)rloc(mdef, TRUE);
 				result |= MM_AGR_STOP;	/* defender moved */
 				if (vis && !canspotmon(mdef)
 #ifdef STEED
@@ -7724,7 +7724,7 @@ boolean ranged;
 				if (!rn2(33)) {
 					/* run/teleport away */
 					if (!tele_restrict(magr))
-						(void)rloc(magr, FALSE);
+						(void)rloc(magr, TRUE);
 					monflee(magr, d(3, 6), TRUE, FALSE);
 					return MM_AGR_STOP;	/* maybe teleported away, definitely not continuing to attack */
 				}
@@ -7998,7 +7998,7 @@ boolean ranged;
 		/* hitter tries to teleport without making an attack */
 		if (!youagr) {
 			if (!tele_restrict(magr)) {
-				(void)rloc(magr, FALSE);
+				(void)rloc(magr, TRUE);
 				return MM_AGR_STOP;
 			}
 		}
@@ -11747,7 +11747,7 @@ int vis;
 				pline("%s %s.", Monnam(magr), magr->minvent ?
 					"brags about the goods some dungeon explorer provided" :
 					"makes some remarks about how difficult theft is lately");
-				if (!tele_restrict(magr)) (void)rloc(magr, FALSE);
+				if (!tele_restrict(magr)) (void)rloc(magr, TRUE);
 				return MM_AGR_STOP;
 			}
 			else if (magr->mcan || engring || Chastity) {
@@ -11758,7 +11758,7 @@ int vis;
 						(is_neuter(pa) || flags.female == magr->female) ? "unaffected" : "uninterested");
 				}
 				if (rn2(3)) {
-					if (!tele_restrict(magr)) (void)rloc(magr, FALSE);
+					if (!tele_restrict(magr)) (void)rloc(magr, TRUE);
 					return MM_AGR_STOP;
 				}
 				break;
@@ -11771,7 +11771,7 @@ int vis;
 				break;
 			default:
 				if (!is_animal(pa) && !tele_restrict(magr))
-					(void)rloc(magr, FALSE);
+					(void)rloc(magr, TRUE);
 				if (is_animal(pa) && *buf) {
 					if (canseemon(magr))
 						pline("%s tries to %s away with %s.",
@@ -15247,7 +15247,7 @@ int vis;						/* True if action is at all visible to the player */
 					tele();
 				}
 				else {
-					rloc(magr, FALSE);
+					rloc(magr, TRUE);
 				}
 				if (enexto(&cc, x(magr), y(magr), &mons[PM_URANIUM_IMP])) {
 					rloc_to(mdef, cc.x, cc.y);
@@ -15255,7 +15255,7 @@ int vis;						/* True if action is at all visible to the player */
 			}
 			else {
 				/* if no attacker, the uranium imp teleports at random */
-				rloc(mdef, FALSE);
+				rloc(mdef, TRUE);
 			}
 			
 			return MM_AGR_STOP;


### PR DESCRIPTION
`rloc()` should only `impossible()` if it failing could result in something bad, such as placing a monster on top of another monster.