### PR TITLE
Fix sanityflag variant of monster parser

### DIFF
--- a/util/lev_comp.y
+++ b/util/lev_comp.y
@@ -861,6 +861,13 @@ monster_detail	: MONSTER_ID chance ':' monster_c ',' m_name ',' coordinate '[' S
 			    Free($6);
 			}
 		  }
+		 monster_infos
+		  {
+			if (++nmons >= MAX_OF_TYPE) {
+			    yyerror("Too many monsters in room or mazepart!");
+			    nmons--;
+			}
+		  }
 	       |  MONSTER_ID chance ':' monster_c ',' m_name ',' coordinate
 		  {
 			tmpmonst[nmons] = New(monster);


### PR DESCRIPTION
It was missing the optional block of monster_info entirely, which
meant that the call to even create the monster would not occur

This broke 3 monsters' spawning, two in the android quest and one in
chaos2, the latter was what made us find this

Fixes #1905 