### PR TITLE
Fix read after free in wary_dog

### DIFF
--- a/src/dog.c
+++ b/src/dog.c
@@ -1596,9 +1596,9 @@ boolean was_dead;
     }
 
     if (edog && (edog->killed_by_u == 1 || edog->abuse > 2)) {
-	untame(mtmp, 0);
-	if (edog->abuse >= 0 && edog->abuse < 10)
-	    if (!rn2(edog->abuse + 1)) mtmp->mpeaceful = 1;
+      boolean be_peaceful = edog->abuse >= 0 && edog->abuse < 10 && !rn2(edog->abuse + 1);
+      untame(mtmp, be_peaceful);
+      edog = (struct edog *)0;
 	if(!quietly && cansee(mtmp->mx, mtmp->my)) {
 	    if (haseyes(youracedata)) {
 		if (haseyes(mtmp->data))
@@ -1615,7 +1615,8 @@ boolean was_dead;
     } else {
 	/* chance it goes wild anyway - Pet Semetary */
 	if (!(edog && (edog->loyal || edog->dominated)) && !rn2(mtmp->mtame)) {
-	    untame(mtmp, 0);
+      untame(mtmp, 0);
+      edog = (struct edog *)0;
 	}
     }
     if (!mtmp->mtame) {


### PR DESCRIPTION
untame actually frees edog - it wouldn't surprise me if there are more
ways something similar can occur with various mextra fields, but this
one was found via fuzzing