### PR TITLE
Enable player AD_PLYS passive as `e`

### DIFF
--- a/src/xhity.c
+++ b/src/xhity.c
@@ -16325,7 +16325,7 @@ boolean endofchain;			/* if the passive is occuring at the end of aggressor's at
 				case AD_PLYS:
 					if (pd->mlet == S_EYE) {	/* assumed to be gaze */
 						/* the eye can't be blinded */
-						if (is_blind(mdef)) {
+						if (youdef ? Blind : is_blind(mdef)) {
 							if (youagr) {
 								pline("%s cannot defend itself.",
 									Adjmonnam(mdef, "blind"));


### PR DESCRIPTION
Gaze passive AD_PLYS remains an on-hit passive, which isn't the same as vanilla but I think is intentional dnh behaviour?

Closes #1961 