### PR TITLE
Put the items into the chests in the tomb

### DIFF
--- a/dat/tomb.des
+++ b/dat/tomb.des
@@ -43,7 +43,7 @@ TRAP: "spiked pit",random
 TRAP: "spiked pit",random
 TRAP: "spiked pit",random
 TRAP: "spiked pit",random
-OBJECT:'(',"chest",(47,9)
+CONTAINER:'(',"chest",(47,9)
 GOLD: random,(47,9)
 GOLD: random,(47,9)
 GOLD: random,(47,9)
@@ -54,27 +54,27 @@ GOLD: random,(47,9)
 GOLD: random,(47,9)
 GOLD: random,(47,9)
 GOLD: random,(47,9)
-OBJECT: '?', random, (47,9)
-OBJECT: '?', random, (47,9)
-OBJECT: '?', random, (47,9)
-OBJECT: '?', random, (47,9)
-OBJECT: '!', random, (47,9)
-OBJECT: '!', random, (47,9)
-OBJECT: '!', random, (47,9)
-OBJECT: random, random, (47,9)
-OBJECT: random, random, (47,9)
-OBJECT: '!', "water", (47,9),cursed,0
-OBJECT: '!', "water", (47,9),cursed,0
+OBJECT: '?', random, contained
+OBJECT: '?', random, contained
+OBJECT: '?', random, contained
+OBJECT: '?', random, contained
+OBJECT: '!', random, contained
+OBJECT: '!', random, contained
+OBJECT: '!', random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: '!', "water", contained,cursed,0
+OBJECT: '!', "water", contained,cursed,0
 OBJECT: random, random, random
-OBJECT:'(',"chest",(23,1)
-OBJECT: random, random, (23,1)
-OBJECT: random, random, (23,1)
-OBJECT: random, random, (23,1)
-OBJECT:'(',"chest",(24,18)
-OBJECT: random, random, (24,18)
-OBJECT: random, random, (24,18)
-OBJECT: random, random, (24,18)
-OBJECT:'(',"chest",(47,10)
+CONTAINER:'(',"chest",(23,1)
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+CONTAINER:'(',"chest",(24,18)
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+CONTAINER:'(',"chest",(47,10)
 GOLD: random,(47,10)
 GOLD: random,(47,10)
 GOLD: random,(47,10)
@@ -85,23 +85,23 @@ GOLD: random,(47,10)
 GOLD: random,(47,10)
 GOLD: random,(47,10)
 GOLD: random,(47,10)
-OBJECT: '?', random, (47,10)
-OBJECT: '?', random, (47,10)
-OBJECT: '?', random, (47,10)
-OBJECT: '?', random, (47,10)
-OBJECT: '+', random, (47,10)
-OBJECT: '+', random, (47,10)
-OBJECT: '+', random, (47,10)
-OBJECT: '+', random, (47,10)
-OBJECT: random, random, (47,10)
-OBJECT: random, random, (47,10)
-OBJECT: random, random, (47,10)
-OBJECT: random, random, (47,10)
-OBJECT: random, random, (47,10)
-OBJECT: '!', "water", (47,10),cursed,0
-OBJECT: '!', "water", (47,10),cursed,0
+OBJECT: '?', random, contained
+OBJECT: '?', random, contained
+OBJECT: '?', random, contained
+OBJECT: '?', random, contained
+OBJECT: '+', random, contained
+OBJECT: '+', random, contained
+OBJECT: '+', random, contained
+OBJECT: '+', random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: random, random, contained
+OBJECT: '!', "water", contained,cursed,0
+OBJECT: '!', "water", contained,cursed,0
 MONSTER: 'M', "priest mummy", (47,9)
-OBJECT:'(',"magic chest",(47,10)
+OBJECT:'(',"magic chest",(47,11)
 MONSTER: '.',random,random
 MONSTER: '.',random,random
 MONSTER: '.',random,random


### PR DESCRIPTION
It's a little strange that the items are on the same square as the chest
rather than inside them. This is explained by the fact the original
variant this des file is from was based on a vanilla that didn't have a
way to contain items via the des file

There unfortunately isn't a way (yet?) to put the gold into the chests,
so they're staying on the ground for now

I took this opportunity to move the magic chest one square south so
there's no longer two 'chests' in the same place