### PR TITLE
Force split worm parts to be level 3 or higher

### DIFF
--- a/src/worm.c
+++ b/src/worm.c
@@ -435,8 +435,7 @@ cutworm(worm, x, y, weap)
     new_worm->wormno = new_wnum;	/* affix new worm number */
 
     /* Devalue the monster level of both halves of the worm. */
-    worm->m_lev = ((unsigned)worm->m_lev <= 3) ?
-		   (unsigned)worm->m_lev : max((unsigned)worm->m_lev - 2, 3);
+    worm->m_lev = max((unsigned)worm->m_lev - 2, 3);
     new_worm->m_lev = worm->m_lev;
 
     /* Calculate the mhp on the new_worm for the (lower) monster level. */


### PR DESCRIPTION
This is the approach vanilla took to ensure there would never be any
level 0 worm parts or 0 hp worms with d0 rolls

In vanilla 343 and slashem it was also possible to segfault in the
worm splitting code, however it seems 343-NAO fixed that,
so I only took the change to the minimum level

Fixes #1911 