### PR TITLE
Fix object looking lava interactions for likes_lava player forms

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -4677,7 +4677,7 @@ boolean picked_some;
 	if (dfeature)
 		Sprintf(fbuf, "There is %s here.", an(dfeature));
 
-	if (!otmp || is_lava(u.ux,u.uy) || (is_pool(u.ux,u.uy, FALSE) && !Underwater)) {
+	if (!otmp || (is_lava(u.ux,u.uy) && !likes_lava(youracedata)) || (is_pool(u.ux,u.uy, FALSE) && !Underwater)) {
 		if (dfeature) pline1(fbuf);
 		read_engr_at(u.ux, u.uy); /* Eric Backus */
 		if (!skip_objects && (Blind || !dfeature))

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -413,7 +413,7 @@ int what;		/* should be a long */
 		struct trap *ttmp = t_at(u.ux, u.uy);
 		/* no auto-pick if no-pick move, nothing there, or in a pool */
 		if (autopickup && (flags.nopick || !OBJ_AT(u.ux, u.uy) ||
-			(is_pool(u.ux, u.uy, FALSE) && !Underwater) || is_lava(u.ux, u.uy))) {
+			(is_pool(u.ux, u.uy, FALSE) && !Underwater) || (is_lava(u.ux, u.uy) && !likes_lava(youracedata)))) {
 			read_engr_at(u.ux, u.uy);
 			return (0);
 		}


### PR DESCRIPTION
Players that are in a likes_lava form will be able to see the items in pools of lava by looking with ; or #look, or when walking over while not blind. In the past, nothing would be displayed despite the player being able to interact with the objects normally as if they were on the floor.