### PR TITLE
Tensa interrupts occupations too.

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -768,6 +768,7 @@ you_calc_movement()
 					body_part(BONES), rnd(6) ? body_part(CREAK) : body_part(CRACK));
 				exercise(A_CON, FALSE);
 				exercise(A_STR, FALSE);
+				stop_occupation();
 				nomul(0, NULL);
 			}
 		}


### PR DESCRIPTION
Note: `nomul(0,NULL)` does not interrupt occupations.
Closes #1963 