### PR TITLE
Fix physical breath attacks

### DIFF
--- a/src/projectile.c
+++ b/src/projectile.c
@@ -2856,7 +2856,12 @@ int tary;
 	/* message */
 	if (youagr || canseemon(magr)) {
 		char * bofp = flash_type(typ, ZAP_BREATH);
-		char * p = strstri(bofp, " of ")+4;
+		char * p = strstri(bofp, " of ");
+
+		if (p) {
+			p += 4;
+			if (!*p) p = NULL;
+		}
 		
 		/* some breaths sound better as "a noun of x" */
 		if (typ == AD_DISN || typ == AD_BLUD)

--- a/src/zap.c
+++ b/src/zap.c
@@ -4129,6 +4129,10 @@ struct zapdata * zapdata;
 
 	/* do effects of zap */
 	switch (zapdata->adtyp) {
+	case AD_PHYS:
+		if (Half_phys(mdef))
+			dmg = (dmg + 1) / 2;
+		return xdamagey(magr, mdef, &attk, dmg);
 	case AD_MAGM:
 		/* check resist */
 		if (Magic_res(mdef)) {


### PR DESCRIPTION
If a shambling horror rolled a breath attack with physical damage it would crash due to a string formatted differently from what was expected and incorrect handling of that

Additionally had it worked there would have been an impossible thrown, so I've added it and given half physical damage a benefit here

Fixes #2046 