### PR TITLE
Pause timer processing on migrating mons/objs

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2817,6 +2817,8 @@ E void FDECL(cleanup_msummon, (genericptr_t, long));
 E void FDECL(desummon_obj, (genericptr_t, long));
 E void FDECL(summoner_gone, (struct monst *, boolean));
 E boolean FDECL(start_timer, (long, SHORT_P, SHORT_P, genericptr_t));
+E void FDECL(pause_timers, (timer_element *));
+E void FDECL(resume_timers, (timer_element *));
 E long FDECL(stop_timer, (SHORT_P, timer_element *));
 E void FDECL(stop_all_timers, (timer_element *));
 E void NDECL(run_timers);

--- a/src/dog.c
+++ b/src/dog.c
@@ -396,7 +396,6 @@ boolean with_you;
 	 * Its coordinate fields were overloaded for use as flags that
 	 * specify its final destination.
 	 */
-
 	if (mtmp->mlstmv < monstermoves - 1L) {
 	    /* heal monster for time spent in limbo */
 	    long nmv = monstermoves - 1L - mtmp->mlstmv;
@@ -513,6 +512,8 @@ boolean with_you;
 		mongone(mtmp);
 	    }
 	}
+	/* now that it's placed, we can resume timers (which may kill mtmp) */
+	resume_timers(mtmp->timed);
 }
 
 /* heal monster for time spent elsewhere */
@@ -868,6 +869,9 @@ migrate_to_level(mtmp, tolev, xyloc, cc)
 	}
 	/* likewise, a summoner leaving affects its summons */
 	summoner_gone(mtmp, TRUE);
+
+	/* timers pause processing while mon is migrating */
+	pause_timers(mtmp->timed);
 
 	relmon(mtmp);
 	mtmp->nmon = migrating_mons;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -1776,6 +1776,7 @@ obj_delivery()
 		otmp->ox = otmp->oy = 0;
 		rloco(otmp);
 	    }
+		resume_timers(otmp->timed);
 	}
 }
 

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -3299,7 +3299,8 @@ add_to_migration(obj)
 {
     if (obj->where != OBJ_FREE)
 	panic("add_to_migration: obj not free");
-
+	
+	pause_timers(obj->timed);
     obj->where = OBJ_MIGRATING;
     obj->nobj = migrating_objs;
     migrating_objs = obj;

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -2986,6 +2986,28 @@ timer_element * tm;
 	}
 }
 
+/* temporarily pause processing of all timers on chain until it they are resumed */
+void
+pause_timers(tm)
+timer_element * tm;
+{
+	timer_element *curr;
+	for (curr = tm; curr; curr = tm->tnxt)
+		rem_procchain_tm(curr);
+}
+
+/* resume processing of all timers on chain */
+void
+resume_timers(tm)
+timer_element * tm;
+{
+	timer_element *curr;
+	for (curr = tm; curr; curr = tm->tnxt)
+		add_procchain_tm(curr);
+	/* catch up with lost time */
+	run_timers();
+}
+
 void
 save_timers(tm, fd, mode)
 struct timer * tm;


### PR DESCRIPTION
Only do their timer things (like blow up, as a grenade, or desummon, as a monster or object) when actually on a level.
This makes sense -- migrating mons/objs should be thought of (in game) as "on another level", not "floating in the void".
Fixes a dmonsfree.