### PR TITLE
Wizlevelport menu, take two.

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -758,7 +758,7 @@ E boolean FDECL(Invocation_lev, (d_level *));
 E int NDECL(level_difficulty);
 E schar FDECL(lev_by_name, (const char *));
 #ifdef WIZARD
-E schar FDECL(print_dungeon, (BOOLEAN_P,schar *,int *));
+E boolean FDECL(print_dungeon, (BOOLEAN_P,BOOLEAN_P,schar *,int *));
 #endif
 E int NDECL(donamelevel);
 E int NDECL(dooverview);

--- a/include/flag.h
+++ b/include/flag.h
@@ -418,6 +418,7 @@ struct instance_flags {
 	int  travelplus;/* how far travel command should attempt to path through the unknown */
 	int	 runmode;	/* update screen display during run moves */
 	int delay_length;	/* length of delay for delay_output */
+	int wizlevelport;	/* options for ^V in wizmode */
 #ifdef AUTOPICKUP_EXCEPTIONS
 	struct autopickup_exception *autopickup_exceptions[2];
 #define AP_LEAVE 0
@@ -464,4 +465,9 @@ extern NEARDATA struct instance_flags iflags;
 #define RUN_STEP	2	/* update display every single step */
 #define RUN_CRAWL	3	/* walk w/ extra delay after each update */
 
+/* wizlevelport options */
+#define WIZLVLPORT_TRADITIONAL		0	/* Select levels directly */
+#define WIZLVLPORT_TWOMENU			1	/* Select a branch, then a level in that branch */
+#define WIZLVLPORT_BRANCHES_FIRST	2	/* With TWOMENU, don't show levels in each branch during 1st selection */
+#define WIZLVLPORT_SELECTED_DUNGEON	4	/* With TWOMENU, only show the levels of the selected branch during 2nd selection */
 #endif /* FLAG_H */

--- a/include/you.h
+++ b/include/you.h
@@ -64,6 +64,7 @@ struct u_event {
 #define ARTWISH_EARNED	1
 #define ARTWISH_SPENT	2
 	Bitfield(ascended,1);		/* has offered the Amulet */
+	Bitfield(knoxmade,1);		/* Portal to Ludios has been made in the main dungeon, teleport ok */
 };
 
 /* KMH, conduct --

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1305,7 +1305,7 @@ wiz_genesis()
 STATIC_PTR int
 wiz_where()
 {
-	if (wizard) (void) print_dungeon(FALSE, (schar *)0, (int *)0);
+	if (wizard) (void) print_dungeon(FALSE, FALSE, (schar *)0, (int *)0);
 	else	    pline("Unavailable command '^O'.");
 	return 0;
 }

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1959,11 +1959,12 @@ print_branch(win, dnum, lower_bound, upper_bound, bymenu, lchoices)
 }
 
 /* Print available dungeon information. */
-schar
-print_dungeon(bymenu, rlev, rdgn)
-boolean bymenu;
-schar *rlev;
-int *rdgn;
+boolean
+print_dungeon(bymenu, gotdgn, rlev, rdgn)
+boolean bymenu;	/* If TRUE, ask for input to select a level */
+boolean gotdgn;	/* Requires bymenu. If FALSE, select dungeon. If TRUE, select a level within rdgn. */
+schar *rlev;	/* returns selected level depth */
+int *rdgn;		/* returns selected level dungeon number */
 {
     int     i, last_level, nlev;
     char    buf[BUFSZ];
@@ -1974,109 +1975,149 @@ int *rdgn;
     anything any;
     struct lchoice lchoices;
 
+	boolean twopartmenu = iflags.wizlevelport;
+	boolean onlyselecteddungeon = (iflags.wizlevelport & WIZLVLPORT_SELECTED_DUNGEON);
+	boolean dungeonsfirst = (iflags.wizlevelport & WIZLVLPORT_BRANCHES_FIRST) && bymenu && !gotdgn;
+
     winid   win = create_nhwindow(NHW_MENU);
     if (bymenu) {
-	start_menu(win);
-	lchoices.idx = 0;
-	lchoices.menuletter = 'a';
+		start_menu(win);
+		lchoices.idx = 0;
+		lchoices.menuletter = 'a';
     }
 
     for (i = 0, dptr = dungeons; i < n_dgns; i++, dptr++) {
-	nlev = dptr->num_dunlevs;
-	if (nlev > 1)
-	    Sprintf(buf, "%s: levels %d to %d", dptr->dname, dptr->depth_start,
-						dptr->depth_start + nlev - 1);
-	else
-	    Sprintf(buf, "%s: level %d", dptr->dname, dptr->depth_start);
 
-	/* Most entrances are uninteresting. */
-	if (dptr->entry_lev != 1) {
-	    if (dptr->entry_lev == nlev)
-		Strcat(buf, ", entrance from below");
-	    else
-		Sprintf(eos(buf), ", entrance on %d",
-			dptr->depth_start + dptr->entry_lev - 1);
-	}
-	if (bymenu) {
-	    any.a_void = 0;
-	    add_menu(win, NO_GLYPH, &any, 0, 0, iflags.menu_headings, buf, MENU_UNSELECTED);
-	} else
-	    putstr(win, 0, buf);
+		/* OPTION: show only levels in selected dungeon on 2nd menu */
+		if (onlyselecteddungeon && gotdgn && (i != *rdgn))
+			continue;
+		/* floating branches cannot be teleported to - they must be anchored first */
+		if ((i == knox_level.dnum) && !u.uevent.knoxmade)
+			continue;
 
-	/*
-	 * Circle through the special levels to find levels that are in
-	 * this dungeon.
-	 */
-	for (slev = sp_levchn, last_level = 0; slev; slev = slev->next) {
-		if (slev->dlevel.dnum != i) continue;
-		
-		/* print any branches before this level */
-		print_branch(win, i, last_level, slev->dlevel.dlevel, bymenu, &lchoices);
-		
-		Sprintf(buf, "   %s: %d", slev->proto, depth(&slev->dlevel));
-		if (Is_stronghold(&slev->dlevel))
-		Sprintf(eos(buf), " (tune %s)", tune);
-		if (bymenu) {
-			/* If other floating branches are added, this will need to change */
-			if (i != knox_level.dnum) {
-			lchoices.lev[lchoices.idx] = slev->dlevel.dlevel;
-			lchoices.dgn[lchoices.idx] = i;
-		} else {
-			lchoices.lev[lchoices.idx] = depth(&slev->dlevel);
-			lchoices.dgn[lchoices.idx] = 0;
+		nlev = dptr->num_dunlevs;
+		if (nlev > 1)
+			Sprintf(buf, "%s: levels %d to %d", dptr->dname, dptr->depth_start,
+							dptr->depth_start + nlev - 1);
+		else
+			Sprintf(buf, "%s: level %d", dptr->dname, dptr->depth_start);
+
+		/* Most entrances are uninteresting. */
+		if (dptr->entry_lev != 1) {
+			if (dptr->entry_lev == nlev)
+			Strcat(buf, ", entrance from below");
+			else
+			Sprintf(eos(buf), ", entrance on %d",
+				dptr->depth_start + dptr->entry_lev - 1);
 		}
-		lchoices.playerlev[lchoices.idx] = depth(&slev->dlevel);
-		any.a_void = 0;
-		any.a_int = lchoices.idx + 1;
-		add_menu(win, NO_GLYPH, &any, lchoices.menuletter,
-				0, ATR_NONE, buf, MENU_UNSELECTED);
-		if (lchoices.menuletter == 'z') lchoices.menuletter = 'A';
-		else lchoices.menuletter++;
-		lchoices.idx++;
+
+		if (bymenu) {
+			if (!gotdgn && twopartmenu) {
+				any.a_int = lchoices.idx + 1;
+				lchoices.dgn[lchoices.idx] = i;
+				add_menu(win, NO_GLYPH, &any, lchoices.menuletter, 0, dungeonsfirst ? ATR_NONE : iflags.menu_headings, buf, MENU_UNSELECTED);
+				if (lchoices.menuletter == 'z') lchoices.menuletter = 'A';
+				else lchoices.menuletter++;
+				lchoices.idx++;
+			}
+			else {
+				any.a_void = 0;
+				add_menu(win, NO_GLYPH, &any, 0, 0, dungeonsfirst ? ATR_NONE : iflags.menu_headings, buf, MENU_UNSELECTED);
+			}
 		} else
-		putstr(win, 0, buf);
-		
-		last_level = slev->dlevel.dlevel;
-	}
-	/* print branches after the last special level */
-	print_branch(win, i, last_level, MAXLEVEL, bymenu, &lchoices);
+			putstr(win, 0, buf);
+
+		/*
+		* Circle through the special levels to find levels that are in
+		* this dungeon.
+		*/
+		if (!dungeonsfirst) {
+			for (slev = sp_levchn, last_level = 0; slev; slev = slev->next) {
+				if (slev->dlevel.dnum != i) continue;
+				
+				/* print any branches before this level */
+				print_branch(win, i, last_level, slev->dlevel.dlevel, (bymenu && ((gotdgn && i == *rdgn) || !twopartmenu)), &lchoices);
+				
+				Sprintf(buf, "   %s: %d", slev->proto, depth(&slev->dlevel));
+				if (Is_stronghold(&slev->dlevel))
+					Sprintf(eos(buf), " (tune %s)", tune);
+				if (bymenu) {
+					if ((gotdgn && i == *rdgn) || !twopartmenu) {
+						lchoices.lev[lchoices.idx] = slev->dlevel.dlevel;
+						lchoices.dgn[lchoices.idx] = i;
+						
+						lchoices.playerlev[lchoices.idx] = depth(&slev->dlevel);
+						any.a_void = 0;
+						any.a_int = lchoices.idx + 1;
+						add_menu(win, NO_GLYPH, &any, lchoices.menuletter,
+							0, ATR_NONE, buf, MENU_UNSELECTED);
+						if (lchoices.menuletter == 'z') lchoices.menuletter = 'A';
+						else lchoices.menuletter++;
+						lchoices.idx++;
+					}
+					else {
+						any.a_void = 0;
+						add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE, buf, MENU_UNSELECTED);
+					}
+				} else {
+					putstr(win, 0, buf);
+				}
+				last_level = slev->dlevel.dlevel;
+			}
+			/* print branches after the last special level */
+			print_branch(win, i, last_level, MAXLEVEL, (bymenu && ((gotdgn && i == *rdgn) || !twopartmenu)), &lchoices);
+		}
     }
 
     /* Print out floating branches (if any). */
     for (first = TRUE, br = branches; br; br = br->next) {
-	if (br->end1.dnum == n_dgns) {
-	    if (first) {
-	    	if (!bymenu) {
-		    putstr(win, 0, "");
-		    putstr(win, 0, "Floating branches");
+		if (br->end1.dnum == n_dgns) {
+			if (first) {
+				if (!bymenu) {
+				putstr(win, 0, "");
+				putstr(win, 0, "Floating branches");
+			}
+			first = FALSE;
+			}
+			Sprintf(buf, "   %s to %s",
+				br_string(br->type), dungeons[br->end2.dnum].dname);
+			if (!bymenu)
+			putstr(win, 0, buf);
 		}
-		first = FALSE;
-	    }
-	    Sprintf(buf, "   %s to %s",
-			br_string(br->type), dungeons[br->end2.dnum].dname);
-	    if (!bymenu)
-		putstr(win, 0, buf);
-	}
     }
     if (bymenu) {
     	int n;
-	menu_item *selected;
-	int idx;
+		menu_item *selected;
+		int idx;
 
-	end_menu(win, "Level teleport to where:");
-	n = select_menu(win, PICK_ONE, &selected);
-	destroy_nhwindow(win);
-	if (n > 0) {
-		idx = selected[0].item.a_int - 1;
-		free((genericptr_t)selected);
-		if (rlev && rdgn) {
-			*rlev = lchoices.lev[idx];
-			*rdgn = lchoices.dgn[idx];
-			return lchoices.playerlev[idx];
+		if (lchoices.idx > 1) {
+			end_menu(win, "Level teleport to where:");
+			n = select_menu(win, PICK_ONE, &selected);
+			destroy_nhwindow(win);
+			if (n > 0)
+				idx = selected[0].item.a_int - 1;
+			free((genericptr_t) selected);
 		}
+		else {
+			/* only one choice; don't bother showing it */
+			end_menu(win, "");
+			destroy_nhwindow(win);
+			idx = 0;
+			n = 1;
+		}
+		if (n > 0) {
+			if (!gotdgn && twopartmenu) {
+				*rdgn = lchoices.dgn[idx];
+				return print_dungeon(bymenu, TRUE, rlev, rdgn);
+			}
+			if (rlev && rdgn) {
+				*rlev = lchoices.lev[idx];
+				*rdgn = lchoices.dgn[idx];
+				return TRUE;
+			}
+		}
+		return FALSE;
 	}
-	return 0;
-    }
 
     /* I hate searching for the invocation pos while debugging. -dean */
     if (Invocation_lev(&u.uz)) {
@@ -2107,7 +2148,7 @@ int *rdgn;
 
     display_nhwindow(win, TRUE);
     destroy_nhwindow(win);
-    return 0;
+    return FALSE;
 }
 #endif /* WIZARD */
 

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -2284,6 +2284,7 @@ xchar x, y;
 	/* Adjust source to be current level and re-insert branch. */
 	*source = u.uz;
 	insert_branch(br, TRUE);
+	u.uevent.knoxmade = TRUE;
 
 #ifdef DEBUG
 	pline("Made knox portal.");


### PR DESCRIPTION
This time, without bugging it up in TTY, and making it optional for those who prefer the traditional ^V settings.

Option: `wizlevelport`.
Values: 0-7
 0 -- Traditional
 1 -- Two-Menu style; options below
 2 -- Only show branches in 1st menu
 4 -- Only show current branch in 2nd menu