### PR TITLE
Confused cursed scrolls of consecration desecrate wielded weapons

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2703,12 +2703,20 @@ struct obj	*sobj;
 	if (confused) {
 		/* consecrates your weapon */
 		/* NOT valid_weapon(), which also allows non-enchantable things that are effective to hit with */
-		if (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep))) {
-			bless(uwep);
-			if (!check_oprop(uwep, OPROP_HOLYW))
-				add_oprop(uwep, OPROP_LESSER_HOLYW);
-			if(uwep->spe < 3)
-				uwep->spe = 3;
+		if (uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || is_gloves(uwep))) {
+			if (sobj->cursed){
+				curse(uwep);
+				if (!check_oprop(uwep, OPROP_UNHYW))
+					add_oprop(uwep, OPROP_LESSER_UNHYW);
+				if(uwep->spe < 3)
+					uwep->spe = 3;
+			} else { // blessed/uncursed
+				bless(uwep);
+				if (!check_oprop(uwep, OPROP_HOLYW))
+					add_oprop(uwep, OPROP_LESSER_HOLYW);
+				if(uwep->spe < 3)
+					uwep->spe = 3;
+			} 
 		}
 		else {
 			goto returnscroll;

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -5985,7 +5985,7 @@ doblessmenu()
 			MENU_UNSELECTED);
 	}
 	incntlet++; //Advance anyway
-	if(uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && !check_oprop(uwep, OPROP_HOLYW)){
+	if(uwep && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep) || is_gloves(uwep)) && !check_oprop(uwep, OPROP_HOLYW)){
 		Sprintf(buf, "Sanctify your weapon");
 		any.a_int = SANCTIFY_WEP;	/* must be non-zero */
 		add_menu(tmpwin, NO_GLYPH, &any,


### PR DESCRIPTION
Also allows you to consecrate/desecrate wielded gloves (not worn!) since that feels cool. Uncursed consecration remains unchanged (consecrates).