### PR TITLE
Merging/freeing fired ammo affects multishot

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -463,7 +463,7 @@ E char misc_cmds[];
 
 E NEARDATA schar tbx, tby;		/* set in mthrowu.c */
 
-E NEARDATA struct multishot { int n, i; short o; boolean s; } m_shot;
+E NEARDATA struct multishot { int n, i; short o; boolean s; struct obj * x;} m_shot;
 
 E NEARDATA struct dig_info {		/* apply.c, hack.c */
 	int	effort;

--- a/include/extern.h
+++ b/include/extern.h
@@ -2365,6 +2365,7 @@ E void NDECL(clearpriests);
 
 /* ### projectile.c ### */
 
+E void FDECL(interrupt_multishot, (struct obj *, struct obj *));
 E int FDECL(projectile, (struct monst *, struct obj *, void *, int, int, int, int, int, int, int, boolean, boolean, boolean));
 E void FDECL(hitfloor2, (struct monst *, struct obj **, struct obj *, boolean, boolean));
 E boolean FDECL(xbreathey, (struct monst *, struct attack *, int, int));

--- a/src/shk.c
+++ b/src/shk.c
@@ -1065,6 +1065,7 @@ register struct obj *obj, *merge;
 #endif
 		}
 	}
+	interrupt_multishot(obj, merge);
 
 	if (donning(obj)) cancel_don();
 	


### PR DESCRIPTION
On merge, update (new) global ammo pointer, m_shot.x, to new stack. On free, interrupt multishot.

Fixes #2074