### PR TITLE
tty statusline improvements

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -273,7 +273,8 @@ E const char *FDECL(rank_of, (int,SHORT_P,BOOLEAN_P));
 E void NDECL(bot);
 #ifdef DUMP_LOG
 E void FDECL(bot1str, (char *));
-E void FDECL(bot2str, (char *, boolean, int));
+E void FDECL(bot2str, (char *, boolean, int, boolean));
+E void FDECL(bot3str, (char *, boolean, int));
 #endif
 
 /* ### cmd.c ### */

--- a/include/extern.h
+++ b/include/extern.h
@@ -273,7 +273,7 @@ E const char *FDECL(rank_of, (int,SHORT_P,BOOLEAN_P));
 E void NDECL(bot);
 #ifdef DUMP_LOG
 E void FDECL(bot1str, (char *));
-E void FDECL(bot2str, (char *));
+E void FDECL(bot2str, (char *, boolean, int));
 #endif
 
 /* ### cmd.c ### */

--- a/include/flag.h
+++ b/include/flag.h
@@ -365,6 +365,7 @@ struct instance_flags {
     boolean invweight;
 	boolean quick_m_abilities;
 	boolean default_template_hilite;
+	int statuslines;
 
 	int pokedex;	/* default monster stats to show in the pokedex */
 /*

--- a/include/global.h
+++ b/include/global.h
@@ -272,6 +272,9 @@ typedef xchar	boolean;		/* 0 or 1 */
 #define Sprintf  (void) sprintf
 #define Strcat   (void) strcat
 #define Strcpy   (void) strcpy
+#define Snprintf (void) snprintf
+#define Strncat  (void) strncat
+#define Strncpy  (void) strncpy
 #ifdef NEED_VARARGS
 #define Vprintf  (void) vprintf
 #define Vfprintf (void) vfprintf
@@ -321,14 +324,16 @@ struct version_info {
  * than COLNO
  *
  * longest practical second status line at the moment is
- *	Astral Plane $:12345 HP:700(700) Pw:111(111) AC:-127 Xp:30/123456789
- *	T:123456 Satiated Conf FoodPois Ill Blind Stun Hallu Overloaded
- * -- or somewhat over 130 characters
+ *	Astral Plane $:123456 HP:1234(1234) Pw:1234(1234) Br:8 AC:-127
+ *	DR:127 Xp:30/123456789 T:123456 Stone Slime Sufct FoodPois Ill
+ *	Satiated Overloaded Blind Stun Conf Hallu Babble Scream Fly
+ *	Ride
+ * -- or about 190 characters
  */
-#if COLNO <= 140
-#define MAXCO 160
+#if COLNO <= 160
+#define MAXCO 200
 #else
-#define MAXCO (COLNO+20)
+#define MAXCO (COLNO+40)
 #endif
 
 #define MAXNROFROOMS	40	/* max number of rooms per level */

--- a/src/botl.c
+++ b/src/botl.c
@@ -588,10 +588,12 @@ void bot2str(char *newbot2, boolean terminal_output, int abbrev)
       status_effect("Ill", "Ill", "Ill");
   }
 /** Hunger **/
-  if(uclockwork)
-    status_effect(ca_hu_stat[u.uhs], ca_hu_stat[u.uhs], ca_hu_stat[u.uhs]);
-  else
-    status_effect(hu_stat[u.uhs], hu_stat[u.uhs], hu_stat[u.uhs]);
+  if(u.uhs != NOT_HUNGRY) {
+    if(uclockwork)
+      status_effect(ca_hu_stat[u.uhs], ca_hu_stat[u.uhs], ca_hu_stat[u.uhs]);
+    else
+      status_effect(hu_stat[u.uhs], hu_stat[u.uhs], hu_stat[u.uhs]);
+  }
 /** Encumbrance **/
   if(cap > UNENCUMBERED)
     status_effect(enc_stat[cap], enc_stat_abbrev1[cap], enc_stat_abbrev2[cap]);

--- a/src/botl.c
+++ b/src/botl.c
@@ -644,7 +644,7 @@ bot2str(char *newbot2, boolean terminal_output, int abbrev, boolean dumplog)
                                          (currenttime % 3600) / 60);
   }
 #endif
-  if (!dumplog && (LI <= 24 || iflags.statuslines <= 2))
+  if (!dumplog && (LI <= ROWNO+3 || iflags.statuslines <= 2))
     do_statuseffects(newbot2, terminal_output, abbrev, 2);
 }
 
@@ -678,7 +678,7 @@ bot3()
 {
 	char newbot3[MAXCO];
 	int abbrev = 0;
-	if (LI <= 24 || iflags.statuslines <= 2)
+	if (LI <= ROWNO+3 || iflags.statuslines <= 2)
 		return;
 	for (;;) {
 		bot3str(newbot3, FALSE, abbrev);

--- a/src/botl.c
+++ b/src/botl.c
@@ -658,6 +658,37 @@ bot2()
 #else
   Strcat(nb = eos(nb), " Hallu");
 #endif
+  if(Levitation)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text("Lev", newbot2);
+#else
+  Strcat(nb = eos(nb), " Lev", newbot2);
+#endif
+  /* flying and levitation are mutually exclusive */
+  if(Flying && !Levitation)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+     add_colored_text("Fly", newbot2);
+#else
+  Strcat(nb = eos(nb), " Fly", newbot2);
+#endif
+  if(u.usteed)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+     add_colored_text("Ride", newbot2);
+#else
+  Strcat(nb = eos(nb), " Ride", newbot2);
+#endif
+  if(Stoned)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text("Stone", newbot2);
+#else
+  Strcat(nb = eos(nb), " Stone");
+#endif
+  if(Golded)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text("Gold", newbot2);
+#else
+  Strcat(nb = eos(nb), " Gold");
+#endif
   if(Slimed)
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
       add_colored_text("Slime", newbot2);

--- a/src/botl.c
+++ b/src/botl.c
@@ -559,34 +559,24 @@ bot2()
   }
 #endif
 
-	if(uclockwork){
-		if(strcmp(ca_hu_stat[u.uhs], "        ")) {
+/** Delayed instadeaths **/
+  if(Stoned || Golded)
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-    	  add_colored_text(ca_hu_stat[u.uhs], newbot2);
+      add_colored_text("Stone", newbot2);
 #else
-		  Sprintf(nb = eos(nb), " %s", ca_hu_stat[u.uhs]);
+  Strcat(nb = eos(nb), " Stone");
 #endif
-		}
-	} else{
-	  if(strcmp(hu_stat[u.uhs], "        ")) {
+  if(Slimed)
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-	      add_colored_text(hu_stat[u.uhs], newbot2);
+      add_colored_text("Slime", newbot2);
 #else
-		  Sprintf(nb = eos(nb), " %s", hu_stat[u.uhs]);
+  Strcat(nb = eos(nb), " Slime");
 #endif
-	  }
-	}
-  if(Invulnerable)
+  if(FrozenAir || Strangled || BloodDrown)
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Invl", newbot2);
+      add_colored_text("Sufct", newbot2);
 #else
-  Strcat(nb = eos(nb), " Invl");
-#endif
-  if(Confusion && !StumbleBlind)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Conf", newbot2);
-#else
-  Strcat(nb = eos(nb), " Conf");
+	Sprintf(nb = eos(nb), " Sufct");
 #endif
   if(Sick) {
       if (u.usick_type & SICK_VOMITABLE)
@@ -602,6 +592,38 @@ bot2()
       Strcat(nb = eos(nb), " Ill");
 #endif
   }
+/** Hunger **/
+  if(uclockwork){
+    if(strcmp(ca_hu_stat[u.uhs], "        ")) {
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text(ca_hu_stat[u.uhs], newbot2);
+#else
+      Sprintf(nb = eos(nb), " %s", ca_hu_stat[u.uhs]);
+#endif
+    }
+  } else {
+    if(strcmp(hu_stat[u.uhs], "        ")) {
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text(hu_stat[u.uhs], newbot2);
+#else
+      Sprintf(nb = eos(nb), " %s", hu_stat[u.uhs]);
+#endif
+    }
+  }
+/** Encumbrance **/
+  if(cap > UNENCUMBERED)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text(enc_stat[cap], newbot2);
+#else
+  Sprintf(nb = eos(nb), " %s", enc_stat[cap]);
+#endif
+/** Other status effects **/
+  if(Invulnerable)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text("Invl", newbot2);
+#else
+  Strcat(nb = eos(nb), " Invl");
+#endif
   if(Blind && !StumbleBlind)
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
       add_colored_text("Blind", newbot2);
@@ -613,6 +635,18 @@ bot2()
       add_colored_text("Stun", newbot2);
 #else
   Strcat(nb = eos(nb), " Stun");
+#endif
+  if(Confusion && !StumbleBlind)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text("Conf", newbot2);
+#else
+  Strcat(nb = eos(nb), " Conf");
+#endif
+  if(Hallucination)
+#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
+      add_colored_text("Hallu", newbot2);
+#else
+  Strcat(nb = eos(nb), " Hallu");
 #endif
 /** Insanity messages **/
   if(Panicking)
@@ -651,13 +685,7 @@ bot2()
 #else
   Strcat(nb = eos(nb), " Faint");
 #endif
-
-  if(Hallucination)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Hallu", newbot2);
-#else
-  Strcat(nb = eos(nb), " Hallu");
-#endif
+/** Less important **/
   if(Levitation)
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
       add_colored_text("Lev", newbot2);
@@ -676,36 +704,6 @@ bot2()
      add_colored_text("Ride", newbot2);
 #else
   Strcat(nb = eos(nb), " Ride", newbot2);
-#endif
-  if(Stoned)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Stone", newbot2);
-#else
-  Strcat(nb = eos(nb), " Stone");
-#endif
-  if(Golded)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Gold", newbot2);
-#else
-  Strcat(nb = eos(nb), " Gold");
-#endif
-  if(Slimed)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Slime", newbot2);
-#else
-  Strcat(nb = eos(nb), " Slime");
-#endif
-  if(FrozenAir || Strangled || BloodDrown)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text("Sufct", newbot2);
-#else
-	Sprintf(nb = eos(nb), " Sufct");
-#endif
-  if(cap > UNENCUMBERED)
-#if defined(STATUS_COLORS) && defined(TEXTCOLOR)
-      add_colored_text(enc_stat[cap], newbot2);
-#else
-  Sprintf(nb = eos(nb), " %s", enc_stat[cap]);
 #endif
 #ifdef DUMP_LOG
 }

--- a/src/display.c
+++ b/src/display.c
@@ -1683,7 +1683,7 @@ int style;
 	bot1str(buf);
 	ptr = (char *) compress_str((const char *) buf);
 	dump("", ptr);
-	bot2str(buf);
+	bot2str(buf, FALSE, 0);
 	dump("", buf);
 	dump("", "");
 	dump("", "");
@@ -1702,7 +1702,7 @@ int style;
 	bot1str(buf);
 	ptr = (char *) compress_str((const char *) buf);
 	dump("", ptr);
-	bot2str(buf);
+	bot2str(buf, FALSE, 0);
 	dump("", buf);
     }
 }

--- a/src/display.c
+++ b/src/display.c
@@ -1683,7 +1683,9 @@ int style;
 	bot1str(buf);
 	ptr = (char *) compress_str((const char *) buf);
 	dump("", ptr);
-	bot2str(buf, FALSE, 0);
+	bot2str(buf, FALSE, 0, TRUE);
+	dump("", buf);
+	bot3str(buf, FALSE, 0);
 	dump("", buf);
 	dump("", "");
 	dump("", "");
@@ -1702,7 +1704,9 @@ int style;
 	bot1str(buf);
 	ptr = (char *) compress_str((const char *) buf);
 	dump("", ptr);
-	bot2str(buf, FALSE, 0);
+	bot2str(buf, FALSE, 0, TRUE);
+	dump("", buf);
+	bot3str(buf, FALSE, 0);
 	dump("", buf);
     }
 }

--- a/src/eat.c
+++ b/src/eat.c
@@ -65,22 +65,22 @@ STATIC_OVL boolean force_save_hs = FALSE;
 
 const char *hu_stat[] = {
 	"Satiated",
-	"        ",
-	"Hungry  ",
-	"Weak    ",
+	"",
+	"Hungry",
+	"Weak",
 	"Fainting",
-	"Fainted ",
-	"Starved "
+	"Fainted",
+	"Starved"
 };
 
 const char *ca_hu_stat[] = {
 	"OvrWound",
-	"        ",
-	"Waning  ",
-	"Unwound ",
+	"",
+	"Waning",
+	"Unwound",
 	"Slipping",
-	"Slipped ",
-	"Stopped "
+	"Slipped",
+	"Stopped"
 };
 
 #endif /* OVLB */

--- a/src/options.c
+++ b/src/options.c
@@ -444,6 +444,7 @@ static struct Comp_Opt
 #ifdef MSDOS
 	{ "soundcard", "type of sound card to use", 20, SET_IN_FILE },
 #endif
+	{ "statuslines", "number of status lines (2 or 3)", 20, SET_IN_GAME },
 	{ "suppress_alert", "suppress alerts about version-specific features",
 						8, SET_IN_GAME },
 	{ "tile_width", "width of tiles", 20, DISP_IN_GAME},	/*WC*/
@@ -656,6 +657,7 @@ initoptions()
 #endif
 	iflags.menu_headings = ATR_INVERSE;
 	iflags.attack_mode = ATTACK_MODE_CHAT;
+	iflags.statuslines = 3;
 
 	/* Use negative indices to indicate not yet selected */
 	flags.initrole = -1;
@@ -2915,6 +2917,26 @@ goodfruit:
         }
 
 
+	fullname = "statuslines";
+	if (match_optname(opts, fullname, sizeof("statuslines")-1, TRUE)) {
+		op = string_for_opt(opts, negated);
+		if (negated) bad_negation(fullname, FALSE);
+		else {
+		    if (!initial)
+		        need_redraw = TRUE;
+		    iflags.statuslines = atoi(op);
+		    if (iflags.statuslines > 3) {
+		        iflags.statuslines = 3;
+		        badoption(opts);
+		    } else if (iflags.statuslines < 2) {
+		        iflags.statuslines = 2;
+		        badoption(opts);
+		    }
+		}
+		return;
+	}
+
+
 #ifdef SORTLOOT
 	fullname = "sortloot";
 	if (match_optname(opts, fullname, 4, TRUE)) {
@@ -4551,6 +4573,8 @@ char *buf;
 	else if (!strcmp(optname, "soundcard"))
 		Sprintf(buf, "%s", to_be_done);
 #endif
+	else if (!strcmp(optname, "statuslines"))
+		Sprintf(buf, "%d", iflags.statuslines);
 	else if (!strcmp(optname, "suppress_alert")) {
 	    if (flags.suppress_alert == 0L)
 		Strcpy(buf, none);

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -892,7 +892,7 @@ tty_create_nhwindow(type)
 	newwin->maxcol = newwin->cols = 0;
 	break;
     case NHW_STATUS:
-	/* status window, 2 lines long, full width, bottom of screen */
+	/* status window, 3 lines long, full width, bottom of screen */
 	newwin->offx = 0;
 #if defined(USE_TILES) && defined(MSDOS)
 	if (iflags.grmode) {
@@ -900,7 +900,7 @@ tty_create_nhwindow(type)
 	} else
 #endif
 	newwin->offy = min((int)ttyDisplay->rows-2, ROWNO+1);
-	newwin->rows = newwin->maxrow = 2;
+	newwin->rows = newwin->maxrow = 3;
 	newwin->cols = newwin->maxcol = min(ttyDisplay->cols, MAXCO);
 	break;
     case NHW_MAP:


### PR DESCRIPTION
This:
- Adds 3 new status conditions from NetHack 3.6 (`Lev`, `Fly`, `Ride`, and `Stone`).
- Reorders status conditions to put delayed instadeaths first.
- Increases the value of `MAXCO` to 200 (160 was possible to overflow, causing undefined behaviour because `Strcpy` doesn't check bounds).
- Adds new `Strncpy`, `Strncat`, and `Snprintf` macros used for displaying status conditions instead of `Strcpy`, `Strcat`, and `Sprintf` to avoid the buffer overflow (which is still possible if you somehow manage to overflow the status line before status conditions, as everything else still uses the unsafe functions, but this should currently be impossible).
- Adds two sets abbreviated names for status conditions and encumbrance (but not hunger - I couldn't think of good abbreviations for clockwork hunger states). These are used if the full names don't fit, but never in dumplogs. statuscolors still use the full names and don't need to be adjusted.
- Removes the padding from hunger states.
- Adds an optional third statusline. It is used for status conditions and displayed if the new `statuslines` option is set to `3` (the default), and the player's terminal is at least 25 rows long. It is also always displayed in dumplogs as they are not restricted by the player's terminal size.
 
The abbreviated names are:
| `str1`       | `str2`     | `str3` |
|--------------|------------|--------|
| `Burdened`   | `Burden`   | `Brd`  |
| `Stressed`   | `Stress`   | `Strs` |
| `Strained`   | `Strain`   | `Strn` |
| `Overtaxed`  | `Overtax`  | `Ovtx` |
| `Overloaded` | `Overload` | `Ovld` |
| `Stone`      | `Ston`     | `Sto`  |
| `Slime`      | `Slim`     | `Slm`  |
| `Sufct`      | `Sfct`     | `Sfc`  |
| `FoodPois`   | `Fpois`    | `Poi`  |
| `Ill`        | `Ill`      | `Ill`  |
| `Invl`       | `Invl`     | `In`   |
| `Blind`      | `Blnd`     | `Bl`   |
| `Stun`       | `Stun`     | `St`   |
| `Conf`       | `Cnf`      | `Cf`   |
| `Hallu`      | `Hal`      | `Hl`   |
| `Panic`      | `Pnc`      | `Pnc`  |
| `Stmblng`    | `Stmbl`    | `Stm`  |
| `Strggrng`   | `Stggr`    | `Stg`  |
| `Babble`     | `Babl`     | `Bbl`  |
| `Scream`     | `Scrm`     | `Scr`  |
| `Faint`      | `Fnt`      | `Fnt`  |
| `Lev`        | `Lev`      | `Lv`   |
| `Fly`        | `Fly`      | `Fl `  |
| `Ride`       | `Rid`      | `Rd`   |

All of these changes only apply to the `tty` windowport (and dumplogs). Currently, with `curses` and `!classic_status`, extra status effects mess up the statusline instead of getting cut off, so I don't want to add new status conditions to it until this is fixed.

None of this should break saves as the new option (`statuslines`) is in `iflags`.