### PR TITLE
Allow spiritual rapier attacks to (conditionally) hit insubstantial targets

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -2479,7 +2479,9 @@ struct attack *attk;
 						(attk->adtyp == AD_MERC) ? " with a blade of mercury!" :
 						(attk->adtyp == AD_WET) ? " with a water-jet blade!" :
 						(attk->adtyp == AD_PSON) ? " with a soul blade!" :
-						(attk->adtyp == AD_BLUD) ? " with a blade of blood!" : "!";
+						(attk->adtyp == AD_BLUD) ? " with a blade of blood!" :
+						(attk->adtyp == AD_EFIR) ? " with a blade of fire!" :
+						(attk->adtyp == AD_EDRC) ? " with a blade of poison!" : "!";
 					if (youdef)
 						specify_you = TRUE;
 				}

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1668,6 +1668,14 @@ struct obj * weapon;
 			))
 			return 2;
 
+		if (hates_holy_mon(mdef) &&
+			attk && attk->adtyp == AD_HOLY)
+			return 2;
+
+		if (hates_unholy_mon(mdef) &&
+			attk && attk->adtyp == AD_UNHY)
+			return 2;
+
 		if (has_blood_mon(mdef) &&
 			attk && attk->adtyp == AD_BLUD)
 			return 2;
@@ -1676,8 +1684,28 @@ struct obj * weapon;
 			attk && attk->adtyp == AD_PSON)
 			return 2;
 
-		if (attk && (attk->adtyp == AD_SHDW))
+		if (attk && attk->adtyp == AD_SHDW)
 			return 2;
+
+		/*if (attk && (attk->adtyp == AD_MERC))
+			return 2; Currently unused, unclear what conditions it should check exactly
+		*/
+
+		if ((flaming(mdef->data) || is_iron(mdef->data)) &&
+			attk && attk->adtyp == AD_WET)
+			return 2;
+
+		if (!((species_resists_fire(mdef))
+				|| (ward_at(x(mdef), y(mdef)) == SIGIL_OF_CTHUGHA)
+				|| (youdef && ((Race_if(PM_HALF_DRAGON) && flags.HDbreath == AD_FIRE)))
+				|| (!youdef && is_half_dragon(pd) && mdef->mvar_hdBreath == AD_FIRE)
+				|| (youdef && u.sealsActive&SEAL_FAFNIR)) &&
+			attk && attk->adtyp == AD_EFIR)
+			return 2;
+
+		if (!Poison_res(mdef) &&
+			attk && attk->adtyp == AD_EDRC)
+			return 2; /* likely will be swapped out to wormwood (poisonous/starlight/water damage) at some point */
 
 		if ((hates_silver(pd) && !(youdef && u.sealsActive&SEAL_EDEN)) && (
 			(youagr && u.sealsActive&SEAL_EDEN) ||

--- a/src/xhityhelpers.c
+++ b/src/xhityhelpers.c
@@ -1672,6 +1672,13 @@ struct obj * weapon;
 			attk && attk->adtyp == AD_BLUD)
 			return 2;
 
+		if (!mindless_mon(mdef) &&
+			attk && attk->adtyp == AD_PSON)
+			return 2;
+
+		if (attk && (attk->adtyp == AD_SHDW))
+			return 2;
+
 		if ((hates_silver(pd) && !(youdef && u.sealsActive&SEAL_EDEN)) && (
 			(youagr && u.sealsActive&SEAL_EDEN) ||
 			(attk && attk->adtyp == AD_GLSS) ||


### PR DESCRIPTION
Since by default all varieties of spiritual rapier are shining, which allows them to phase armor, it makes sense that they should count as shining for hitting insubstantial targets (shade, hudor kamerel, etc.) as well.

There are currently message handling for 10 kinds of spiritual rapier attacks - `AD_SHDW`, `AD_STAR`, `AD_MOON`, `AD_HOLY`, `AD_UNHY`, `AD_BLUD`, `AD_MERC`, `AD_PSON`, `AD_WET`, `AD_EFIR`, and `AD_EDRC`. Of these, all but holy, unholy and mercury are currently used. This PR allows most of these to hit insubstantial targets if they would normally be 'vulnerable' or at least affected by that damage otherwise.

1. Shadowblades (edderkops et. al.) always hit insubstantial targets
2. Starlight & moonlight rapiers (various Eladrin) hit insubstantial targets if they're vulnerable to silver damage
3. Holy and unholy light-beams (unused) hit insubstantial targets if they're vulnerable to holy or unholy damage respectively (currently unused in practice but message handling existed)
4. Blades of rotten blood (Ascodel) hit insubstantial targets if they have blood
5. Soulblades (elocators) hit insubstantial targets if they have a mind
6. Blades of mercury (unused) never hit insubstantial targets (currently unused in practice, message handling existed, but unclear what the proper criteria are)
7. Water-jet blades (Uiscerre Eladrin) hit insubstantial targets if they are vulnerable to water damage, i.e. flaming or made of iron
8. Blades of fire (Fierna) hit insubstantial targets if they're not immune to fire damage, which includes monster innate resistances, standing on a Sigil of Cthugha, having Fafnir bound, and being a half-dragon with fire breath
9. Blades of poison (Naome) hit insubstantial targest if they're not poison resistant

Those are the only damage types used for spiritual rapiers now, so any new kinds of spiritual rapier attack will not automatically hit insubstantial targets unless handling is added. I tested most of these by forced polyforms, editing the damage type of black web shadowblades in `xhity.c` to holy/unholy and temporarily giving mercury rilmani proper blades instead of claws. They shouldn't crash on normal hit attempts, both in MvM/UvM and MvU but there's probably at least one edge case I missed.