### PR TITLE
Xorns (and other metalivores) cannot eat bolted magic chests

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2031,7 +2031,8 @@ meatmetal(mtmp)
 	    if (mtmp->mtyp == PM_RUST_MONSTER && !is_rustprone(otmp))
 		continue;
 	    if (is_metallic(otmp) && !obj_resists(otmp, 0, 95) &&
-		touch_artifact(otmp, mtmp, FALSE)) {
+			touch_artifact(otmp, mtmp, FALSE) && !(otmp->otyp == MAGIC_CHEST && otmp->obolted)
+			) {
 		if (mtmp->mtyp == PM_RUST_MONSTER && otmp->oerodeproof) {
 		    if (canseemon(mtmp) && flags.verbose) {
 			pline("%s eats %s!",


### PR DESCRIPTION
Closes #2061 