### PR TITLE
Fix a/an essence trap

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -808,7 +808,7 @@ unsigned trflags;
 		((ttype == HOLE || ttype == TRAPDOOR || ttype == PIT || ttype == SPIKED_PIT) && u.sealsActive&SEAL_SIMURGH)
 		)) {
 		You("escape %s %s.",
-		    (ttype == ARROW_TRAP && !trap->madeby_u) ? "an" :
+		    ((ttype == ARROW_TRAP || ttyp == VIVI_TRAP) && !trap->madeby_u) ? "an" :
 			a_your[trap->madeby_u],
 		    defsyms[trap_to_defsym(ttype)].explanation);
 		nomul(0, NULL);


### PR DESCRIPTION
'a/your' is coded as an array so it's a lot more work to make it correct in the general case using `an()`.