### PR TITLE
Adjust weight & resizing to remove arbitrary +1

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2360,8 +2360,9 @@ register struct obj *obj;
 			else wt = wt*difsize*difsize;
 		} else {
 			difsize = abs(difsize)+1;
-			if(obj->oclass == ARMOR_CLASS || obj->oclass == WEAPON_CLASS) wt = wt/(difsize) + 1;
-			else wt = wt/(difsize*difsize) + 1;
+			if(obj->oclass == ARMOR_CLASS || obj->oclass == WEAPON_CLASS) wt = wt/(difsize);
+			else wt = wt/(difsize*difsize);
+			if (wt < 1) wt = 1;
 		}
 	}
 	


### PR DESCRIPTION
Now, it increases to 1 if the wt was in danger of hitting 0. This reduces things like a small long sword going 40 -> 21 and therefore not technically being in bounds for basic two-weapon, and similarly for other weapons that were really bugging me. Thanks for coming to my TEDx Talk.