### PR TITLE
Make GDCB's weight actually adjustable

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -570,7 +570,7 @@ A("Fire Brand",			LONG_SWORD,						"ember-runed %s",
 	),
 
 A("The Green Dragon Crescent Blade",		NAGINATA,	(const char *)0,
-	1200L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	1200L, MT_DEFAULT, MZ_DEFAULT, WT_SPECIAL,
 	A_LAWFUL, NON_PM, NON_PM, TIER_B, (ARTG_GIFT),
 	NO_MONS(),
 	ATTK(AD_PHYS, 1, 25), NOFLAG,

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2093,6 +2093,10 @@ struct obj *obj;
 		case ART_GOLDEN_SWORD_OF_Y_HA_TALLA:
 			wt = 2*objects[SCIMITAR].oc_weight;
 			break;
+		case ART_GREEN_DRAGON_CRESCENT_BLAD:
+			wt = 2*objects[NAGINATA].oc_weight;
+			wt = wt * materials[obj->obj_material].density / materials[objects[obj->otyp].oc_material].density;
+			break;
 		case ART_AEGIS:
 			wt = objects[CLOAK].oc_weight;
 			break;

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2582,8 +2582,6 @@ register struct obj *obj;
 		return (int)((obj->quan + 50L) / 100L);
 	else if (obj->otyp == HEAVY_IRON_BALL && obj->owt != 0)
 		return((int)(obj->owt));	/* kludge for "very" heavy iron ball */
-	else if (obj->oartifact == ART_GREEN_DRAGON_CRESCENT_BLAD && obj->owt != 0)
-		return((int)(obj->owt));	/* kludge for "very" heavy gdcb */
 	return(wt ? wt*(int)obj->quan : ((int)obj->quan + 1)>>1);
 }
 


### PR DESCRIPTION
This means any future changes to its weight independent of its base item type or material need to be handled in artifact_weight, which isn't ideal if it's going to ever change weights a lot. Should be able to use ovar1 or something to track its status though so hey.