### PR TITLE
Add rcfile option to set fg color, bg color, and symbol for any template

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -321,8 +321,8 @@
 #define GLYPH_MON_OFF		0
 #define GLYPH_PET_OFF		(NUMMONS	+ GLYPH_MON_OFF)
 #define GLYPH_PEACE_OFF		(NUMMONS	+ GLYPH_PET_OFF)
-#define GLYPH_ZOMBIE_OFF	(NUMMONS	+ GLYPH_PEACE_OFF)
-#define GLYPH_INVIS_OFF		(NUMMONS	+ GLYPH_ZOMBIE_OFF)
+#define GLYPH_MTEMPLATE_OFF	(NUMMONS	+ GLYPH_PEACE_OFF)
+#define GLYPH_INVIS_OFF		(NUMMONS*MAXTEMPLATE	+ GLYPH_MTEMPLATE_OFF)
 #define GLYPH_DETECT_OFF	(1		+ GLYPH_INVIS_OFF)
 #define GLYPH_BODY_OFF		(NUMMONS	+ GLYPH_DETECT_OFF)
 #define GLYPH_RIDDEN_OFF	(NUMMONS	+ GLYPH_BODY_OFF)
@@ -344,7 +344,7 @@
 #define ridden_mon_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_RIDDEN_OFF)
 #define pet_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_PET_OFF)
 #define peace_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_PEACE_OFF)
-#define zombie_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_ZOMBIE_OFF)
+#define mtemplate_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_MTEMPLATE_OFF)
 
 #define cmap_to_glyph(cmap_idx) ((int) (cmap_idx)   + GLYPH_CMAP_OFF)
 #define explosion_to_glyph(expltype,idx)	\
@@ -360,7 +360,7 @@
 #define ridden_monnum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_RIDDEN_OFF)
 #define petnum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_PET_OFF)
 #define peacenum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_PEACE_OFF)
-#define zombienum_to_glyph(mtyp)	((int) (mtyp) + GLYPH_ZOMBIE_OFF)
+#define mtemplatenum_to_glyph(mtyp, mtemplate)	((int) (mtyp) + GLYPH_MTEMPLATE_OFF + NUMMONS*(mtemplate-1))
 
 /* The hero's glyph when seen as a monster.
  */
@@ -386,7 +386,7 @@
 	(glyph_is_normal_monster(glyph) ? ((glyph)-GLYPH_MON_OFF) :	\
 	glyph_is_pet(glyph) ? ((glyph)-GLYPH_PET_OFF) :			\
 	glyph_is_peace(glyph) ? ((glyph)-GLYPH_PEACE_OFF) :			\
-	glyph_is_zombie(glyph) ? ((glyph)-GLYPH_ZOMBIE_OFF) :			\
+	glyph_is_mtemplate(glyph) ? (((glyph)-GLYPH_MTEMPLATE_OFF) % NUMMONS) :			\
 	glyph_is_detected_monster(glyph) ? ((glyph)-GLYPH_DETECT_OFF) :	\
 	glyph_is_ridden_monster(glyph) ? ((glyph)-GLYPH_RIDDEN_OFF) :	\
 	NO_GLYPH)
@@ -416,7 +416,7 @@
 		(glyph_is_normal_monster(glyph)				\
 		|| glyph_is_pet(glyph)					\
 		|| glyph_is_peace(glyph)					\
-		|| glyph_is_zombie(glyph)					\
+		|| glyph_is_mtemplate(glyph)					\
 		|| glyph_is_ridden_monster(glyph)			\
 		|| glyph_is_detected_monster(glyph))
 #define glyph_is_normal_monster(glyph)					\
@@ -425,8 +425,8 @@
     ((glyph) >= GLYPH_PET_OFF && (glyph) < (GLYPH_PET_OFF+NUMMONS))
 #define glyph_is_peace(glyph)						\
     ((glyph) >= GLYPH_PEACE_OFF && (glyph) < (GLYPH_PEACE_OFF+NUMMONS))
-#define glyph_is_zombie(glyph)						\
-    ((glyph) >= GLYPH_ZOMBIE_OFF && (glyph) < (GLYPH_ZOMBIE_OFF+NUMMONS))
+#define glyph_is_mtemplate(glyph)						\
+    ((glyph) >= GLYPH_MTEMPLATE_OFF && (glyph) < (GLYPH_MTEMPLATE_OFF+NUMMONS*MAXTEMPLATE))
 #define glyph_is_body(glyph)						\
     ((glyph) >= GLYPH_BODY_OFF && (glyph) < (GLYPH_BODY_OFF+NUMMONS))
 #define glyph_is_ridden_monster(glyph)					\

--- a/include/extern.h
+++ b/include/extern.h
@@ -2108,6 +2108,7 @@ E void NDECL(free_autopickup_exceptions);
 E boolean FDECL(add_menu_coloring, (char *));
 #endif /* MENU_COLOR */
 E boolean FDECL(parse_monster_color, (char *));
+E boolean FDECL(parse_monster_template, (char *));
 E int FDECL(parse_codepoint, (char *));
 E boolean FDECL(parse_monster_symbol, (const char *));
 E boolean FDECL(parse_object_symbol, (const char *));

--- a/include/flag.h
+++ b/include/flag.h
@@ -371,7 +371,6 @@ struct instance_flags {
 	boolean wc_color;		/* use color graphics                  */
 	boolean wc_hilite_pet;		/* hilight pets (blue)                    */
 	boolean wc_hilite_peaceful;		/* hilight peaceful monsters (brown)   */
-	boolean wc_hilite_zombies;		/* hilight pets  (green)               */
 	boolean wc_zombie_z;		/* show zombies as Z of monster's color    */
 	boolean wc_hilite_detected;		/* hilight detected monsters (magenta)   */
 	boolean wc_ascii_map;		/* show map using traditional ascii    */
@@ -453,6 +452,12 @@ struct instance_flags {
 #ifdef REALTIME_ON_BOTL
   boolean  showrealtime; /* show actual elapsed time */
 #endif
+	struct {
+		int set;
+		int fg;
+		int bg;
+		char symbol;
+	} monstertemplate[MAXTEMPLATE];
 };
 
 /*
@@ -466,8 +471,6 @@ struct instance_flags {
 #endif
 #define hilite_pet wc_hilite_pet
 #define hilite_peaceful wc_hilite_peaceful
-#define hilite_zombies wc_hilite_zombies
-#define zombie_z wc_zombie_z
 #define hilite_detected wc_hilite_detected
 #define use_inverse wc_inverse
 #ifdef MAC_GRAPHICS_ENV
@@ -506,5 +509,10 @@ extern NEARDATA struct instance_flags iflags;
 	(((magr) == &youmonst) ? WIZCOMBATDEBUG_UVM : 0) | \
 	(((mdef) == &youmonst) ? WIZCOMBATDEBUG_MVU : 0)   \
 	))
+
+/* monstertemplate options */
+#define MONSTERTEMPLATE_FOREGROUND	0x1
+#define MONSTERTEMPLATE_BACKGROUND	0x2
+#define MONSTERTEMPLATE_SYMBOL		0x4
 
 #endif /* FLAG_H */

--- a/src/display.c
+++ b/src/display.c
@@ -492,19 +492,12 @@ display_monster(x, y, mon, sightflags, worm_tail)
 	    else
 		num = peacenum_to_glyph(appear);
 	}
-	else if (!Hallucination && (
-				has_template(mon, VAMPIRIC) ||
-				has_template(mon, ZOMBIFIED) ||
-				has_template(mon, SKELIFIED) ||
-				has_template(mon, CRYSTALFIED) ||
-				has_template(mon, SLIME_REMNANT) ||
-				has_template(mon, FRACTURED)
-			)) {
+	else if (!Hallucination && mon->mtemplate != 0) {
 	    if (worm_tail) num = mon->mtyp == PM_HUNTING_HORROR ?
-			zombienum_to_glyph(PM_HUNTING_HORROR_TAIL):
-			zombienum_to_glyph(PM_LONG_WORM_TAIL);
+			mtemplatenum_to_glyph(PM_HUNTING_HORROR_TAIL, mon->mtemplate):
+			mtemplatenum_to_glyph(PM_LONG_WORM_TAIL, mon->mtemplate);
 	    else
-		num = zombienum_to_glyph(appear);
+		num = mtemplatenum_to_glyph(appear, mon->mtemplate);
 	/* [ALI] Only use detected glyphs when monster wouldn't be
 	 * visible by any other means.
 	 */
@@ -1464,8 +1457,8 @@ show_glyph(x,y,glyph)
 	    text = "detected mon";	offset = glyph - GLYPH_DETECT_OFF;
 	} else if (glyph >= GLYPH_INVIS_OFF) {		/* invisible mon */
 	    text = "invisible mon";	offset = glyph - GLYPH_INVIS_OFF;
-	} else if (glyph >= GLYPH_ZOMBIE_OFF) {		/* a zombie */
-	    text = "zombie";		offset = glyph - GLYPH_ZOMBIE_OFF;
+	} else if (glyph >= GLYPH_MTEMPLATE_OFF) {		/* a zombie */
+	    text = "mtemplate";		offset = glyph - GLYPH_MTEMPLATE_OFF;
 	} else if (glyph >= GLYPH_PEACE_OFF) {		/* a peaceful monster */
 	    text = "peaceful mon";		offset = glyph - GLYPH_PEACE_OFF;
 	} else if (glyph >= GLYPH_PET_OFF) {		/* a pet */
@@ -1627,8 +1620,8 @@ int glyph;
 	ch = def_monsyms[(int)mons[offset].mlet];
     } else if ((offset = (glyph - GLYPH_INVIS_OFF)) >= 0) {  /* invisible */
 	ch = DEF_INVISIBLE;
-    } else if ((offset = (glyph - GLYPH_ZOMBIE_OFF)) >= 0) {	/* a zombie */
-	ch = def_monsyms[(int)mons[offset].mlet];
+    } else if ((offset = (glyph - GLYPH_MTEMPLATE_OFF)) >= 0) {	/* a templated monster */
+	ch = def_monsyms[(int)mons[offset % NUMMONS].mlet];
     } else if ((offset = (glyph - GLYPH_PEACE_OFF)) >= 0) {	/* a peaceful monster */
 	ch = def_monsyms[(int)mons[offset].mlet];
     } else if ((offset = (glyph - GLYPH_PET_OFF)) >= 0) {	/* a pet */

--- a/src/files.c
+++ b/src/files.c
@@ -2056,7 +2056,9 @@ char		*tmp_levels;
 #endif
 	} else if (match_varname(buf, "MONSTERCOLOR", 12)) {
 	    return parse_monster_color(bufp);
-	} else if (match_varname(buf, "MONSTERSYMBOL", 13)) {
+	} else if (match_varname(buf, "MONSTERTEMPLATE", 15)) {
+	    return parse_monster_template(bufp);
+	}else if (match_varname(buf, "MONSTERSYMBOL", 13)) {
 	    return parse_monster_symbol(bufp);
 	} else if (match_varname(buf, "OBJECTSYMBOL", 12)) {
 	    return parse_object_symbol(bufp);

--- a/src/options.c
+++ b/src/options.c
@@ -124,14 +124,10 @@ static struct Bool_Opt
 	{"hilite_pet",    &iflags.wc_hilite_pet, TRUE, SET_IN_GAME},	/*WC*/
 #ifdef WIN32CON
 	{"hilite_peaceful",    &iflags.wc_hilite_peaceful, FALSE, SET_IN_GAME},	/*WC*/
-	{"hilite_zombie",    &iflags.wc_hilite_zombies, FALSE, SET_IN_GAME},	/*WC*/
-	{"zombies_as_Z",    &iflags.wc_zombie_z, TRUE, SET_IN_GAME},	/*WC*/
 	{"hilite_detected",    &iflags.wc_hilite_detected, FALSE, SET_IN_GAME},	/*WC*/
 	{"use_inverse",   &iflags.wc_inverse, TRUE, SET_IN_GAME},		/*WC*/
 #else
 	{"hilite_peaceful",    &iflags.wc_hilite_peaceful, TRUE, SET_IN_GAME},	/*WC*/
-	{"hilite_zombie",    &iflags.wc_hilite_zombies, TRUE, SET_IN_GAME},	/*WC*/
-	{"zombies_as_Z",    &iflags.wc_zombie_z, FALSE, SET_IN_GAME},	/*WC*/
 	{"hilite_detected",    &iflags.wc_hilite_detected, TRUE, SET_IN_GAME},	/*WC*/
 	{"use_inverse",   &iflags.wc_inverse, FALSE, SET_IN_GAME},		/*WC*/
 #endif
@@ -1495,6 +1491,126 @@ parse_monster_color(str)
     } else {
 	return FALSE;
     }
+}
+
+/* parse template:target:value and set corresponding in iflags */
+boolean
+parse_monster_template(str)
+char * str;
+{
+    int i, c = NO_COLOR, template;
+	char s;
+	int type = 0;
+    char *s_temp, *s_type, *s_val;
+    char buf[BUFSZ];
+
+    if (!str) return FALSE;
+
+    strncpy(buf, str, BUFSZ);
+	s_temp = buf;
+    s_type = strchr(s_temp, ':');
+    if (!s_type) return FALSE;
+	else s_type++;
+	s_val = strchr(s_type, ':');
+	if (!s_val) return FALSE;
+	else s_val++;
+
+    /* skip whitespace at start of strings */
+    while (*s_temp && isspace(*s_temp)) s_temp++;
+	while (*s_type && isspace(*s_type)) s_type++;
+	while (*s_val  && isspace(*s_val )) s_val++;
+
+	/* determine template */
+	if (strstri(s_temp, "zombi") == s_temp)
+		template = ZOMBIFIED;
+	else if (strstri(s_temp, "skel") == s_temp)
+		template = SKELIFIED;
+	else if ((strstri(s_temp, "cryst") == s_temp) || strstri(s_temp, "vitri") == s_temp)
+		template = CRYSTALFIED;
+	else if ((strstri(s_temp, "fracture") == s_temp) || (strstri(s_temp, "witness") == s_temp))
+		template = FRACTURED;
+	else if (strstri(s_temp, "vampir") == s_temp)
+		template = VAMPIRIC;
+	else if ((strstri(s_temp, "illuminated") == s_temp) || (strstri(s_temp, "shining") == s_temp))
+		template = ILLUMINATED;
+	else if (strstri(s_temp, "pseudo") == s_temp)
+		template = PSEUDONATURAL;
+	else if (strstri(s_temp, "tomb") == s_temp)
+		template = TOMB_HERD;
+	else if (strstri(s_temp, "yith") == s_temp)
+		template = YITH;
+	else if (strstri(s_temp, "crani") == s_temp)
+		template = CRANIUM_RAT;
+	else if (strstri(s_temp, "mistweaver") == s_temp)
+		template = MISTWEAVER;
+	else if (strstri(s_temp, "deloused") == s_temp)
+		template = DELOUSED;
+	else if (strstri(s_temp, "black web") == s_temp)
+		template = M_BLACK_WEB;
+	else if (strstri(s_temp, "great web") == s_temp)
+		template = M_GREAT_WEB;
+	else if (strstri(s_temp, "slime") == s_temp)
+		template = SLIME_REMNANT;
+	else if (strstri(s_temp, "yellow") == s_temp)
+		template = YELLOW_TEMPLATE;
+	else if (strstri(s_temp, "dream") == s_temp)
+		template = DREAM_LEECH;
+	else if (strstri(s_temp, "mad") == s_temp)
+		template = MAD_TEMPLATE;
+	else if (strstri(s_temp, "fallen") == s_temp)
+		template = FALLEN_TEMPLATE;
+	else if (strstri(s_temp, "world") == s_temp)
+		template = WORLD_SHAPER;
+	else if (strstri(s_temp, "mindless") == s_temp)
+		template = MINDLESS;
+	else if (strstri(s_temp, "poison") == s_temp)
+		template = POISON_TEMPLATE;
+	else if (strstri(s_temp, "moly") == s_temp)
+		template = MOLY_TEMPLATE;
+	else
+		return FALSE;
+
+	/* determine type */
+	if ((strstri(s_type, "fg") == s_type) ||
+		(strstri(s_type, "fore") == s_type))
+		type = MONSTERTEMPLATE_FOREGROUND;
+	else if ((strstri(s_type, "bg") == s_type) ||
+			(strstri(s_type, "back") == s_type))
+		type = MONSTERTEMPLATE_BACKGROUND;
+	else if (strstri(s_type, "sym") == s_type)
+		type = MONSTERTEMPLATE_SYMBOL;
+	else
+		return FALSE;
+    /* determine color, if type is forground or background */
+	if (type == MONSTERTEMPLATE_BACKGROUND || type == MONSTERTEMPLATE_FOREGROUND) {
+		for (i = 0; i < SIZE(colornames); i++)
+		if (strstri(s_val, colornames[i].name) == s_val) {
+			c = colornames[i].color;
+			break;
+		}
+		if ((i == SIZE(colornames)) && (*s_val >= '0' && *s_val <='9'))
+			c = atoi(s_val);
+		if (c > 15) return FALSE;
+	}
+	/* read symbol, if type is symbol */
+	else {
+		if (!(*s_val)) return FALSE;
+		s = *s_val;
+	}
+	switch(type) {
+		case MONSTERTEMPLATE_FOREGROUND:
+			iflags.monstertemplate[template - 1].fg = c;
+			break;
+		case MONSTERTEMPLATE_BACKGROUND:
+			iflags.monstertemplate[template - 1].bg = c;
+			break;
+		case MONSTERTEMPLATE_SYMBOL:
+			iflags.monstertemplate[template - 1].symbol = s;
+			break;
+	}
+	iflags.monstertemplate[template - 1].set |= type;
+
+	return TRUE;
 }
 
 /** Split up a string that matches name:value or 'name':value and

--- a/win/curses/cursdial.c
+++ b/win/curses/cursdial.c
@@ -996,9 +996,9 @@ menu_display_page(nhmenu *menu, WINDOW * win, int page_num)
             start_col += 4;
         }
         if (menu_item_ptr->glyph != NO_GLYPH && iflags.use_menu_glyphs) {
-            unsigned special;   /*notused */
+            unsigned bgcolor;   /*notused */
 			glyph_t curglyph = (glyph_t)curletter;//Note: a glyph is a long int
-            mapglyph(menu_item_ptr->glyph, &curglyph, &color, &special, u.ux, u.uy);
+            mapglyph(menu_item_ptr->glyph, &curglyph, &color, &bgcolor, u.ux, u.uy);
 			curletter = (int)curglyph;//This seems bad, but it makes explicit what this code was always doing...
             curses_toggle_color_attr(win, color, NONE, ON);
             mvwaddch(win, menu_item_ptr->line_num + 1, start_col, curletter);

--- a/win/curses/cursinit.c
+++ b/win/curses/cursinit.c
@@ -387,57 +387,29 @@ curses_init_nhcolors()
 #ifdef TEXTCOLOR
     if (has_colors()) {
         use_default_colors();
-        init_pair(1, COLOR_BLACK, -1);
-        init_pair(2, COLOR_RED, -1);
-        init_pair(3, COLOR_GREEN, -1);
-        init_pair(4, COLOR_YELLOW, -1);
-        init_pair(5, COLOR_BLUE, -1);
-        init_pair(6, COLOR_MAGENTA, -1);
-        init_pair(7, COLOR_CYAN, -1);
-        init_pair(8, -1, -1);
-
-        {
-            int i;
-
-            int clr_remap[16] = {
-                COLOR_BLACK, COLOR_RED, COLOR_GREEN, COLOR_YELLOW,
-                COLOR_BLUE,
-                COLOR_MAGENTA, COLOR_CYAN, -1, COLOR_WHITE,
-                COLOR_RED + 8, COLOR_GREEN + 8, COLOR_YELLOW + 8,
-                COLOR_BLUE + 8,
-                COLOR_MAGENTA + 8, COLOR_CYAN + 8, COLOR_WHITE + 8
-            };
-
-            for (i = 0; i < (COLORS >= 16 ? 16 : 8); i++) {
-                init_pair(17 + (i * 2) + 0, clr_remap[i], COLOR_RED);
-                init_pair(17 + (i * 2) + 1, clr_remap[i], COLOR_BLUE);
-            }
-
-            boolean hicolor = FALSE;
-            if (COLORS >= 16)
-                hicolor = TRUE;
-
-            /* Work around the crazy definitions above for more background colors... */
-            for (i = 0; i < (COLORS >= 16 ? 16 : 8); i++) {
-                init_pair((hicolor ? 49 : 9) + i, clr_remap[i], COLOR_GREEN);
-                init_pair((hicolor ? 65 : 33) + i, clr_remap[i], COLOR_YELLOW);
-                init_pair((hicolor ? 81 : 41) + i, clr_remap[i], COLOR_MAGENTA);
-                init_pair((hicolor ? 97 : 49) + i, clr_remap[i], COLOR_CYAN);
-                init_pair((hicolor ? 113 : 57) + i, clr_remap[i], COLOR_WHITE);
-            }
-        }
-
-
-        if (COLORS >= 16) {
-            init_pair(9, COLOR_WHITE, -1);
-            init_pair(10, COLOR_RED + 8, -1);
-            init_pair(11, COLOR_GREEN + 8, -1);
-            init_pair(12, COLOR_YELLOW + 8, -1);
-            init_pair(13, COLOR_BLUE + 8, -1);
-            init_pair(14, COLOR_MAGENTA + 8, -1);
-            init_pair(15, COLOR_CYAN + 8, -1);
-            init_pair(16, COLOR_WHITE + 8, -1);
-        }
+		int i, j;
+		int cnum = COLORS >= 16 ? 16 : 8;
+		int clr_remap[16] = {
+			COLOR_BLACK, COLOR_RED, COLOR_GREEN, COLOR_YELLOW,
+			COLOR_BLUE,
+			COLOR_MAGENTA, COLOR_CYAN, -1, COLOR_WHITE,
+			COLOR_RED + 8, COLOR_GREEN + 8, COLOR_YELLOW + 8,
+			COLOR_BLUE + 8,
+			COLOR_MAGENTA + 8, COLOR_CYAN + 8, COLOR_WHITE + 8
+		};
+		/* standard colors */
+		for (i=0; i < cnum; i++) {
+			init_pair(i+1, clr_remap[i], -1);
+		}
+		/* with backgrounds */
+		for (i=0; i < cnum; i++) {
+			for (j=0; j < cnum; j++) {
+				if (i != j)
+					init_pair(j + i*cnum + cnum + 1, clr_remap[j], clr_remap[i]);
+				else
+					init_pair(j + i*cnum + cnum + 1, COLOR_BLACK, clr_remap[j]);
+			}
+		}
 
         if (can_change_color()) {
             /* Preserve initial terminal colors */

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -553,26 +553,14 @@ curses_print_glyph(winid wid, XCHAR_P x, XCHAR_P y, int glyph)
 {
     glyph_t ch;
     int color;
-    unsigned int special;
+    unsigned int bgcolor;
     int attr = -1;
 
     /* map glyph to character and color */
-    mapglyph(glyph, &ch, &color, &special, x, y);
-    if ((special & MG_PET) && iflags.hilite_pet)
-        attr = curses_color_attr(color, CLR_BLUE);
-    else if ((special & MG_STAIRS) && iflags.hilite_hidden_stairs)
-        attr = curses_color_attr(color, CLR_RED);
-    else if ((special & MG_PEACE) && iflags.hilite_peaceful)
-        attr = curses_color_attr(color, CLR_BROWN);
-    else if (special & MG_ZOMBIE) {
-        if (iflags.hilite_zombies)
-            attr = curses_color_attr(color, CLR_GREEN);
-        if (iflags.zombie_z)
-            ch = 'Z';
-    } else if ((special & MG_DETECT) && iflags.hilite_detected)
-        attr = curses_color_attr(color, CLR_MAGENTA);
-    else if (special & MG_OBJPILE && iflags.hilite_obj_piles)
-        attr = curses_color_attr(color, CLR_BLUE);
+    mapglyph(glyph, &ch, &color, &bgcolor, x, y);
+	if (bgcolor != NO_COLOR) {
+		attr = curses_color_attr(color, bgcolor);
+	}
 
     if (iflags.cursesgraphics)
         ch = curses_convert_glyph(ch, glyph);

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -229,6 +229,7 @@ attr_t
 curses_color_attr(int nh_color, int bg_color)
 {
     int color = nh_color + 1;
+	int cnum = COLORS >= 16 ? 16 : 8;
     attr_t cattr = A_NORMAL;
 
     if (!nh_color) {
@@ -248,70 +249,9 @@ curses_color_attr(int nh_color, int bg_color)
 
     /* Can we do background colors? We can if we have more than
        16*7 colors (more than 8*7 for terminals with bold) */
-    if (COLOR_PAIRS > (COLORS >= 16 ? 16 : 8) * 7) {
-        /* NH3 has a rather overcomplicated way of defining
-           its colors past the first 16:
-           Pair    Foreground  Background
-           17      Black       Red
-           18      Black       Blue
-           19      Red         Red
-           20      Red         Blue
-           21      Green       Red
-           ...
-           (Foreground order: Black, Red, Green, Yellow, Blue,
-           Magenta, Cyan, Gray/White)
-
-           To work around these oddities, we define backgrounds
-           by the following pairs:
-
-           16 COLORS
-           49-64: Green
-           65-80: Yellow
-           81-96: Magenta
-           97-112: Cyan
-           113-128: Gray/White
-
-           8 COLORS
-           9-16: Green
-           33-40: Yellow
-           41-48: Magenta
-           49-56: Cyan
-           57-64: Gray/White */
-
-        if (bg_color == nh_color)
-            color = 1; /* Make foreground black if fg==bg */
-
-        if (bg_color == CLR_RED || bg_color == CLR_BLUE) {
-            /* already defined before extension */
-            color *= 2;
-            color += 16;
-            if (bg_color == CLR_RED)
-                color--;
-        } else {
-            boolean hicolor = FALSE;
-            if (COLORS >= 16)
-                hicolor = TRUE;
-
-            switch (bg_color) {
-            case CLR_GREEN:
-                color = (hicolor ? 48 : 8) + color;
-                break;
-            case CLR_BROWN:
-                color = (hicolor ? 64 : 32) + color;
-                break;
-            case CLR_MAGENTA:
-                color = (hicolor ? 80 : 40) + color;
-                break;
-            case CLR_CYAN:
-                color = (hicolor ? 96 : 48) + color;
-                break;
-            case CLR_GRAY:
-                color = (hicolor ? 112 : 56) + color;
-                break;
-            default:
-                break;
-            }
-        }
+    if (COLOR_PAIRS > cnum * 7) {
+		if (bg_color != NO_COLOR && bg_color != CLR_BLACK)
+			color += cnum * (1+bg_color);
     }
     cattr |= COLOR_PAIR(color);
 

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -320,7 +320,8 @@ init_tilemap()
 		tilemap[GLYPH_MON_OFF+i] = tilenum;
 		tilemap[GLYPH_PET_OFF+i] = tilenum;
 		tilemap[GLYPH_PEACE_OFF+i] = tilenum;
-		tilemap[GLYPH_ZOMBIE_OFF+i] = tilenum;
+		for (j=0; j<MAXTEMPLATE; j++)
+			tilemap[GLYPH_MTEMPLATE_OFF+i+j*NUMMONS] = tilenum;
 		tilemap[GLYPH_DETECT_OFF+i] = tilenum;
 		tilemap[GLYPH_RIDDEN_OFF+i] = tilenum;
 		tilemap[GLYPH_BODY_OFF+i] = corpsetile;


### PR DESCRIPTION
Syntax:
MONSTERTEMPLATE = <template name> : <fg / bg / symbol> : <color/character>

ex
```
MONSTERTEMPLATE = zombified     :symbol :Z
MONSTERTEMPLATE = zombie        :bg     :green
MONSTERTEMPLATE = illuminated   : bg    :yellow
MONSTERTEMPLATE = tomb herd     :fg     :gray
MONSTERTEMPLATE = vitrified     :background : cyan
MONSTERTEMPLATE = pseudonatural :foreground : lightmagenta
```

Note: on TTY, it only has 8 colors of background available (no bright colors)

Does not *break* saves, though games in progress will have hallucination-like rememberances of areas explored prior to the update because the glyphs are shifted. These can be somewhat fixed by ctrl-r to redraw terrain, and then exploring to re-see the tiles that ctrl-r doesn't fix.