### PR TITLE
Fix pets never attacking peaceful metroids

### DIFF
--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -1013,7 +1013,7 @@ boolean ranged;
 	if(mtmp->mtame && mtmp2->mpeaceful && !u.uevent.uaxus_foe && mtmp2->mtyp == PM_AXUS)
 		return FALSE;
 	
-	if(mtmp->mtame && mtmp2->mpeaceful && is_metroid(mtmp2->data) && is_metroid(mtmp2->data))
+	if(mtmp->mtame && mtmp2->mpeaceful && is_metroid(mtmp->data) && is_metroid(mtmp2->data))
 		return FALSE;
 	
 	if(mtmp->mhp < 100 && attacktype_fordmg(mtmp2->data, AT_BOOM, AD_MAND))


### PR DESCRIPTION
A check intended to make tame metroids never attack peaceful metroids
checked mtmp2 twice instead of checking mtmp and mtmp2, causing all
pets, not just metroids, to never attack peaceful metroids.