### PR TITLE
A Healer's self-targeted spells also hit their pets

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -2491,10 +2491,12 @@ boolean ordinary;
 	int	damage = 0;
 	char buf[BUFSZ];
 
-    if (Role_if(PM_HEALER))
+    if (Role_if(PM_HEALER)) {
+        struct monst *mtmp;
         for (mtmp = fmon; mtmp; mtmp = mtmp->nmon)
             if (mtmp->mtame)
                 bhitm(mtmp, obj);
+    }
 
 	switch(obj->otyp) {
 		case WAN_STRIKING:

--- a/src/zap.c
+++ b/src/zap.c
@@ -2491,6 +2491,11 @@ boolean ordinary;
 	int	damage = 0;
 	char buf[BUFSZ];
 
+    if (Role_if(PM_HEALER))
+        for (mtmp = fmon; mtmp; mtmp = mtmp->nmon)
+            if (mtmp->mtame)
+                bhitm(mtmp, obj);
+
 	switch(obj->otyp) {
 		case WAN_STRIKING:
 		    makeknown(WAN_STRIKING);


### PR DESCRIPTION
Applies to spells aimed at self, not ray bounces. Primarily intended for
healing the squad, but no one is enforcing fireball safety regulations.

When attempting to test this, I encountered the following error:
```
cc -g -Wno-knr-promoted-parameter -Iinclude -DDLB -Wall -Wno-comment -Wno-unused-variable -Wno-misleading-indentation -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-label -Wno-unknown-pragmas -Wno-missing-braces -Wno-format-overflow -MMD -MP -c -o src/allmain.o src/allmain.c
In file included from include/hack.h:117,
                 from src/allmain.c:8:
include/decl.h:536:10: fatal error: gnames.h: No such file or directory
  536 | #include "gnames.h"
      |          ^~~~~~~~~~
compilation terminated.
make: *** [GNUmakefile:126: src/allmain.o] Error 1
```

I have a working build of 3.19.1, so I'm not sure what has changed in the interim.