### PR TITLE
Cut the Goat off from the Future

### DIFF
--- a/src/dig.c
+++ b/src/dig.c
@@ -2495,7 +2495,7 @@ bury_an_obj(otmp)
 		&& !obj_resists(otmp, 0, 100)) {
 	    (void) start_timer((under_ice ? 0L : 250L) + (long)rnd(250),
 			       TIMER_OBJECT, ROT_ORGANIC, (genericptr_t)otmp);
-	} else if(otmp->otyp == HOLY_SYMBOL_OF_THE_BLACK_MOTHE){
+	} else if(otmp->otyp == HOLY_SYMBOL_OF_THE_BLACK_MOTHE && !Infuture){
 	    (void) start_timer(250L + (long)rnd(250), TIMER_OBJECT, ROT_ORGANIC, (genericptr_t)otmp);
 	}
 	add_to_buried(otmp);

--- a/src/mon.c
+++ b/src/mon.c
@@ -5539,7 +5539,7 @@ xkilled(mtmp, dest)
 				//We are in the "player has killed monster" function, so it's their fault
 				if(goat_mouth_at(x,y) && has_object_type(invent, HOLY_SYMBOL_OF_THE_BLACK_MOTHE)){
 					goat_eat(corpse, GOAT_EAT_OFFERED); //Goat eat tries *really* hard to destroy whatever you give it.
-				} else if(mtmp->mgoatmarked){
+				} else if(mtmp->mgoatmarked && !Infuture){
 					goat_eat(corpse, GOAT_EAT_MARKED); //Goat eat tries *really* hard to destroy whatever you give it.
 				} else goat_seenonce = FALSE;
 				corpse = (struct obj *)0; //corpse pointer is now stale


### PR DESCRIPTION
* You can't summon Mouths of the Goat by burying holy symbols
* The Goat can't eat the corpses from drooling-weapon kills
   * By carrying a drooling-weapon into the Future, you're carrying a disconnected Goat mouth -- it can bite, but it can't feed the Goat