### PR TITLE
Fix Rod of Force inspect skill

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -3062,10 +3062,8 @@ struct obj *obj;
 		else if(obj->otyp == DOUBLE_LIGHTSABER && !obj->altmode){
 			CHECK_ALTERNATE_SKILL(P_TWO_HANDED_SWORD)
 		}
-		else if(obj->otyp == ROD_OF_FORCE){
-			if(!uarms && !u.twoweap){
-				CHECK_ALTERNATE_SKILL(P_TWO_HANDED_SWORD)
-			}
+		else if(obj->otyp == ROD_OF_FORCE && !uarms && !u.twoweap){
+			CHECK_ALTERNATE_SKILL(P_TWO_HANDED_SWORD)
 		}
 		else if(obj->otyp == KHOPESH){
 			CHECK_ALTERNATE_SKILL(P_AXE)


### PR DESCRIPTION
If you had a shield or offhand weapon, it would not set a type before returning.