### PR TITLE
Fix banana timer issue

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2885,7 +2885,7 @@ E void FDECL(cleanup_msummon, (genericptr_t, long));
 E void FDECL(desummon_obj, (genericptr_t, long));
 E void FDECL(summoner_gone, (struct monst *, boolean));
 E void FDECL(stop_corpse_timers, (struct obj *));
-E boolean FDECL(start_timer, (long, SHORT_P, SHORT_P, genericptr_t));
+E timer_element * FDECL(start_timer, (long, SHORT_P, SHORT_P, genericptr_t));
 E void FDECL(pause_timer, (timer_element *));
 E void FDECL(resume_timer, (timer_element *));
 E void FDECL(pause_timers, (timer_element *));
@@ -2897,7 +2897,8 @@ E void FDECL(stop_all_timers, (timer_element *));
 E void NDECL(run_timers);
 E void FDECL(save_timers, (timer_element *,int,int));
 E void FDECL(rest_timers, (int,genericptr_t,timer_element *,int,BOOLEAN_P,long));
-E void FDECL(split_timers, (struct timer *, int, genericptr_t));
+E void FDECL(copy_timer, (struct timer *, int, genericptr_t));
+E void FDECL(copy_timers, (struct timer *, int, genericptr_t));
 #ifdef WIZARD
 E int NDECL(wiz_timeout_queue);
 E void NDECL(timer_sanity_check);

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -11131,7 +11131,7 @@ xchar x, y;	/* clone's preferred location or 0 (near mon) */
 	/* duplicate timers */
 	if (mon->timed) {
 		m2->timed = (struct timer *) 0;
-		split_timers(mon->timed, TIMER_MONSTER, (genericptr_t)m2);
+		copy_timers(mon->timed, TIMER_MONSTER, (genericptr_t)m2);
 	}
 
 	/* place the monster -- we want to do this before any display things happen */

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -429,7 +429,7 @@ long num;
 		cpy_ox(obj, otmp, ox_id);
 		
 	if (obj->unpaid) splitbill(obj,otmp);
-	if (obj->timed) split_timers(obj->timed, TIMER_OBJECT, (genericptr_t)otmp);
+	if (obj->timed) copy_timers(obj->timed, TIMER_OBJECT, (genericptr_t)otmp);
 	if (obj_sheds_light(obj)) obj_split_light_source(obj, otmp);
 	return otmp;
 }
@@ -485,7 +485,7 @@ struct obj *obj;
 		cpy_ox(obj, otmp, ox_id);
 	
 	otmp->unpaid = 0;
-	if (obj->timed) split_timers(obj->timed, TIMER_OBJECT, (genericptr_t)otmp);
+	if (obj->timed) copy_timers(obj->timed, TIMER_OBJECT, (genericptr_t)otmp);
 	if (obj_sheds_light(obj)) obj_split_light_source(obj, otmp);
 	return otmp;
 }

--- a/src/zap.c
+++ b/src/zap.c
@@ -1915,6 +1915,9 @@ no_unwear:
 
 	/* copy OX structures */
 	mov_all_ox(obj, otmp);
+	/* copy not otyp-related timers */
+	copy_timer(get_timer(obj->timed, DESUMMON_OBJ), TIMER_OBJECT, (genericptr_t)otmp);
+
 	/* ** we are now done adjusting the object ** */
 
 


### PR DESCRIPTION
1. Rename split_timers to copy_timers
2. Create single-timer-copying function, copy_timer, which copies the exact timer given. Use in conjunction with get_timer.
3. Fix copy_timers not copying timer flags
4. Poly_obj copies the DESUMMON_OBJ timer, so summoned items properly desummon.
5. Closes #2000 