### PR TITLE
Also set ->light pointer to NULL.

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -517,10 +517,12 @@ register struct obj *otmp;
 	dummy = newobj(0);
 	*dummy = *otmp;
 	dummy->oextra_p = NULL;
+	dummy->light = NULL;
+	dummy->timed = NULL;
+	dummy->mp = NULL;
 	dummy->where = OBJ_FREE;
 	dummy->o_id = flags.ident++;
 	if (!dummy->o_id) dummy->o_id = flags.ident++;	/* ident overflowed */
-	dummy->timed = 0;
 	register int ox_id;
 	for (ox_id=0; ox_id<NUM_OX; ox_id++)
 		cpy_ox(otmp, dummy, ox_id);


### PR DESCRIPTION
It took some trying to call `bill_dummy_object()` with a lightsource but it was doable and it caused a crash while saving.