### PR TITLE
Port xnh/vanilla's displacing peacefuls change

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -176,7 +176,7 @@
  * definition here is convenient.
  */
 #define is_safepet(mon) \
-	(mon && mon->mtame && canspotmon(mon) && flags.safe_dog \
+	(mon && (mon->mtame || mon->mpeaceful) && canspotmon(mon) && flags.safe_dog \
 		&& !Confusion && !Hallucination && !Stunned)
 
 


### PR DESCRIPTION
This allows you to displace peacefuls by moving into them, which is a
fairly popular change originating in xnh.

It's especially annoying playing lawful pre-axus in dnh as a horde of
autons can spontaneously appear making moving through certain levels
incredibly annoying.