### PR TITLE
Port vanilla's autopickup shop handling

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -636,6 +636,38 @@ boolean grab;	 /* forced pickup, rather than forced leave behind? */
 }
 #endif /* AUTOPICKUP_EXCEPTIONS */
 
+STATIC_OVL boolean
+autopick_testobj(otmp, calc_costly)
+struct obj *otmp;
+boolean calc_costly;
+{
+    static boolean costly = FALSE;
+    const char *otypes = flags.pickup_types;
+    boolean pickit = FALSE;
+
+    if (calc_costly) {
+	costly = otmp->where == OBJ_FLOOR
+	    && costly_spot(otmp->ox, otmp->oy);
+    }
+
+    if (costly && !otmp->no_charge)
+	return FALSE;
+
+    pickit = !*otypes || index(otypes, otmp->oclass);
+
+#ifdef AUTOPICKUP_EXCEPTIONS
+    if (!pickit)
+	pickit = is_autopickup_exception(otmp, TRUE);
+
+    pickit = pickit && !is_autopickup_exception(otmp, FALSE);
+#endif
+
+    if (!pickit)
+	pickit = iflags.pickup_thrown && otmp->was_thrown;
+
+    return pickit;
+}
+
 /*
  * Pick from the given list using flags.pickup_types.  Return the number
  * of items picked (not counts).  Create an array that returns pointers
@@ -652,31 +684,20 @@ menu_item **pick_list;	/* list of objects and counts to pick up */
 	menu_item *pi;	/* pick item */
 	struct obj *curr;
 	int n;
-	const char *otypes = flags.pickup_types;
+	boolean check_costly = TRUE;
 
 	/* first count the number of eligible items */
-	for (n = 0, curr = olist; curr; curr = FOLLOW(curr, follow))
-
-
-#ifndef AUTOPICKUP_EXCEPTIONS
-           if (!*otypes || index(otypes, curr->oclass) || (iflags.pickup_thrown && curr->was_thrown))
-#else
-	     if (((!*otypes || index(otypes, curr->oclass) ||
-		   is_autopickup_exception(curr, TRUE)) &&
-		  !is_autopickup_exception(curr, FALSE)) || (iflags.pickup_thrown && curr->was_thrown))
-#endif
+	for (n = 0, curr = olist; curr; curr = FOLLOW(curr, follow)) {
+           if (autopick_testobj(curr, check_costly))
 		n++;
+	   check_costly = FALSE;
+	}
+	    
 
 	if (n) {
 	    *pick_list = pi = (menu_item *) alloc(sizeof(menu_item) * n);
 	    for (n = 0, curr = olist; curr; curr = FOLLOW(curr, follow))
-#ifndef AUTOPICKUP_EXCEPTIONS
-               if (!*otypes || index(otypes, curr->oclass) || (iflags.pickup_thrown && curr->was_thrown)) {
-#else
-		 if (((!*otypes || index(otypes, curr->oclass) ||
-		       is_autopickup_exception(curr, TRUE)) &&
-		      !is_autopickup_exception(curr, FALSE)) || (iflags.pickup_thrown && curr->was_thrown)) {
-#endif
+               if (autopick_testobj(curr, FALSE)) {
 		    pi[n].item.a_obj = curr;
 		    pi[n].count = curr->quan;
 		    n++;


### PR DESCRIPTION
The behaviour in vanilla is as follows:

If you have autopickup on, and the square you move to is part of a shop,
and the item being considered costs money, do not pick up the object.

Possibly a solution to #1964 though perhaps we should add a way to control it,
or have our autopickup exceptions override the rule that costly items aren't picked up