### PR TITLE
Add invweight option

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -343,7 +343,7 @@ struct instance_flags {
     boolean artifact_descriptors;
 	boolean force_artifact_names;
     boolean dnethack_dungeon_colors;
-    boolean inv_weight;
+    boolean invweight;
 	boolean quick_m_abilities;
 
 	int pokedex;	/* default monster stats to show in the pokedex */

--- a/include/flag.h
+++ b/include/flag.h
@@ -343,6 +343,7 @@ struct instance_flags {
     boolean artifact_descriptors;
 	boolean force_artifact_names;
     boolean dnethack_dungeon_colors;
+    boolean inv_weight;
 	boolean quick_m_abilities;
 
 	int pokedex;	/* default monster stats to show in the pokedex */

--- a/src/invent.c
+++ b/src/invent.c
@@ -4095,9 +4095,19 @@ long* out_cnt;
 #endif /* SORTLOOT */
 
 #ifdef DUMP_LOG
-	if (want_disp)
+	if (want_disp){
 #endif
-	start_menu(win);
+		start_menu(win);
+#ifdef DUMP_LOG
+		if (!lets){
+			any.a_void = 0;
+			char invheading[QBUFSZ];
+			int wcap = weight_cap();
+			Sprintf(invheading, "Inventory: %d/%d weight (%d/52 slots)", inv_weight() + wcap, wcap, inv_cnt());
+			add_menu(win, NO_GLYPH, &any, 0, 0, ATR_BOLD, invheading, MENU_UNSELECTED);
+		}
+	}
+#endif
 nextclass:
 	classcount = 0;
 	any.a_void = 0;		/* set all bits to zero */

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2349,6 +2349,10 @@ weapon:
 		{
 			buf = strprepend(buf + 2, "an ");
 		}
+
+		if (iflags.inv_weight && (obj->where == OBJ_INVENT || wizard)) {
+			Sprintf(eos(buf), " {%d}", obj->owt);
+		}
 	}
 	return buf;
 }

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2350,7 +2350,7 @@ weapon:
 			buf = strprepend(buf + 2, "an ");
 		}
 
-		if (iflags.inv_weight && (obj->where == OBJ_INVENT || wizard)) {
+		if (iflags.invweight && (obj->where == OBJ_INVENT || wizard)) {
 			Sprintf(eos(buf), " {%d}", obj->owt);
 		}
 	}

--- a/src/options.c
+++ b/src/options.c
@@ -143,7 +143,7 @@ static struct Bool_Opt
 	{"role_obj_names",    &iflags.role_obj_names, TRUE, SET_IN_GAME},
 	{"obscure_role_obj_names",    &iflags.obscure_role_obj_names, FALSE, SET_IN_GAME},
 	{"dnethack_dungeon_colors",    &iflags.dnethack_dungeon_colors, TRUE, SET_IN_GAME},
-	{"inv_weight",    &iflags.inv_weight, TRUE, SET_IN_GAME},
+	{"invweight",    &iflags.invweight, TRUE, SET_IN_GAME},
 	{"hitpointbar", &iflags.hitpointbar, FALSE, SET_IN_GAME},
 	{"hp_monitor", (boolean *)0, TRUE, SET_IN_FILE}, /* For backward compat, HP monitor patch */
 	{"hp_notify", &iflags.hp_notify, FALSE, SET_IN_GAME},

--- a/src/options.c
+++ b/src/options.c
@@ -143,6 +143,7 @@ static struct Bool_Opt
 	{"role_obj_names",    &iflags.role_obj_names, TRUE, SET_IN_GAME},
 	{"obscure_role_obj_names",    &iflags.obscure_role_obj_names, FALSE, SET_IN_GAME},
 	{"dnethack_dungeon_colors",    &iflags.dnethack_dungeon_colors, TRUE, SET_IN_GAME},
+	{"inv_weight",    &iflags.inv_weight, TRUE, SET_IN_GAME},
 	{"hitpointbar", &iflags.hitpointbar, FALSE, SET_IN_GAME},
 	{"hp_monitor", (boolean *)0, TRUE, SET_IN_FILE}, /* For backward compat, HP monitor patch */
 	{"hp_notify", &iflags.hp_notify, FALSE, SET_IN_GAME},

--- a/win/curses/cursinvt.c
+++ b/win/curses/cursinvt.c
@@ -38,16 +38,6 @@ curses_update_inv(void)
     /* Clear the window as it is at the moment. */
     werase(win);
 
-    wmove(win, y, x);
-    attr_t attr = A_UNDERLINE;
-    wattron(win, attr);
-    wprintw(win, "Inventory:");
-    wattroff(win, attr);
-
-    /* The actual inventory will override this if we do carry stuff */
-    wmove(win, y + 1, x);
-    wprintw(win, "Not carrying anything");
-
     display_inventory(NULL, FALSE);
 
     if (border)


### PR DESCRIPTION
Add `invweight` option, to display the weight of an object after its full name (i.e. in the inventory). Also shows the full inventory weight plus carrycap in the inventory regardless of that option. Shoutout xNetHack for having it functioning for me to copy from.