### PR TITLE
Expand `deadmonster` to 2 bits to mark 'dead' as well as 'purge'.

### DIFF
--- a/include/monst.h
+++ b/include/monst.h
@@ -178,8 +178,11 @@ struct monst {
 	Bitfield(mtoobig,1);/* elevated spell failure */ /*111*/
 	Bitfield(mrotting,1);/* spreads poison clouds */ /*112*/
 	
-	Bitfield(deadmonster,1); /* is DEADMONSTER */ /*113*/
-	Bitfield(mnoise,1); /* is DEADMONSTER */ /*114*/
+	Bitfield(deadmonster,2); /* is DEADMONSTER */ /*114*/
+#define DEADMONSTER_DEAD	0x1
+#define DEADMONSTER_PURGE	0x2
+#define DEADMONSTER(mon)	((mon) != &youmonst && (mon)->deadmonster)
+	Bitfield(mnoise,1); /* made noise in the last turn (dochug) */ /*115*/
 	
 	unsigned long long int 	seenmadnesses;	/* monster has seen these madnesses */
 	
@@ -350,7 +353,6 @@ struct monst {
 #define MON_SWEP(mon)	((mon)->msw)
 #define MON_NOSWEP(mon)	((mon)->msw = (struct obj *)0)
 
-#define DEADMONSTER(mon)	((mon) != &youmonst && (mon)->deadmonster)
 #define MIGRATINGMONSTER(mon)	((mon) != &youmonst && !(mon)->mx && !(mon)->my)
 
 #endif /* MONST_H */

--- a/src/mon.c
+++ b/src/mon.c
@@ -3484,8 +3484,8 @@ m_detach(mtmp, mptr)
 struct monst *mtmp;
 struct permonst *mptr;	/* reflects mtmp->data _prior_ to mtmp's death */
 {
-	if(mtmp->deadmonster) {
-		impossible("attempting to detach deadmonster %s", m_monnam(mtmp));
+	if(mtmp->deadmonster & DEADMONSTER_PURGE) {
+		impossible("attempting to detach already-marked deadmonster %s", m_monnam(mtmp));
 		return;
 	}
 	if (mtmp->mleashed) m_unleash(mtmp, FALSE);
@@ -3504,7 +3504,7 @@ struct permonst *mptr;	/* reflects mtmp->data _prior_ to mtmp's death */
 	if(mtmp->isshk) shkgone(mtmp);
 	if(mtmp->wormno) wormgone(mtmp);
 
-	mtmp->deadmonster = 1;
+	mtmp->deadmonster |= DEADMONSTER_PURGE;
 	iflags.purge_monsters++;
 }
 
@@ -3960,6 +3960,8 @@ register struct monst *mtmp;
 	}
 	lifesaved_monster(mtmp);
 	if (mtmp->mhp > 0) return;
+	/* we did not lifesave */
+	mtmp->deadmonster |= DEADMONSTER_DEAD;
 	//Special messages (Nyarlathotep)
 	if(canseemon(mtmp) && (mtmp->mtyp == PM_GOOD_NEIGHBOR || mtmp->mtyp == PM_HMNYW_PHARAOH)){
 		int nyar_form = rn2(SIZE(nyar_description));
@@ -4804,6 +4806,8 @@ register struct monst *mdef;
 {
 	mondead(mdef);
 	if (mdef->mhp > 0) return;	/* lifesaved */
+	/* we did not lifesave */
+	mdef->deadmonster |= DEADMONSTER_DEAD;
 
 	if (corpse_chance(mdef, (struct monst *)0, FALSE) &&
 	    (accessible(mdef->mx, mdef->my) || is_pool(mdef->mx, mdef->my, FALSE)))
@@ -4816,6 +4820,7 @@ mongone(mdef)
 register struct monst *mdef;
 {
 	mdef->mhp = 0;	/* can skip some inventory bookkeeping */
+	mdef->deadmonster |= DEADMONSTER_DEAD;
 #ifdef STEED
 	/* Player is thrown from his steed when it disappears */
 	if (mdef == u.usteed)
@@ -4842,6 +4847,7 @@ monvanished(mdef)
 register struct monst *mdef;
 {
 	mdef->mhp = 0;	/* can skip some inventory bookkeeping */
+	mdef->deadmonster |= DEADMONSTER_DEAD;
 #ifdef STEED
 	/* Player is thrown from his steed when it disappears */
 	if (mdef == u.usteed)
@@ -4886,6 +4892,8 @@ register struct monst *mdef;
 	 */
 	lifesaved_monster(mdef);
 	if (mdef->mhp > 0) return;
+	/* we did not lifesave */
+	mdef->deadmonster |= DEADMONSTER_DEAD;
 
 	mdef->mtrapped = 0;	/* (see m_detach) */
 
@@ -4980,6 +4988,8 @@ register struct monst *mdef;
 	 */
 	lifesaved_monster(mdef);
 	if (mdef->mhp > 0) return;
+	/* we did not lifesave */
+	mdef->deadmonster |= DEADMONSTER_DEAD;
 
 	mdef->mtrapped = 0;	/* (see m_detach) */
 
@@ -5114,6 +5124,8 @@ register struct monst *mdef;
 	 */
 	lifesaved_monster(mdef);
 	if (mdef->mhp > 0) return;
+	/* we did not lifesave */
+	mdef->deadmonster |= DEADMONSTER_DEAD;
 
 	mdef->mtrapped = 0;	/* (see m_detach) */
 
@@ -5420,6 +5432,8 @@ xkilled(mtmp, dest)
 		if (!cansee(x,y)) pline("Maybe not...");
 		return;
 	}
+	/* we did not lifesave */
+	mtmp->deadmonster |= DEADMONSTER_DEAD;
 
 	mdat = mtmp->data; /* note: mondead can change mtmp->data */
 	mndx = monsndx(mdat);

--- a/src/worn.c
+++ b/src/worn.c
@@ -668,7 +668,7 @@ struct monst *mon;
 struct obj *obj;
 boolean on, silently;
 {
-	/* don't bother with dead monsters -- at best nothing will happen, at worst we get bad messages */
+	/* dead monsters shouldn't print messages about them no longer getting their intrinsics */
 	if (DEADMONSTER(mon))
 		silently = TRUE;
 


### PR DESCRIPTION
DEADMONSTER() generally just needs the 1st bit, but we want the 2nd bit to be sure that we're only purging monsters once.

Set the 1st bit when we would previously be setting (or confirming) that monster hp <1 and isn't recovering.
Set the 2nd bit after unlinking.

Fixes issues of monsters dying because of `mongone()`/`mondead()`/etc before they reach `m_detach()`.