### PR TITLE
Oops, re-add fix_object() adding missing lightsources to eternal lights

### DIFF
--- a/src/o_init.c
+++ b/src/o_init.c
@@ -1494,6 +1494,9 @@ fix_object(otmp)
 	struct obj *otmp;
 {
 	otmp->owt = weight(otmp);
+	if (obj_eternal_light(otmp) && !otmp->lamplit) {
+		begin_burn(otmp);
+	}
 }
 
 /*o_init.c*/


### PR DESCRIPTION
Was erronerously removed by b903083595a843b1cc90d4625274522095b1b964.