### PR TITLE
Remove condition for unlinking summoner in summoner_gone

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -3366,10 +3366,10 @@ boolean travelling;	/* if true, don't vanish summoned items in its inventory */
 	timer_element * tm;
 	struct esum * esum;
 	for (tm = timer_base; tm; tm = tm->next) {
-		if (tm->timeout > monstermoves && (
+		if (
 			(tm->func_index == DESUMMON_MON && (((struct monst *)tm->arg)->mextra_p) && (esum = ((struct monst *)tm->arg)->mextra_p->esum_p) && (mon == esum->summoner)) ||
 			(tm->func_index == DESUMMON_OBJ && (((struct obj   *)tm->arg)->oextra_p) && (esum = ((struct obj   *)tm->arg)->oextra_p->esum_p) && (mon == esum->summoner))
-			))
+			)
 		{
 			/* exception 1: summoned pets may follow the player between levels */
 			if ((tm->func_index == DESUMMON_MON) && (mon == &youmonst)) {


### PR DESCRIPTION
Could possibly have been the cause of use-after-frees, if a permanent summon was right on time to refresh its duration, and its summoner dies/leaves before the timer gets handled (on the same monstermoves turn).