### PR TITLE
Always check if spell would be useless before mcasting

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -2479,6 +2479,8 @@ int tary;
 		impossible("cast_spell() called with no caster");
 		return MM_MISS;
 	}
+	if (spell_would_be_useless(magr, mdef, spell, tarx, tary))
+		return MM_MISS;
 
 	/*debug*/
 	//if (wizard) {


### PR DESCRIPTION
So calling cast_spell() should be safe; it will do its own checks that magr is allowed to cast a spell at mdef/tarx-tary.

Closes #2078 