### PR TITLE
When copying a variable-size xstruct, always reallocate

### DIFF
--- a/src/mextra.c
+++ b/src/mextra.c
@@ -134,7 +134,8 @@ int mx_id;
 	void * mx_p2;
 	if ((mx_p1 = get_mx(mon1, mx_id))) {
 		mx_p2 = get_mx(mon2, mx_id);
-		if(!mx_p2) {
+		if(!mx_p2 || mx_list[mx_id].s_size == -1) {
+			rem_mx(mon2, mx_id);
 			if (mx_list[mx_id].s_size != -1)
 				add_mx(mon2, mx_id);
 			else

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -516,6 +516,7 @@ register struct obj *otmp;
 	    subfrombill(otmp, shop_keeper(*u.ushops));
 	dummy = newobj(0);
 	*dummy = *otmp;
+	dummy->oextra_p = NULL;
 	dummy->where = OBJ_FREE;
 	dummy->o_id = flags.ident++;
 	if (!dummy->o_id) dummy->o_id = flags.ident++;	/* ident overflowed */

--- a/src/oextra.c
+++ b/src/oextra.c
@@ -130,7 +130,8 @@ int ox_id;
 	void * ox_p2;
 	if ((ox_p1 = get_ox(obj1, ox_id))) {
 		ox_p2 = get_ox(obj2, ox_id);
-		if(!ox_p2) {
+		if(!ox_p2 || ox_list[ox_id].s_size == -1) {
+			rem_ox(obj2, ox_id);
 			if (ox_list[ox_id].s_size != -1)
 				add_ox(obj2, ox_id);
 			else


### PR DESCRIPTION
Also, don't copy oextra pointers when duplicating an object in `bill_dummy_obj()`, that's what `cpy_ox()` is for.