### PR TITLE
Allow the rakuyo generated in fishing hamlets to be an artifact

### DIFF
--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -2341,7 +2341,7 @@ mkwell(left)
 		}
 		
 		levl[x][y].typ = POOL;
-		mksobj_at(RAKUYO, x, y, NO_MKOBJ_FLAGS);
+		mksobj_at(RAKUYO, x, y, MKOBJ_ARTIF);
 	}
 }
 


### PR DESCRIPTION
Previously it never was, now it has a 1/20 chance to be like a normal floor item