### PR TITLE
Bugfix: lock.c

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -431,7 +431,7 @@ pick_lock(pick_p) /* pick a lock with a given object */
 		return MOVE_CANCELLED;
 	}
 	if(!freehand()){
-		You_cant("hold %s -- you have no free hands!", doname(pick));
+		You_cant("hold %s -- you have no free %s!", doname(pick), makeplural(body_part(HAND)));
 		return MOVE_CANCELLED;
 	}
 
@@ -863,7 +863,7 @@ int x, y;
 	    return MOVE_CANCELLED;
 	}
 	if(!freehand()){
-	    You_cant("open anything -- you have no free hands!");
+	    You_cant("open anything -- you have no free %s!", makeplural(body_part(HAND)));
 		return MOVE_CANCELLED;
 	}
 
@@ -976,7 +976,7 @@ doclose()		/* try to close a door */
 	    return MOVE_CANCELLED;
 	}
 	if(!freehand()){
-	    You_cant("close anything -- you have no free hands!");
+	    You_cant("close anything -- you have no free %s!", makeplural(body_part(HAND)));
 		return MOVE_CANCELLED;
 	}
 


### PR DESCRIPTION
This fixes a bug relating to using items while not having any free hands (i.e. trying to use lockpicks while wearing a straitjacket [how this was discovered]). Instead of telling the player "you have no free hands!", this fix tells the player "you have no free <hands>!"

Discovered on a custom fork of dNAO, still applicable here.

Won't be able to PR for every instance right now, but I've found cases of this in muse.c, apply.c, spell.c, weapon.c, do_wear.c, music.c, and sounds.c.