### PR TITLE
No more dmonsfree errors

### DIFF
--- a/include/monst.h
+++ b/include/monst.h
@@ -157,6 +157,7 @@ struct monst {
 	Bitfield(mpetitioner,1);/* already dead (shouldn't leave a corpse) */ /*92*/
 	Bitfield(mdoubt,1);/* clerical spellcasting blocked */ /*93*/
 	Bitfield(menvy,1);/* wants only others stuff */ /*94*/
+	Bitfield(deadmonster,1); /* is DEADMONSTER */ /*95*/
 	
 	char mbdrown;	/* drowning in blood */
 	char mtaneggs;	/* tannin eggs */
@@ -319,7 +320,7 @@ struct monst {
 #define MON_SWEP(mon)	((mon)->msw)
 #define MON_NOSWEP(mon)	((mon)->msw = (struct obj *)0)
 
-#define DEADMONSTER(mon)	((mon) != &youmonst && (mon)->mhp < 1)
+#define DEADMONSTER(mon)	((mon) != &youmonst && (mon)->deadmonster)
 #define MIGRATINGMONSTER(mon)	((mon) != &youmonst && !(mon)->mx && !(mon)->my)
 
 #endif /* MONST_H */

--- a/src/mon.c
+++ b/src/mon.c
@@ -3387,7 +3387,7 @@ dmonsfree()
     int count = 0;
 
     for (mtmp = &fmon; *mtmp;) {
-	if ((*mtmp)->mhp <= 0) {
+	if (DEADMONSTER(*mtmp)) {
 	    struct monst *freetmp = *mtmp;
 	    *mtmp = (*mtmp)->nmon;
 		rem_all_mx(freetmp);
@@ -3479,6 +3479,10 @@ m_detach(mtmp, mptr)
 struct monst *mtmp;
 struct permonst *mptr;	/* reflects mtmp->data _prior_ to mtmp's death */
 {
+	if(mtmp->deadmonster) {
+		impossible("attempting to detach deadmonster %s", m_monnam(mtmp));
+		return;
+	}
 	if (mtmp->mleashed) m_unleash(mtmp, FALSE);
 	    /* to prevent an infinite relobj-flooreffects-hmon-killed loop */
 	mtmp->mtrapped = 0;
@@ -3494,6 +3498,8 @@ struct permonst *mptr;	/* reflects mtmp->data _prior_ to mtmp's death */
 
 	if(mtmp->isshk) shkgone(mtmp);
 	if(mtmp->wormno) wormgone(mtmp);
+
+	mtmp->deadmonster = 1;
 	iflags.purge_monsters++;
 }
 


### PR DESCRIPTION
Instead, make the `impossible()` as soon as the monster is double-killed. This will make debugging much easier.