### PR TITLE
Fix the sack in the grue des files

### DIFF
--- a/dat/grue.des
+++ b/dat/grue.des
@@ -104,7 +104,7 @@ STAIR:(68,10),down
 
 # Treasure
 OBJECT:'#',"uncharged lantern",(62,18)
-OBJECT:'(',"sack",(62,18)
+CONTAINER:'(',"sack",(62,18)
 OBJECT:'#',"+2 blessed wrathful silver elven broadsword",contained
 OBJECT:'#',"platinum bar",contained
 
@@ -270,7 +270,7 @@ STAIR:(66,15),down
 
 # Treasure
 OBJECT:'#',"uncharged lantern",(67,17)
-OBJECT:'(',"sack",(67,17)
+CONTAINER:'(',"sack",(67,17)
 OBJECT:'#',"+2 blessed wrathful silver elven broadsword",contained
 OBJECT:'#',"platinum bar",contained
 


### PR DESCRIPTION
This should be marked with CONTAINER rather than OBJECT as the two
following objects are intended to be contained there

Without that, entering the level could throw impossibles, or worse have
container refer to a stale object and crash

fixes #1889 