### PR TITLE
Silently release held enemies when trying to go up/down stairs

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -952,7 +952,7 @@ dodown()
 			}
 		}
 	}
-	if(u.ustuck) {
+	if(u.ustuck && (u.uswallow || !sticks(&youmonst))) {
 		You("are %s, and cannot go down.",
 			!u.uswallow ? "being held" : is_animal(u.ustuck->data) ?
 			"swallowed" : "engulfed");
@@ -1038,7 +1038,7 @@ doup()
 		return MOVE_CANCELLED;
 	} else
 #endif
-	if(u.ustuck) {
+	if(u.ustuck && (u.uswallow || !sticks(&youmonst))) {
 		You("are %s, and cannot go up.",
 			!u.uswallow ? "being held" : is_animal(u.ustuck->data) ?
 			"swallowed" : "engulfed");


### PR DESCRIPTION
The creature with a grab attack is assumed to be the one doing the grabbing (grabbers can't grab grabbers). So when you have a grab attack, you can (silently) release whoever you're grabbing when you want to take the stairs.

Closes #2064 