### PR TITLE
Make more levels bones eligible!

### DIFF
--- a/dat/dngnch1.def
+++ b/dat/dngnch1.def
@@ -37,13 +37,13 @@ LEVALIGN:	chaotic
 RNDLEVEL:	"castle" "none" @ (-1, 0) 6
 CHAINBRANCH:	"Gehennom" "castle" + (0, 0) no_down
 
-RNDLEVEL:		"lawlev" "none" @ (12, 8) 3
+RNDLEVEL:		"lawlev" "L" @ (12, 8) 3
 LEVALIGN:	lawful
 CHAINBRANCH:	"Law Quest" "lawlev" + (0, 0) portal
-LEVEL:		"neulev" "none" @ (12, 8)
+LEVEL:		"neulev" "N" @ (12, 8)
 LEVALIGN:	neutral
 CHAINBRANCH:	"Neutral Quest" "neulev" + (0, 0) portal
-LEVEL:		"chalev" "none" @ (12, 8)
+LEVEL:		"chalev" "C" @ (12, 8)
 LEVALIGN:	chaotic
 CHAINBRANCH:	"Chaos Quest" "chalev" + (0, 0) portal
 BRANCH:		"The Elemental Planes" @ (1, 0) no_down up
@@ -180,7 +180,7 @@ ENTRY:		2
 DUNGEON:		"Chaos Quest" "C" (9, 0)
 DESCRIPTION:    mazelike
 ALIGNMENT:      chaotic
-LEVEL:		"chaosf" "none" @ (1, 0)
+LEVEL:		"chaosf" "F" @ (1, 0)
 LEVEL:		"chaoss" "A" @ (2, 0)
 LEVEL:		"chaost" "B" @ (3, 0)
 LEVEL:		"chaosm" "M" @ (4, 0)

--- a/dat/dngnch2.def
+++ b/dat/dngnch2.def
@@ -37,13 +37,13 @@ LEVALIGN:	chaotic
 RNDLEVEL:	"castle" "none" @ (-1, 0) 6
 CHAINBRANCH:	"Gehennom" "castle" + (0, 0) no_down
 
-RNDLEVEL:		"lawlev" "none" @ (12, 8) 3
+RNDLEVEL:		"lawlev" "L" @ (12, 8) 3
 LEVALIGN:	lawful
 CHAINBRANCH:	"Law Quest" "lawlev" + (0, 0) portal
-LEVEL:		"neulev" "none" @ (12, 8)
+LEVEL:		"neulev" "N" @ (12, 8)
 LEVALIGN:	neutral
 CHAINBRANCH:	"Neutral Quest" "neulev" + (0, 0) portal
-LEVEL:		"chalv2" "none" @ (12, 8)
+LEVEL:		"chalv2" "C" @ (12, 8)
 LEVALIGN:	chaotic
 CHAINBRANCH:	"Chaos Quest" "chalv2" + (0, 0) portal
 BRANCH:		"The Elemental Planes" @ (1, 0) no_down up
@@ -180,7 +180,7 @@ ENTRY:		2
 DUNGEON:		"Chaos Quest" "S" (10, 0)
 DESCRIPTION:    mazelike
 ALIGNMENT:      chaotic
-LEVEL:		"ossa1" "none" @ (1, 0)
+LEVEL:		"ossa1" "O" @ (1, 0)
 LEVEL:		"mith1" "A" @ (2, 0)
 LEVEL:		"mith2" "B" @ (3, 0)
 LEVEL:		"mith3" "C" @ (4, 0)

--- a/dat/dngnch3.def
+++ b/dat/dngnch3.def
@@ -37,13 +37,13 @@ LEVALIGN:	chaotic
 RNDLEVEL:	"castle" "none" @ (-1, 0) 6
 CHAINBRANCH:	"Gehennom" "castle" + (0, 0) no_down
 
-RNDLEVEL:		"lawlev" "none" @ (12, 8) 3
+RNDLEVEL:		"lawlev" "L" @ (12, 8) 3
 LEVALIGN:	lawful
 CHAINBRANCH:	"Law Quest" "lawlev" + (0, 0) portal
-LEVEL:		"neulev" "none" @ (12, 8)
+LEVEL:		"neulev" "N" @ (12, 8)
 LEVALIGN:	neutral
 CHAINBRANCH:	"Neutral Quest" "neulev" + (0, 0) portal
-LEVEL:		"chalv3" "none" @ (12, 8)
+LEVEL:		"chalv3" "C" @ (12, 8)
 LEVALIGN:	chaotic
 CHAINBRANCH:	"Chaos Quest" "chalv3" + (0, 0) portal
 BRANCH:		"The Elemental Planes" @ (1, 0) no_down up
@@ -180,7 +180,7 @@ ENTRY:		2
 DUNGEON:		"Chaos Quest" "F" (15, 0)
 DESCRIPTION:    mazelike
 ALIGNMENT:      chaotic
-LEVEL:		"frst1" "none" @ (1, 0)
+LEVEL:		"frst1" "A" @ (1, 0)
 LEVEL:		"frst2" "B" @ (2, 0)
 LEVEL:		"frst3" "C" @ (3, 0)
 LEVEL:		"ford"  "none" @ (4, 0)

--- a/include/extern.h
+++ b/include/extern.h
@@ -724,6 +724,7 @@ E void NDECL(init_dungeons);
 E s_level *FDECL(find_level, (const char *));
 E s_level *FDECL(Is_special, (d_level *));
 E branch *FDECL(Is_branchlev, (d_level *));
+E d_level *FDECL(branchlev_other_end, (branch *, d_level *));
 E int FDECL(ledger_no, (d_level *));
 E int NDECL(maxledgerno);
 E schar FDECL(depth, (d_level *));

--- a/src/bones.c
+++ b/src/bones.c
@@ -10,6 +10,7 @@ extern char bones[];	/* from files.c */
 extern long bytes_counted;
 #endif
 
+STATIC_DCL boolean FDECL(no_bones_level_core, (d_level *, boolean));
 STATIC_DCL boolean FDECL(no_bones_level, (d_level *));
 STATIC_DCL void FDECL(goodfruit, (int));
 STATIC_DCL void FDECL(resetobjs,(struct obj *,BOOLEAN_P));
@@ -17,22 +18,33 @@ STATIC_DCL void FDECL(drop_upon_death, (struct monst *, struct obj *, int, int))
 STATIC_DCL void FDECL(sanitize_name, (char *namebuf));
 
 STATIC_OVL boolean
-no_bones_level(lev)
+no_bones_level_core(lev, recursed)
 d_level *lev;
+boolean recursed;
 {
 	extern d_level save_dlevel;		/* in do.c */
 	s_level *sptr;
+	branch * bptr;
 
 	if (ledger_no(&save_dlevel)) assign_level(lev, &save_dlevel);
 
 	return (boolean)(((sptr = Is_special(lev)) != 0 && !sptr->boneid)
 		|| !dungeons[lev->dnum].boneid
-		   /* no bones on the last or multiway branch levels */
-		   /* in any dungeon (level 1 isn't multiway).       */
-		|| Is_botlevel(lev) || (Is_branchlev(lev) && lev->dlevel > 1)
+			/* no bones in the branch level TO the Quest (because this portal can be voided) */
+		|| (!recursed && (bptr = Is_branchlev(lev)) && In_quest(branchlev_other_end(bptr, lev)))
+			/* no bones in a branch level if the other end is nobones */
+		|| (!recursed && (bptr = Is_branchlev(lev)) && no_bones_level_core(branchlev_other_end(bptr, lev), TRUE))
 		   /* no bones in the invocation level               */
 		|| (In_hell(lev) && lev->dlevel == dunlevs_in_dungeon(lev) - 1)
 		);
+}
+
+/* wrapper for no_bones_level_core, so that it and only it can recursively call itself with recursed = TRUE */
+STATIC_OVL boolean
+no_bones_level(lev)
+d_level * lev;
+{
+	return no_bones_level_core(lev, FALSE);
 }
 
 /* Call this function for each fruit object saved in the bones level: it marks
@@ -373,11 +385,6 @@ can_make_bones()
 	    return FALSE;		/* no bones for specific levels */
 	if (u.uswallow) {
 	    return FALSE;		/* no bones when swallowed */
-	}
-	if (!Is_branchlev(&u.uz)) {
-	    /* no bones on non-branches with portals */
-	    for(ttmp = ftrap; ttmp; ttmp = ttmp->ntrap)
-		if (ttmp->ttyp == MAGIC_PORTAL) return FALSE;
 	}
 
 	if(depth(&u.uz) <= 0 ||		/* bulletproofing for endgame */

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1194,6 +1194,21 @@ Is_branchlev(lev)
 	return (branch *) 0;
 }
 
+d_level *
+branchlev_other_end(bptr, lev)
+branch * bptr;
+d_level * lev;
+{
+	d_level * other_end;
+	if (bptr->end1.dnum == lev->dnum && bptr->end1.dlevel == lev->dlevel)
+		other_end = &(bptr->end2);
+	else if (bptr->end2.dnum == lev->dnum && bptr->end2.dlevel == lev->dlevel)
+		other_end = &(bptr->end1);
+	else
+		other_end = (d_level *)0;
+	return other_end;
+}
+
 /* goto the next level (or appropriate dungeon) */
 void
 next_level(at_stairs)

--- a/src/files.c
+++ b/src/files.c
@@ -695,7 +695,9 @@ d_level *lev;
 {
 	static char bonesid[16];
 	s_level *sptr;
+	branch * bptr;
 	char *dptr;
+	char *bspr;
 
 	Sprintf(bonesid, "%c%s", dungeons[lev->dnum].boneid,
 			In_quest(lev) ? urole.filecode : "0");
@@ -704,6 +706,13 @@ d_level *lev;
 	    Sprintf(dptr, ".%c", sptr->boneid);
 	else
 	    Sprintf(dptr, ".%d", lev->dlevel);
+	if ((bptr = Is_branchlev(lev)) != 0)
+	{
+		bspr = eos(dptr);
+		d_level * end = branchlev_other_end(bptr, lev);
+		Sprintf(bspr, ".%c%s", dungeons[end->dnum].boneid,
+			In_quest(end) ? urole.filecode : "0");
+	}
 	Sprintf(file, "bon%s", bonesid);
 #ifdef BONES_POOL
 	Sprintf(eos(file), ".%ld", (u.ubirthday % 10));

--- a/src/restore.c
+++ b/src/restore.c
@@ -996,39 +996,28 @@ boolean ghostly;
 	    }
 
 	    br = Is_branchlev(&u.uz);
-	    if (br && u.uz.dlevel == 1) {
-		d_level ltmp;
+	    if (br //&& u.uz.dlevel == 1
+			) {
+			d_level * ltmp = branchlev_other_end(br, &u.uz);
 
-		if (on_level(&u.uz, &br->end1))
-		    assign_level(&ltmp, &br->end2);
-		else
-		    assign_level(&ltmp, &br->end1);
-
-		switch(br->type) {
-		case BR_STAIR:
-		case BR_NO_END1:
-		case BR_NO_END2: /* OK to assign to sstairs if it's not used */
-		    assign_level(&sstairs.tolev, &ltmp);
-		    break;		
-		case BR_PORTAL: /* max of 1 portal per level */
-		    {
-			register struct trap *ttmp;
-			for(ttmp = ftrap; ttmp; ttmp = ttmp->ntrap)
-			    if (ttmp->ttyp == MAGIC_PORTAL)
+			switch(br->type) {
+			case BR_STAIR:
+			case BR_NO_END1:
+			case BR_NO_END2: /* OK to assign to sstairs if it's not used */
+				assign_level(&sstairs.tolev, ltmp);
+				break;		
+			case BR_PORTAL:
+				{
+				register struct trap *ttmp;
+				/* find the portal on the level that links to the correct dungeon, we will correct which dlevel it goes to */
+				for(ttmp = ftrap; ttmp; ttmp = ttmp->ntrap)
+					if (ttmp->ttyp == MAGIC_PORTAL && ttmp->dst.dnum == ltmp->dnum)
+					break;
+				if (!ttmp) panic("getlev: need portal but none found");
+				assign_level(&ttmp->dst, ltmp);
+				}
 				break;
-			if (!ttmp) panic("getlev: need portal but none found");
-			assign_level(&ttmp->dst, &ltmp);
-		    }
-		    break;
-		}
-	    } else if (!br) {
-		/* Remove any dangling portals. */
-		register struct trap *ttmp;
-		for (ttmp = ftrap; ttmp; ttmp = ttmp->ntrap)
-		    if (ttmp->ttyp == MAGIC_PORTAL) {
-			deltrap(ttmp);
-			break; /* max of 1 portal/level */
-		    }
+			}
 	    }
 	}
 


### PR DESCRIPTION
Portals and Branches no longer make levels bones-ineligible.

Portals
* The level branching to the Quest is explicitly ineligible, because that portal can be destroyed.
* Branches accessed via portal try to find the portal on the bones level leading to the other end of the branch.

Branches
* Bones save branch levels with an ID indicating the Dungeon that was being branched to (or none)
* * ex, ID is "MainDungeon.NeutralEntrance.BranchingToNeutrality"
* * ex, ID is "MainDungeon.dLevel16.BranchingToLostTomb"
* * ex, ID is "LostTomb.LostTomb.BranchingToMainDungeon"
* Bones don't save exact level (Special char / dlevel) because it makes dlevel branches much less likely to be found, and there are no side effects that I can think of.