### PR TITLE
Don't `impossible()` on failing to find a light/timer in processing c…

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -96,7 +96,6 @@ struct ls_t * ls;
 			return;
 		}
 	}
-	impossible("couldn't find ls in processing chain");
 	return;
 }
 

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -2858,7 +2858,6 @@ timer_element * tm;
 			return;
 		}
 	}
-	impossible("couldn't find tm in processing chain");
 	return;
 }
 


### PR DESCRIPTION
…hain

That's how we pause processing >_>
They're stored on the local chain, anyways -- if we don't find them *there* we have problems.