### PR TITLE
Fix disintegration read after free

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -4585,7 +4585,7 @@ struct zapdata * zapdata;
 					for (otmp = mdef->minvent; otmp; otmp = otmp2) {
 						otmp2 = otmp->nobj;
 						if (!(oresist_disintegration(otmp) || obj_resists(otmp, 5, 50) || otmp == m_lsvd)) {
-							obj_extract_self(otmp);
+							obj_extract_and_unequip_self(otmp);
 							obfree(otmp, (struct obj *)0);
 						}
 					}


### PR DESCRIPTION
When disintegration, from e.g. a raygun, hits a monster and disintegrates
items from their inventory and kills them in the same turn it would
check how much xp to award based on items that were just destroyed such
as their weapon

The fix is replacing obj_extract_self with obj_extract_and_unequip_self
which correctly handles removing the items