### PR TITLE
Numina doesn't grant Omnisense

### DIFF
--- a/src/sounds.c
+++ b/src/sounds.c
@@ -5189,7 +5189,6 @@ int floorID;
 	case NUMINA:
 		propchain[i++] = BLOCK_CONFUSION;
 		propchain[i++] = DETECT_MONSTERS;
-		propchain[i++] = OMNISENSE;
 		break;
 	}
 	/* add termintor */


### PR DESCRIPTION
Numina already grants `DETECT_MONSTERS`, which is level-wide monster *detection*. This is what it should be.

What `OMNISENSE` does is make infrared/blood/life/earth/all 'sense' cover the whole level, but these visiontypes are treated as 'sight' and not 'sense', which makes for awkward "I can see the foo, interrupt current action".