### PR TITLE
Fix ward-engraved-artifacts being unreadable

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -68,6 +68,7 @@ doread()
 			&& !(scroll->oclass == SPBOOK_CLASS)
 			&& !(scroll->oclass == AMULET_CLASS)
 			&& !arti_mandala(scroll)
+			&& !scroll->oward
 			&& scroll->oartifact != ART_ROD_OF_THE_ELVISH_LORDS
 		) || scroll->otyp==LIGHTSABER
 	){


### PR DESCRIPTION
Note: artifacts that DO have on-read effects will be unable to access those effects if they have a ward carved into them. Looking at you, Excalibur.