### PR TITLE
Fix chaos2 mummies segfaulting

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1645,7 +1645,7 @@ E struct permonst * FDECL(permonst_of, (int, int));
 E struct attack *FDECL(attacktype_fordmg, (struct permonst *,int,int));
 E boolean FDECL(at_least_one_attack, (struct monst *));
 E boolean FDECL(attacktype, (struct permonst *,int));
-E boolean FDECL(mon_attacktype, (struct monst *,int));
+E struct attack *FDECL(mon_attacktype, (struct monst *,int));
 E boolean FDECL(noattacks, (struct permonst *));
 E int FDECL(attackindex, (struct permonst *,int,int));
 E boolean FDECL(poly_when_stoned, (struct permonst *));

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1457,7 +1457,7 @@ int atyp;
     return attacktype_fordmg(ptr, atyp, AD_ANY) ? TRUE : FALSE;
 }
 
-boolean
+struct attack *
 mon_attacktype(mon, atyp)
 struct monst *mon;
 int atyp;
@@ -1480,10 +1480,10 @@ int atyp;
 		attk = getattk(mon, (struct monst *) 0, res, &indexnum, &prev_attk, TRUE, &subout, &tohitmod)
 	){
 		if(attk->aatyp == atyp)
-			return TRUE;
+			return attk;
 	}
 
-    return FALSE;
+    return (struct attack *)0;
 }
 
 boolean

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -243,8 +243,8 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 			/* attacks that are on a line that do NOT stop on hit */
 			(m_online(magr, mdef, tarx, tary, dogbesafe, FALSE) && (
 				(mon_attacktype(magr, AT_BREA) && !magr->mcan) ||
-				(mon_attacktype(magr, AT_MAGC) && !magr->mcan && !real_spell_adtyp((attacktype_fordmg(magr->data, AT_MAGC, AD_ANY))->adtyp)) ||
-				(mon_attacktype(magr, AT_MMGC) && !magr->mcan && !real_spell_adtyp((attacktype_fordmg(magr->data, AT_MMGC, AD_ANY))->adtyp))
+				(mon_attacktype(magr, AT_MAGC) && !magr->mcan && !real_spell_adtyp(mon_attacktype(magr, AT_MAGC)->adtyp)) ||
+				(mon_attacktype(magr, AT_MMGC) && !magr->mcan && !real_spell_adtyp(mon_attacktype(magr, AT_MMGC)->adtyp))
 			))
 			||
 			/* attacks that splash */
@@ -289,8 +289,8 @@ int force_linedup;	/* if TRUE, we have some offensive item ready that will work 
 			(distmin(magr->mx, magr->my, tarx, tary) <= 8 && (
 				(is_commander(magr->data) && !rn2(4)) ||	/* !rn2(4) -> reduce command frequency */
 				(mon_attacktype(magr, AT_GAZE) && !magr->mcan) ||
-				(mon_attacktype(magr, AT_MAGC) && !magr->mcan && real_spell_adtyp((attacktype_fordmg(magr->data, AT_MAGC, AD_ANY))->adtyp)) ||
-				(mon_attacktype(magr, AT_MMGC) && !magr->mcan && real_spell_adtyp((attacktype_fordmg(magr->data, AT_MMGC, AD_ANY))->adtyp))
+				(mon_attacktype(magr, AT_MAGC) && !magr->mcan && real_spell_adtyp(mon_attacktype(magr, AT_MAGC)->adtyp)) ||
+				(mon_attacktype(magr, AT_MMGC) && !magr->mcan && real_spell_adtyp(mon_attacktype(magr, AT_MMGC)->adtyp))
 			))
 			))
 		{


### PR DESCRIPTION
`mon_attacktype()` was upgraded to see things that aren't in the monster statblock, but that means that the followup also needs to use it or else it'll fail to find the attack, so `->adtyp` crashes.