### PR TITLE
Make the Star of Hypernotus display correctly w.r.t. the "star sapphire" material

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -2100,7 +2100,7 @@ A("Idol of Bokrug, the water-lizard",		STATUE,	"sea-green stone likeness of a wa
 	NOINVOKE, NOFLAG
 	),
 
-A("The Star of Hypernotus",		AMULET_VERSUS_CURSES,	"blue-green star-shaped stone",
+A("The Star of Hypernotus",		AMULET_VERSUS_CURSES,	"blue-green star-shaped %s",
 	2500L, GEMSTONE, MZ_DEFAULT, WT_DEFAULT,
 	A_NEUTRAL, PM_MADMAN, NON_PM, TIER_S, (ARTG_NOGEN|ARTG_NOWISH|ARTG_MAJOR),
 	NO_MONS(),

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1564,6 +1564,9 @@ char *buf;
 	} else if(obj->oartifact == ART_IBITE_ARM && artilist[obj->oartifact].material && obj->obj_material == artilist[obj->oartifact].material){
 		//Ibite arm descriptor includes "flabby," which is both a material and an appearance :-/
 		return;
+	} else if(obj->oartifact == ART_STAR_OF_HYPERNOTUS && artilist[obj->oartifact].material && obj->obj_material == artilist[obj->oartifact].material){
+		//Star of Hypernotus plays "fast and loose" with the material - and the material affects the final word rather than being a prefix
+		return;
 	} else {
 		/*Special case: circlets should always show their material, but oc_showmat is tied to otyp, not appearance */
 		if (obj->otyp == find_gcirclet())
@@ -1704,7 +1707,8 @@ boolean with_price;
 		if (strstri(oart->desc, "%s")) {
 			getting_obj_base_desc = TRUE;
 			char * buf2 = nextobuf();
-			Sprintf(buf2, oart->desc, xname(obj));
+			if (obj->oartifact == ART_STAR_OF_HYPERNOTUS) Sprintf(buf2, oart->desc, (objects[obj->ovar1].oc_name_known) ? OBJ_NAME(objects[obj->ovar1]) : "stone");
+			else Sprintf(buf2, oart->desc, xname(obj));
 			Strcat(buf, buf2);
 			getting_obj_base_desc = FALSE;
 		}


### PR DESCRIPTION
Now shows as an "engraved blue-green star-shaped stone" when unidentified, and if you don't know the "star sapphire" gem. If you do know the star sapphire gem, shows up as an "engraved blue-green star-shaped star sapphire". Previously, this would show as an "engraved blue-green blue-green star-shaped stone", or an "engraved star sapphire blue-green star-shaped stone" or something like that. This fixes that.

Does some shenanigans to do so - special-cases the star of hypernotus to not have a material descriptor ever, and makes the 'artifact description' into "blue-green star shaped %s". The code that formats artifact description "%s"s into base names is then also special-cased to choose between "stone" and "star sapphire" (via the gem's identified proper name) as a base name instead.

Note: star sapphires are a kind of sapphire with a star-shaped pattern on/in them, so star-shaped star sapphire is not redundant (I think).