### PR TITLE
Make `MM_MISS` return mean no time taken, not miss.

### DIFF
--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -1094,7 +1094,7 @@ register int after;	/* this is extra fast monster movement */
 				if (res & MM_AGR_DIED)
 					return 2; /* Oops, died */
 
-				if (!(mon_ranged_gazeonly) && (res & MM_HIT))
+				if (!(mon_ranged_gazeonly) && (res & (MM_HIT|MM_AGR_STOP)))
 					return 1; /* that was our move for the round */
 			}
 		}
@@ -1161,7 +1161,10 @@ register int after;	/* this is extra fast monster movement */
 			if (mstatus & MM_DEF_DIED) return 2;
 		    }
 
-		    return 0;
+			if (mstatus != MM_MISS)
+		    	return 0;
+			else
+				continue;	/* go to next possible place to move */
 		}
 
 		{   /* Dog avoids harmful traps, but perhaps it has to pass one

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -1732,7 +1732,7 @@ const char * spellname[] =
  * Magr attempts to cast a monster spell at mdef, who they think is at (tarx, tary)
  * If !mdef or (tarx, tary) is (0,0), magr doesn't have a target and should use an undirected spell.
  * 
- * Returns MM_MISS if the spellcasting failed
+ * Returns MM_MISS if the spellcasting failed and took no time
  * 
  * Can handle any of uvm, mvm, mvu.
  *
@@ -1810,7 +1810,7 @@ int tary;
 		(needs_familiar(magr))
 		)) {
 		cursetxt(magr, mdef, is_undirected_spell(spellnum));
-		return MM_MISS;
+		return MM_HIT;
 	}
 
 	/* At this point, magr is committing to attempting to cast a spell */
@@ -1858,7 +1858,7 @@ int tary;
 		if (!youagr && youdef) {
 			magr->mux = magr->muy = 0;
 		}
-		return MM_MISS;
+		return MM_HIT;
 	}
 
 	/* interrupt the player if the player is being targeted (comes after filtering out spells that miss and fizzle entirely) */
@@ -1913,7 +1913,7 @@ int tary;
 			if (magr->mspec_used)
 				magr->mspec_used /= 2;
 		}
-		return MM_MISS;
+		return MM_HIT;
 	}
 
 	/* print spell-cast message */
@@ -2011,7 +2011,7 @@ int tary;
 			/* get a direction to cast in (assumes ranged spell is possible) */
 			if (!getdir((const char *)0)) {
 				pline_The("air crackles around you.");
-				return MM_MISS;
+				return MM_HIT;
 			}
 			else {
 				rangedspell = TRUE;
@@ -2025,7 +2025,7 @@ int tary;
 				pline_The("air crackles around %s.", mon_nam(magr));
 			impossible("monster got to elemspell() with no target location?"); // test; does this happen?
 			pline("%s is attempting to cast at %s.", Monnam(magr), mdef ? mon_nam(mdef) : "no target");
-			return MM_MISS;
+			return MM_HIT;
 		}
 	}
 	else if (foundem && dist2(x(magr), y(magr), tarx, tary) <= 2) {
@@ -2050,7 +2050,7 @@ int tary;
 					levl[tarx][tary].typ == WATER
 					? "empty water" : "thin air");
 			}
-			return MM_MISS;
+			return MM_HIT;
 		}
 		/* otherwise, print a spellcasting message */
 		else {
@@ -3060,7 +3060,7 @@ int tary;
 				}
 				//else damage
 			}
-			else return MM_MISS;
+			else return MM_HIT;	/* no effect but spell was cast */
 		}
 		return xdamagey(magr, mdef, attk, dmg);
 
@@ -3285,7 +3285,7 @@ int tary;
 				if (youagr || youdef || canseemon(mdef))
 					pline("Silver rays whiz past %s!",
 					youdef ? "you" : mon_nam(mdef));
-				return MM_MISS;
+				return MM_HIT;
 			}
 			if (n == 1)
 				rays = "a ray";

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1933,7 +1933,7 @@ register struct monst *mtmp;
 			if (res & MM_AGR_DIED)
 				return 1; /* Oops. */
 
-			if(!(mon_ranged_gazeonly) && (res & MM_HIT))
+			if(!(mon_ranged_gazeonly) && (res & (MM_HIT|MM_AGR_STOP)))
 				return 0; /* that was our move for the round */
 		}
 	}
@@ -2170,7 +2170,7 @@ register int after;
 	    if((dist2(mtmp->mx, mtmp->my, tx, ty) < 2) &&
 	       intruder && (intruder != mtmp)) {
 			notonhead = (intruder->mx != tx || intruder->my != ty);
-			if(mattackm(mtmp, intruder) == 2) return(2);
+			if(mattackm(mtmp, intruder) & MM_AGR_DIED) return(2);
 			mmoved = 1;
 			goto postmov;
 		} else if(mtmp->mtyp != PM_DEMOGORGON 
@@ -2681,7 +2681,7 @@ not_special:
 		    notonhead = 0;
 		    mstatus = mattackm(mtmp2, mtmp);	/* return attack */
 		    if (mstatus & MM_DEF_DIED)
-			return 2;
+				return 2;
 		}
 		return 3;
 	    }

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -301,8 +301,8 @@ atk_done:
  * Monster to monster attacks.  When a monster attacks another (mattackm),
  * any or all of the following can be returned.  See mattackm() for more
  * details.
- * MM_MISS		0x00	aggressor missed
- * MM_HIT		0x01	aggressor hit defender
+ * MM_MISS		0x00	aggressor did not make any attacks
+ * MM_HIT		0x01	aggressor attacked defender
  * MM_DEF_DIED	0x02	defender died
  * MM_AGR_DIED	0x04	aggressor died
  * MM_AGR_STOP	0x08	aggressor must stop attacking for some reason
@@ -403,7 +403,7 @@ int tary;
 	/* monsters may be in for a surprise if attacking a hidden player */
 	if (youdef && !ranged && !missedyou && !u.uswallow) {
 		if (u_surprise(magr, canseemon(magr)))
-			return MM_MISS;	/* they can't attack this turn */
+			return MM_AGR_STOP;	/* they can't attack this turn */
 	}
 
 	/*	Special demon/minion handling code */
@@ -455,7 +455,7 @@ int tary;
 				pline("%s%s!", upstart(buf), from_nowhere);
 			    }
 				/* help came, that was their action */
-				return MM_MISS;
+				return MM_AGR_STOP;
 			} /* else no help came; but you didn't know it tried */
 		}
 	    }
@@ -3965,8 +3965,8 @@ boolean ranged;
  * Monster to monster attacks.  When a monster attacks another (mattackm),
  * any or all of the following can be returned.  See mattackm() for more
  * details.
- * MM_MISS		0x00	aggressor missed
- * MM_HIT		0x01	aggressor hit defender
+ * MM_MISS		0x00	aggressor cancelled attacking
+ * MM_HIT		0x01	aggressor attacked defender
  * MM_DEF_DIED	0x02	defender died
  * MM_AGR_DIED	0x04	aggressor died
  *
@@ -5726,7 +5726,7 @@ boolean ranged;
 				else
 					pline("%s whispers banal platitudes in %s %s.", Monnam(magr), s_suffix(mon_nam(mdef)), mbodypart(mdef, EAR));
 			}
-			return MM_MISS;
+			return MM_HIT;
 		}
 		if(vis && dohitmsg){
 			if(youagr)
@@ -6041,7 +6041,7 @@ boolean ranged;
 					(youdef ? "you" : mon_nam(mdef))
 					);
 			}
-			return MM_MISS;
+			return MM_HIT;	/* took time */
 		}
 		else {
 			/* print basic hit message */
@@ -6399,7 +6399,7 @@ boolean ranged;
 		/* does nothing at all to noncorporeal or amoprhous creatures */
 		if (noncorporeal(pd) || amorphous(pd))
 		{
-			/* no hitmessage, either */
+			/* skipped, takes no time */
 			return MM_MISS;
 		}
 		else {
@@ -7321,12 +7321,12 @@ boolean ranged;
 				Levitation || Flying) {
 				pline("%s tries to reach your %s %s!", Monnam(magr),
 					sidestr, body_part(LEG));
-				return MM_MISS;
+				return MM_HIT;
 			}
 			else if (magr->mcan) {
 				pline("%s nuzzles against your %s %s!", Monnam(magr),
 					sidestr, body_part(LEG));
-				return MM_MISS;
+				return MM_HIT;
 			}
 			else {
 				if (uarmf) {
@@ -7688,7 +7688,7 @@ boolean ranged;
 				}
 				/* give the player some space */
 				monflee(magr, d(3, 6), TRUE, FALSE);
-				/* and miss */
+				/* and doesn't take time */
 				return (MM_MISS);
 			}
 		}
@@ -7736,7 +7736,7 @@ boolean ranged;
 				if (slips_free(magr, mdef, attk, vis)) {
 					/* message was printed (if visible) */
 					/* nothing happens */
-					return MM_MISS;
+					return MM_HIT;
 				}
 				else {
 					/* get stuck */
@@ -7853,8 +7853,8 @@ boolean ranged;
 							body_part(LEG));
 					}
 				}
-				/* return miss -- nothing happens */
-				return MM_MISS;
+				/* return miss -- nothing happens, but took time */
+				return MM_HIT;
 			}
 		}
 		/* make physical attack without hitmsg */
@@ -10746,7 +10746,7 @@ int vis;
 			}
 			else {
 				You("avoid the gaze of the right head of Demogorgon!");
-				return MM_MISS;
+				return MM_HIT;
 			}
 		}
 		else {
@@ -17701,5 +17701,5 @@ struct monst * mdef;
 			}
 		break;
 	}
-	return MM_MISS;
+	return MM_HIT;
 }

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -589,7 +589,7 @@ register struct monst *mtmp;
 
 int
 mattackm(magr, mdef)
-register struct monst *magr, *mdef;
+struct monst *magr, *mdef;
 {
 	/* this needs both attacker and defender, currently */
 	if (!magr || !mdef)
@@ -681,7 +681,7 @@ fightm(mtmp)		/* have monsters fight each other */
 		    }
 			
 			//If was conflict and a miss, can continue to attack.  Otherwise, ignore you.
-		    return (((result & MM_HIT) || !conflict) ? 1 : 0);
+		    return (((result & (MM_HIT|MM_AGR_STOP)) || !conflict) ? 1 : 0);
 		}
 	    }
 	}


### PR DESCRIPTION
Fix pets doing nothing if they try to attack something and their attack chain does utterly nothing (incl. messages, like wild misses).

Would need to rewrite monster movement to be able to fix this for non-tame mon v mon combat -- they pick the square to moveto/attack too strongly at the moment to retarget.