### PR TITLE
Cav and Ymir should grant increased offhand wt limits

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -3434,8 +3434,14 @@ int wep_type;
 			case P_MASTER:			maxweight = 50; break;
 			case P_GRAND_MASTER:	maxweight = 60; break;
 		}
-		if (youracedata->msize > MZ_MEDIUM)
-			maxweight *= 1+(youracedata->msize - MZ_MEDIUM);
+		int wielder_size = (youracedata->msize - MZ_MEDIUM);
+
+		if (Role_if(PM_CAVEMAN))
+			wielder_size += 1;
+		if (u.sealsActive&SEAL_YMIR)
+			wielder_size += 1;
+		if (wielder_size > 0)
+			maxweight *= 1+wielder_size;
 
 		if (wep_type == P_BARE_HANDED_COMBAT) {
 			bonus -= abs(bonus * 2 / 3);


### PR DESCRIPTION
They grant bonus size for bimanual but no offhand wt limits to actually use any of your new funny sticks. This doesn't really ever matter for cav with their restricted two-weapon but is a nice fix for Ymir on some builds.