### PR TITLE
Fix operator precedence warnings

### DIFF
--- a/include/youprop.h
+++ b/include/youprop.h
@@ -167,7 +167,7 @@
 #define	FacelessCloak(obj) ((obj)->otyp == WHITE_FACELESS_ROBE || (obj)->otyp == BLACK_FACELESS_ROBE || (obj)->otyp == SMOKY_VIOLET_FACELESS_ROBE)
 #define	Faceless(obj) (FacelessHelm(obj) || FacelessCloak(obj))
 
-#define save_vs_sanloss()	((uwep && uwep->oartifact == ART_NODENSFORK) || (rnd(30) < (ACURR(A_WIS) + uring_art(ART_NARYA) ? narya() : 0)))
+#define save_vs_sanloss()	((uwep && uwep->oartifact == ART_NODENSFORK) || (rnd(30) < (ACURR(A_WIS) + (uring_art(ART_NARYA) ? narya() : 0))))
 
 #define Mortal_race	(!nonliving(youracedata) && !is_minion(youracedata) && !is_demon(youracedata) && !is_primordial(youracedata))
 #define Dark_immune	(is_unalive(youracedata) || is_primordial(youracedata))


### PR DESCRIPTION
The warning pointed out that the addition would be performed first, so
narya would always be the value here