### PR TITLE
Check whether DS are worn when enchanting

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1791,7 +1791,10 @@ struct obj	*sobj;
 				} else {
 					Your("%s merges and hardens!", xname(otmp));
 				}
-				setworn((struct obj *)0, W_ARM);
+				boolean is_worn = !!(otmp->owornmask & W_ARM);
+				if (is_worn) {
+					setworn((struct obj *)0, W_ARM);
+				}
 				/* assumes same order */
 				otmp->otyp = GRAY_DRAGON_SCALE_SHIELD +
 					otmp->otyp - GRAY_DRAGON_SCALES;
@@ -1805,8 +1808,9 @@ struct obj	*sobj;
 				fix_object(otmp);
 
 				long wornmask = 0L;
-				if (canwearobj(otmp, &wornmask, FALSE))
+				if (is_worn && canwearobj(otmp, &wornmask, FALSE)) {
 					setworn(otmp, wornmask);
+				}
 				break;
 			} else {
 				if(Blind) {
@@ -1893,8 +1897,12 @@ struct obj	*sobj;
 				break;
 			}
 			/* dragon scales get turned into dragon scale mail */
+			boolean is_worn = !!(otmp->owornmask & W_ARM);
+
 			Your("%s merges and hardens!", xname(otmp));
-			setworn((struct obj *)0, W_ARM);
+			if (is_worn) {
+				setworn((struct obj *)0, W_ARM);
+			}
 			/* assumes same order */
 			otmp->otyp = GRAY_DRAGON_SCALE_MAIL +
 						otmp->otyp - GRAY_DRAGON_SCALES;
@@ -1908,7 +1916,10 @@ struct obj	*sobj;
 				otmp->blessed = 1;
 			}
 			otmp->known = 1;
-			setworn(otmp, W_ARM);
+			long wornmask = 0L;
+			if (is_worn && canwearobj(otmp, &wornmask, FALSE)) {
+				setworn(otmp, W_ARM);
+			}
 			break;
 		}
 		Your("%s %s%s%s%s for a %s.",

--- a/src/shk.c
+++ b/src/shk.c
@@ -5515,13 +5515,19 @@ shk_armor_works(slang, shkp)
 					obj->otyp <= YELLOW_DRAGON_SCALES) {
 			/* dragon scales get turned into dragon scale mail */
 			Your("%s merges and hardens!", xname(obj));
-			setworn((struct obj *)0, W_ARM);
+			boolean is_worn = !!(obj->owornmask & W_ARM);
+			if (is_worn) {
+			    setworn((struct obj *)0, W_ARM);
+			}
 			/* assumes same order */
 			obj->otyp = GRAY_DRAGON_SCALE_MAIL +
 						obj->otyp - GRAY_DRAGON_SCALES;
 			obj->cursed = 0;
 			obj->known = 1;
-			setworn(obj, W_ARM);
+			long wornmask = 0L;
+			if (is_worn && canwearobj(obj, &wornmask, FALSE)) {
+			    setworn(obj, wornmask);
+			}
 			break;
 		}
 


### PR DESCRIPTION
If the dragon scales aren't worn, then we shouldn't go through the
process of removing the player's body armour and wearing the dragon
scales.

Fixes #1974 