### PR TITLE
Allow the Oracle to tell you about Demon/Devil Lords

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -83,6 +83,7 @@ E struct dgn_topology {		/* special dungeon levels for speed */
 #define DISPATER_LEVEL	2
 #define MAMMON_LEVEL	3
 #define BELIAL_LEVEL	4
+#define CHROMA_LEVEL	5
 	d_level	d_hell2_level;
 	int		hell2_variant;
 #define LEVIATHAN_LEVEL	1

--- a/include/dungeon.h
+++ b/include/dungeon.h
@@ -180,6 +180,7 @@ typedef struct branch {
 #define Is_dis_level(x)		(on_level(x, &hell1_level) && dungeon_topology.hell1_variant == DISPATER_LEVEL)
 #define Is_mammon_level(x)	(on_level(x, &hell1_level) && dungeon_topology.hell1_variant == MAMMON_LEVEL)
 #define Is_belial_level(x)	(on_level(x, &hell1_level) && dungeon_topology.hell1_variant == BELIAL_LEVEL)
+#define Is_chromatic_level(x)	(on_level(x, &hell1_level) && dungeon_topology.hell1_variant == CHROMA_LEVEL)
 #define Is_hell2(x)			(on_level(x, &hell2_level))
 #define Is_leviathan_level(x)	(on_level(x, &hell2_level) && dungeon_topology.hell2_variant == LEVIATHAN_LEVEL)
 #define Is_lilith_level(x)		(on_level(x, &hell2_level) && dungeon_topology.hell2_variant == LILITH_LEVEL)

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -2834,6 +2834,8 @@ boolean printdun;
 				Sprintf(eos(buf), " [Minauros]");
 			} else if(Is_belial_level(&mptr->lev)){
 				Sprintf(eos(buf), " [Phlegethos]");
+			} else if(Is_chromatic_level(&mptr->lev)){
+				Sprintf(eos(buf), " [Dragon Caves]");
 			} else {
 				Sprintf(eos(buf), " [Upper Hell]");
 			}

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -1431,9 +1431,26 @@ register const char *s;
 	if(*s) {
 	    if(sp && sp->rndlevs){
 			levvar = rnd((int) sp->rndlevs);
-			/* special case -- chalev should always use the corresponding level */
+			/* special cases -- 
+			 * chalev should always use the corresponding level
+			 * hell/abyss floors are set at game start for oracle sneak peeks
+			 * medusa & grue are still random as of right now, as is sea
+			*/
 			if (!strcmp(sp->proto, "chalev"))
 				levvar = chaos_dvariant + 1;
+			else if (Is_hell1(&u.uz))
+				levvar = dungeon_topology.hell1_variant;
+			else if (Is_hell2(&u.uz))
+				levvar = dungeon_topology.hell2_variant;
+			else if (Is_abyss1(&u.uz))
+				levvar = dungeon_topology.abyss_variant;
+			else if (Is_abyss2(&u.uz))
+				levvar = dungeon_topology.abys2_variant;
+			else if (Is_abyss3(&u.uz))
+				levvar = dungeon_topology.brine_variant;
+			
+			if (dungeon_topology.hell1_variant == CHROMA_LEVEL) levvar = BAEL_LEVEL;
+			
 			Sprintf(protofile, "%s-%d", s, levvar);
 		}
 	    else Strcpy(protofile, s);
@@ -1458,16 +1475,6 @@ register const char *s;
 //	pline("%d", levvar);
 	if (Is_challenge_level(&u.uz)){
 		dungeon_topology.challenge_variant = levvar;
-	} else if(Is_hell1(&u.uz)){
-		dungeon_topology.hell1_variant = levvar;
-	} else if(Is_hell2(&u.uz)){
-		dungeon_topology.hell2_variant = levvar;
-	} else if(Is_abyss1(&u.uz)){
-		dungeon_topology.abyss_variant = levvar;
-	} else if(Is_abyss2(&u.uz)){
-		dungeon_topology.abys2_variant = levvar;
-	} else if(Is_abyss3(&u.uz)){
-		dungeon_topology.brine_variant = levvar;
 	} else if(In_sea(&u.uz)){
 		dungeon_topology.sea_variant = levvar;
 	}
@@ -1480,8 +1487,9 @@ register const char *s;
 		} else if(Is_arcadiadonjon(&u.uz)){
 			Strcpy(protofile, "towrtob");
 		}
-	} 
-	if(Is_hell1(&u.uz) && !Role_if(PM_CAVEMAN) && dungeon_topology.hell1_variant == BAEL_LEVEL && rn2(2)){
+	}
+	
+	if(Is_hell1(&u.uz) && dungeon_topology.hell1_variant == CHROMA_LEVEL){
 			Strcpy(protofile, "hell-a");
 	}
 	/* quick hack for Binders entering Astral -- change the gods out before loading the level, so that

--- a/src/rumors.c
+++ b/src/rumors.c
@@ -337,6 +337,8 @@ outgmaster()
 #define GLIMPSE_POLYP 3
 #define GLIPMSE_CHAOS 4
 #define GLIMPSE_OOONA 5
+#define GLIMPSE_ABYSS 6
+#define GLIMPSE_HELLL 7
 
 int
 doconsult(oracl)
@@ -518,6 +520,18 @@ register struct monst *oracl;
 					'i', 0, ATR_NONE, buf,
 					MENU_UNSELECTED);
 
+				Sprintf(buf, "Knowledge of the Layers of the Abyss");
+				any.a_int = GLIMPSE_ABYSS;	/* must be non-zero */
+				add_menu(tmpwin, NO_GLYPH, &any,
+					'a', 0, ATR_NONE, buf,
+					MENU_UNSELECTED);
+
+				Sprintf(buf, "Knowledge of the Lords of the Nine Hells");
+				any.a_int = GLIMPSE_HELLL;	/* must be non-zero */
+				add_menu(tmpwin, NO_GLYPH, &any,
+					'h', 0, ATR_NONE, buf,
+					MENU_UNSELECTED);
+
 				end_menu(tmpwin, "What glimpses dost thou ask for?");
 
 				how = PICK_ONE;
@@ -527,7 +541,7 @@ register struct monst *oracl;
 					n = selected[0].item.a_int;
 					free(selected);
 				}
-				else n = rnd(5);
+				else n = rnd(7);
 				switch (n){
 					case GLIMPSE_ELDRN:
 						switch(dungeon_topology.alt_tulani){
@@ -587,6 +601,115 @@ register struct monst *oracl;
 						else if (u.oonaenergy == AD_ELEC)
 							pline("They say meeting Oona can be a bit of a shock...");
 					break;
+					case GLIMPSE_ABYSS:
+						if (rn2(3)){
+							switch (dungeon_topology.brine_variant){ // demo, dagon, lamashtu
+								case DEMOGORGON_LEVEL:
+									pline("They say that a closed drawbridge should be left well enough alone.");
+								break;
+								case DAGON_LEVEL:
+									pline("They say that the darkest depths hide the most dangerous foes.");
+								break;
+								case LAMASHTU_LEVEL:
+									pline("They say that the depths of the Abyss can drive even the brightest lights to madness.");
+								break;
+								break;
+									pline("unknown or un-initialized hell1");
+								break;
+							}
+						} else if (rn2(2)) {
+							switch (dungeon_topology.abyss_variant){ // juib, zugg, yeen, baph, pale night, kostch
+								case JUIBLEX_LEVEL:
+									pline("They say the Father of Slimes will always save his children from calamity.");
+								break;
+								case ZUGGTMOY_LEVEL:
+									if (Hallucination) pline("Can you feel your heart burning? Can you feel the struggle within?");
+									else pline("They say that even decay itself is a form of life.");
+								break;
+								case YEENOGHU_LEVEL:
+									pline("They say that even the most savage of butchers have those they bow to.");
+								break;
+								case BAPHOMET_LEVEL:
+									pline("They say that the most twisted labyrinths trap the angriest denizens.");
+								break;
+								case NIGHT_LEVEL:
+									pline("They say that sometimes, it's best to not look beyond the veil.");
+								break;
+								case KOSTCH_LEVEL:
+									pline("They say that fury doesn't always burn hot.");
+								break;
+								default:
+									pline("unknown or un-initialized hell2");
+								break;
+							}
+						} else {
+							switch (dungeon_topology.abys2_variant){ // orcus, mal, grazzt, lolth
+								case ORCUS_LEVEL:
+									if(u.sealsActive&SEAL_TENEBROUS) {
+										if (u.ufirst_light) pline("They see that if Creation began with light, then darkness will persist at the end of all things.");
+										else pline("They say that the Word that echoes around you lives on.");
+									}
+									else pline("They say that death is only a temporary setback to some denizens of the Abyss.");
+								break;
+								case MALCANTHET_LEVEL:
+									pline("They say that despite its looks, paradise is only paradise to some.");
+								break;
+								case GRAZ_ZT_LEVEL:
+									pline("They say that the most self indulgent tend to be jealous lovers.");
+								break;
+								case LOLTH_LEVEL:
+									if (u.ualign.god == GOD_LOLTH) pline("The symbol you bear has been more common around here lately.");
+									else pline("They say that not only demons haunt the depths of the Abyss, but divine power as well.");
+								break;
+									pline("unknown or un-initialized hell1");
+								break;
+							}
+						}
+					break;
+					case GLIMPSE_HELLL:
+						if (rn2(2)){
+							switch (dungeon_topology.hell1_variant){ // bael, dis, mammon, belial
+								case BAEL_LEVEL:
+									pline("They say that not only minotaurs can be found at the centers of mazes.");
+								break;
+								case CHROMA_LEVEL:
+									pline("They say that if you're lucky, not only demons can be found in the Abyss.");
+								break;
+								case DISPATER_LEVEL:
+									pline("They say that the Iron City is ruled with an iron fist.");
+								break;
+								case MAMMON_LEVEL:
+									pline("They say that sometimes, the filthiest muck hides the greatest riches.");
+								break;
+								case BELIAL_LEVEL:
+									pline("They say the scorching heats of Gehennom have been worse recently.");
+								break;
+									pline("unknown or un-initialized hell1");
+								break;
+							}
+						} else {
+							switch (dungeon_topology.hell2_variant){ // levi, lilith, baalze, meph
+								case LEVIATHAN_LEVEL:
+									pline("They say that sometimes, it's best to leave frozen foes alone.");
+								break;
+								case LILITH_LEVEL:
+									pline("They say that the only thing worse than an evil witch is a whole coven of them.");
+								break;
+								case BAALZEBUB_LEVEL:
+									pline("They say that the harder they fall, the more dangerous they are.");
+								break;
+								case MEPHISTOPHELES_LEVEL:
+									pline("They say that sculptures made of ice are sometimes more lifelike than ones made of stone.");
+								break;
+								default:
+									pline("unknown or un-initialized hell2");
+								break;
+							}
+						}
+					break;
+					default:
+						impossible("Oracle rolled a non-existent dungeon hint? :(");
+					break;
 				}
 
 				if (!u.uevent.major_oracle){
@@ -617,5 +740,6 @@ register struct monst *oracl;
 #undef GLIMPSE_POLYP
 #undef GLIPMSE_CHAOS
 #undef GLIMPSE_OOONA
-
+#undef GLIMPSE_ABYSS
+#undef GLIMPSE_HELLL
 /*rumors.c*/

--- a/src/rumors.c
+++ b/src/rumors.c
@@ -602,7 +602,7 @@ register struct monst *oracl;
 							pline("They say meeting Oona can be a bit of a shock...");
 					break;
 					case GLIMPSE_ABYSS:
-						if (rn2(3)){
+						if (!rn2(3)){
 							switch (dungeon_topology.brine_variant){ // demo, dagon, lamashtu
 								case DEMOGORGON_LEVEL:
 									pline("They say that a closed drawbridge should be left well enough alone.");
@@ -623,7 +623,10 @@ register struct monst *oracl;
 									pline("They say the Father of Slimes will always save his children from calamity.");
 								break;
 								case ZUGGTMOY_LEVEL:
-									if (Hallucination) pline("Can you feel your heart burning? Can you feel the struggle within?");
+									if (Hallucination || \
+										(!ClearThoughts && u.umadness&MAD_SPORES && !Race_if(PM_ANDROID) && !Race_if(PM_CLOCKWORK_AUTOMATON))
+										)
+											pline("Can you feel your heart burning? Can you feel the struggle within?");
 									else pline("They say that even decay itself is a form of life.");
 								break;
 								case YEENOGHU_LEVEL:

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -2802,6 +2802,16 @@ u_init()
 	u.silver_flame_z.dnum = u.uz.dnum;
 	u.silver_flame_z.dlevel = rn2(dunlevs_in_dungeon(&u.uz)) + dungeons[u.uz.dnum].depth_start;
 
+	dungeon_topology.hell1_variant = rnd(BELIAL_LEVEL); // bael, dis, mammon, belial + later chance of chromatic dragon for non-cav
+	dungeon_topology.hell2_variant = rnd(MEPHISTOPHELES_LEVEL); // levi, lilth, baalze, meph
+	dungeon_topology.abyss_variant = rnd(KOSTCH_LEVEL); // juib, zugg, yeen, baph, pale night, kostch
+	dungeon_topology.abys2_variant = rnd(LOLTH_LEVEL); // orcus, mal, grazzt, lolth
+	dungeon_topology.brine_variant = rnd(LAMASHTU_LEVEL); // demo, dagon, lamashtu
+	
+	if(!Role_if(PM_CAVEMAN) && dungeon_topology.hell1_variant == BAEL_LEVEL && rn2(2)){
+		dungeon_topology.hell1_variant = CHROMA_LEVEL;
+	}
+
 	int common_caste = 0;
 	switch(rn2(6)){
 		case 0:


### PR DESCRIPTION
Reworks how mkmaze.c handles picking a level for abyss, abs2, brine, hell1, hell2. Does NOT affect any other special levels or actually how it generates any, just forces the appropriat level var to match the dungeon topology variant listing instead of picking a random level var and setting the variant listing to match. Should have unchanged behavior from before. The one change I actually made about the levels was to give the chromatic dragon an actual flag for herself (`CHROMA_LEVEL`), with `Is_chromatic_level` handling the checks. However, this is pretty useless, and only currently affects the level name in #overview (now "Dragon Caves" instead of "Upper Hell" for her).

Oracle hints for each thing are more than open to suggestions - seriously, I'm writing all of these in one go and I am NOT a poet by any means. Some phrasings could be less awkward and some messages more inspired.