### PR TITLE
Adjust half-dragons and tripe

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -2052,7 +2052,7 @@ struct obj *otmp;
 		     * alternative form's food! 
 		     */
 		    pline("That tripe ration was surprisingly good!");
-		else if (maybe_polyd(is_orc(youmonst.data), Race_if(PM_ORC)))
+		else if (maybe_polyd(is_orc(youmonst.data), Race_if(PM_ORC)) || maybe_polyd(is_half_dragon(youmonst.data), Race_if(PM_HALF_DRAGON)))
 		    pline(Hallucination ? "Tastes great! Less filling!" :
 			  "Mmm, tripe... not bad!");
 		else {

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -330,7 +330,9 @@ static struct trobj Knight[] = {
 	{ KITE_SHIELD, 0, ARMOR_CLASS, 1, UNDEF_BLESS },
 	{ GLOVES, 0, ARMOR_CLASS, 1, UNDEF_BLESS },
 	{ HIGH_BOOTS, 0, ARMOR_CLASS, 1, UNDEF_BLESS },
+#define K_APPLES 7
 	{ APPLE, 0, FOOD_CLASS, 10, 0 },
+#define K_CARROTS 8
 	{ CARROT, 0, FOOD_CLASS, 10, 0 },
 	{ 0, 0, 0, 0, 0 }
 };
@@ -2100,7 +2102,11 @@ u_init()
 		break;
 	case PM_KNIGHT:
 		if(Race_if(PM_DWARF)) ini_inv(DwarfNoble);
-		else ini_inv(Knight);
+		else if(Race_if(PM_HALF_DRAGON)){
+			Knight[K_APPLES].trquan = rn1(9, 5);
+			Knight[K_CARROTS].trquan = 1;
+			ini_inv(Knight);
+		} else ini_inv(Knight);
 		knows_class(WEAPON_CLASS);
 		knows_class(ARMOR_CLASS);
 		/* give knights chess-like mobility


### PR DESCRIPTION
Half-dragon knights previously started with 20-30 tripe rations, which was incredibly overkill and sometimes ended up with you being nearly burdened from the get-go. This halves this number - previously it was derived from converting the 10-15 apples & carrots each (2 aum per, 50 nutrition per, for a total of 40-60 aum and 1000-1500 nutrition) to tripe rations for your carnivorous pseudodragon (10 aum per, 200 nutrition per, for a total of 200-300 aum and 4000-6000 nutrition). This PR tones that back to 10-15 tripe total, half the original value. This should allow you to not have to lug around a ridiculous number.

In addition, half-dragons are added to the check to make tripe a valid foodstuff. It's a little weird that pseudodragons apparently treat is as a treat, but other dragonkin dudes can't stand it either. Previously orcs could already eat it without issue, now half-dragons can as well.