### PR TITLE
Fix bugs with dilution

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -4692,6 +4692,7 @@ mergable_traits(otmp, obj)	/* returns TRUE if obj  & otmp can be merged */
 	    obj->oeroded != otmp->oeroded ||
 	    obj->oeroded2 != otmp->oeroded2 ||
 	    obj->oeroded3 != otmp->oeroded3 ||
+		obj->odiluted != otmp->odiluted ||
 	    obj->obj_material != otmp->obj_material ||
 	    obj->bypass != otmp->bypass)
 	    return(FALSE);

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -797,11 +797,14 @@ struct obj *obj;
 char *buf;
 {
 	boolean iscrys = (obj->otyp == CRYSKNIFE);
-	if (!is_damageable(obj) && obj->otyp != MASK && !iscrys && !(obj->oclass == POTION_CLASS && obj->odiluted)) return;
+	if (!is_damageable(obj) && obj->otyp != MASK && !iscrys) return;
 
 	/* food uses oeroded to determine if it is rotten -- do not show this */
 	if (obj->oclass == FOOD_CLASS)
 		return;
+
+	if (obj->oclass == POTION_CLASS && obj->odiluted)
+		Strcat(buf, "diluted ");
 
 	if (obj->oeroded && !iscrys) {
 		switch (obj->oeroded) {
@@ -809,7 +812,6 @@ char *buf;
 		case 3:	Strcat(buf, "thoroughly "); break;
 		}
 		Strcat(buf, 
-			obj->oclass == POTION_CLASS ? "diluted " :
 			is_rustprone(obj) ? "rusty " :
 			is_evaporable(obj) ? "tenuous " :
 			is_flammable(obj) ? "burnt " : "eroded ");


### PR DESCRIPTION
Bugs coming from splitting `odiluted` off from `oeroded`
- Different dilution states were mergable
- Dilution wasn't being shown in object names