### PR TITLE
New artifact: Enforced Mind

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1274,6 +1274,21 @@ A("Apotheosis Veil",				CRYSTAL_HELM,			(const char *)0,
 	ENLIGHTENING, (ARTI_PLUSSEV)
 	),
 
+/*
+ * does not give telepathy. if you have telepathy, turns it to active and boosts doubles range 
+ * if you don't have telepathy, nullifies mind blasts and any psychic damage
+ * makes monsters within your extrinsic telepathy range treated as if they WERE telepathic (does not include cross-level, only in your range)
+ */
+A("Enforced Mind",				HELM_OF_TELEPATHY,			(const char *)0,
+	2500L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	A_LAWFUL, NON_PM, NON_PM, TIER_C, NOFLAG,
+	NO_MONS(),
+	NO_ATTK(), NOFLAG,
+	PROPS(BLOCK_CONFUSION), NOFLAG,
+	PROPS(SLEEP_RES), NOFLAG,
+	NOINVOKE, (ARTI_PLUSSEV)
+	),
+
 /*Needs encyc entry*/
 /* Doubles gold found in the dungeon when worn. */
 /* Also gives +1d6 physical damage to attacks when worn. */

--- a/include/display.h
+++ b/include/display.h
@@ -24,14 +24,14 @@
  * Returns true if the hero can sense the given monster.  This includes
  * monsters that are hiding or mimicing other monsters.
  */
+
+#define etele_dist ((uarmh && uarmh->oartifact == ART_ENFORCED_MIND) ? (BOLT_LIM * BOLT_LIM * 4) : (BOLT_LIM * BOLT_LIM))
 #define tp_sensemon(mon) (	/* The hero can always sense a monster IF:  */\
     (!mindless_mon(mon)) &&	/* 1. the monster has a brain to sense AND  */\
       ((Blind && Blind_telepat) ||	/* 2a. hero is blind and telepathic OR	    */\
 				/* 2b. hero is using a telepathy inducing   */\
 				/*	 object and in range		    */\
-      (Unblind_telepat &&					      \
-	(distu(mon->mx, mon->my) <= (BOLT_LIM * BOLT_LIM))))		      \
-)
+      (Unblind_telepat && (distu(mon->mx, mon->my) <= etele_dist))))
 
 #define sensemon(mon) (tp_sensemon(mon) || Detect_monsters || MATCH_WARN_OF_MON(mon) || sense_by_scent(mon))
 

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -19,7 +19,9 @@
 #define mon_intrinsic(mon,typ)	(((mon)->mintrinsics[((typ)-1)/32] & (0x1L << ((typ)-1)%32)) != 0)
 #define mon_extrinsic(mon,typ)	(((mon)->mextrinsics[((typ)-1)/32] & (0x1L << ((typ)-1)%32)) != 0)
 #define mon_acquired_trinsic(mon,typ) (((mon)->acquired_trinsics[((typ)-1)/32] & (0x1L << ((typ)-1)%32)) != 0)
-#define mon_resistance(mon,typ)	(mon_intrinsic(mon,typ) || mon_extrinsic(mon,typ) || (typ == SWIMMING && Is_waterlevel(&u.uz)) || (typ == TELEPORT && mad_monster_turn(mon, MAD_NON_EUCLID) && !(mon)->mpeaceful) || (typ == TELEPORT_CONTROL && mad_monster_turn(mon, MAD_NON_EUCLID)))
+#define mon_resistance(mon,typ)	(mon_intrinsic(mon,typ) || mon_extrinsic(mon,typ) || (typ == SWIMMING && Is_waterlevel(&u.uz)) || \
+	(typ == TELEPORT && mad_monster_turn(mon, MAD_NON_EUCLID) && !(mon)->mpeaceful) || (typ == TELEPORT_CONTROL && mad_monster_turn(mon, MAD_NON_EUCLID)) || \
+	(typ == TELEPAT && mon != &youmonst && !mindless_mon(mon) && uarmh && uarmh->oartifact == ART_ENFORCED_MIND && distu((mon)->mx, (mon)->my) <= etele_dist))
 
 #define species_resists_fire(mon)	(((mon)->data->mresists & MR_FIRE) != 0)
 #define species_resists_cold(mon)	(((mon)->data->mresists & MR_COLD) != 0)

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -369,7 +369,8 @@
 #define ETelepat		u.uprops[TELEPAT].extrinsic
 #define Blind_telepat		(HTelepat || ETelepat || \
 				 species_is_telepathic(youracedata))
-#define Unblind_telepat		(ETelepat)
+#define Unblind_telepat		(ETelepat || (Blind_telepat && uarmh && uarmh->oartifact == ART_ENFORCED_MIND))
+#define Tele_blind		(!Blind_telepat && uarmh && uarmh->oartifact == ART_ENFORCED_MIND)
 
 #define HWarning		u.uprops[WARNING].intrinsic
 #define EWarning		u.uprops[WARNING].extrinsic

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -4398,7 +4398,7 @@ cthulhu_mind_blast()
 	int nd = 1;
 	if(on_level(&rlyeh_level,&u.uz))
 		nd = 5;
-	if (Unblind_telepat || (Blind_telepat && Blind) || (Blind_telepat && rn2(2)) || !rn2(10)) {
+	if (!Tele_blind && (Unblind_telepat || (Blind_telepat && Blind) || (Blind_telepat && rn2(2)) || !rn2(10))) {
 		int dmg;
 		pline("It locks on to your %s!",
 			(Unblind_telepat || (Blind_telepat && Blind)) ? "telepathy" :

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3516,7 +3516,7 @@ char *hittee;			/* target's name: "you" or mon_nam(mdef) */
 		and = TRUE;
 	}
 	if (pen->ovar1_seals&SEAL_OSE){
-		if(youdefend && (Blind_telepat || !rn2(5))) *dmgptr += d(dnum,15);
+		if(youdefend && !Tele_blind && (Blind_telepat || !rn2(5))) *dmgptr += d(dnum,15);
 		else if(!youdefend && !mindless_mon(mdef) && (mon_resistance(mdef,TELEPAT) || !rn2(5))) *dmgptr += d(dnum,15);
 	} // nvPh - telepathy
 	if (pen->ovar1_seals&SEAL_OTIAX){
@@ -4247,7 +4247,7 @@ int * truedmgptr;
 	}
 	//Psionic does slightly buffed damage, but triggers less frequently
 	// Buffed vs. telepathic beings
-	if(youdef && (Blind_telepat || !rn2(5))){
+	if(youdef && !Tele_blind && (Blind_telepat || !rn2(5))){
 		if (check_oprop(otmp, OPROP_PSIOW))
 			*truedmgptr += basedmg + otmp->spe;
 		if (check_oprop(otmp, OPROP_LESSER_PSIOW))
@@ -4282,7 +4282,7 @@ int * truedmgptr;
 	}
 	if(check_oprop(otmp, OPROP_DEEPW)){
 		if(otmp->spe < 8){
-		if(youdef && (Blind_telepat || !rn2(5)))
+		if(youdef && !Tele_blind && (Blind_telepat || !rn2(5)))
 			*truedmgptr += d(1, 15 - (otmp->spe) * 2);
 		else if(!youdef && !mindless_mon(mdef) && (mon_resistance(mdef,TELEPAT) || !rn2(5)))
 			*truedmgptr += d(1, 15 - (otmp->spe) * 2);
@@ -6669,7 +6669,7 @@ boolean printmessages; /* print generic elemental damage messages */
 			extern const int clockwisey[8];
 			int nx, ny;
 			if(otmp->otyp != BULLWHIP || !rn2(4)){
-				if(youdef && (Blind_telepat || !rn2(5))){
+				if(youdef && !Tele_blind && (Blind_telepat || !rn2(5))){
 					*truedmgptr += d(2,2)+d(1,4);
 				}
 				else if(!youdef && !mindless_mon(mdef) && (mon_resistance(mdef,TELEPAT) || !rn2(5))){
@@ -12792,7 +12792,7 @@ int spe;
 		pline("You hear a creaking in the sky.");
 		break;
 	}
-	if (Unblind_telepat || (Blind_telepat && Blind) || (Blind_telepat && rn2(2)) || !rn2(10)) {
+	if (!Tele_blind && (Unblind_telepat || (Blind_telepat && Blind) || (Blind_telepat && rn2(2)) || !rn2(10))) {
 		pline("It locks on to your %s!",
 			(Unblind_telepat || (Blind_telepat && Blind)) ? "telepathy" :
 			Blind_telepat ? "latent telepathy" : "mind");

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1265,9 +1265,11 @@ struct monst *mon;
 		if(arm && (arm->otyp == PLAIN_DRESS || arm->otyp == NOBLE_S_DRESS)){
 			tmp += arm->spe;
 		}
-
 		if(wep && wep->oartifact == ART_SODE_NO_SHIRAYUKI){
 			tmp += wep->spe;
+		}
+		if(uarmh && uarmh->oartifact == ART_ENFORCED_MIND){
+			tmp += uarmh->spe;
 		}
 	}
 	if (x == A_STR) {

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2639,6 +2639,10 @@ base_uac()
 			dexbonus += max((int)( (ACURR(A_WIS)-1)/2 - 5 ),0) + (int)(u.ulevel/6 + 1);
 			if(Confusion && u.udrunken>u.ulevel) dexbonus += u.udrunken/9+1;
 		}
+		
+		if (uarmh && uarmh->oartifact == ART_ENFORCED_MIND){
+			dexbonus += max((int)((ACURR(A_CHA)-11)/2), 0);
+		}
 		/*Corsets suck*/
 		if(uarmu && uarmu->otyp == VICTORIAN_UNDERWEAR){
 			uac += 2; //flat penalty. Something in the code "corrects" ac values >10, this is a kludge.

--- a/src/mon.c
+++ b/src/mon.c
@@ -3030,7 +3030,7 @@ struct monst *looker;
 	if(earthsense(looker->data) && !(Flying || Levitation|| unsolid(youracedata) || Stealth)){
 		return TRUE;
 	}
-	if (mon_resistance(looker, TELEPAT)) {/* player always has a mind? */
+	if (mon_resistance(looker, TELEPAT) && !Tele_blind) {/* player always has a mind? */
 		return TRUE;
 	}
 	if(goodsmeller(looker->data) && distmin(u.ux, u.uy, looker->mx, looker->my) <= 6){
@@ -8608,7 +8608,7 @@ int damage;
 		}
 	}
 	if(primary != &youmonst && !origin->mpeaceful){
-		if (tp_sensemon(origin) || (Blind_telepat && rn2(2)) || !rn2(10)) {
+		if (!Tele_blind && (tp_sensemon(origin) || (Blind_telepat && rn2(2)) || !rn2(10))) {
 			int dmg;
 			//Note: You "hear" it in your mind, not with your ears, so You_hear() is wrong.
 			You("hear a terrible scream!");

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1801,7 +1801,7 @@ register struct monst *mtmp;
 		if (mtmp->mpeaceful && !mtmp->mberserk &&
 		    (!Conflict || resist(mtmp, RING_CLASS, 0, 0))){
 			if(!reducedFlayerMessages) pline("It feels quite soothing.");
-		} else {
+		} else if (!Tele_blind){
 			register boolean m_sen = tp_sensemon(mtmp);
 
 			if(mdat->mtyp == PM_ELDER_BRAIN){

--- a/src/worn.c
+++ b/src/worn.c
@@ -105,6 +105,8 @@ int otyp;
 		while(objects[otyp].oc_oprop[j] && !got_prop) {
 			if (objects[otyp].oc_oprop[j] == cur_prop)
 				got_prop = TRUE;
+			if (obj && obj->oartifact == ART_ENFORCED_MIND && cur_prop == TELEPAT)
+				got_prop = FALSE;
 			j++;
 		}
 


### PR DESCRIPTION
* lawful helm of telepathy (default material)
* does not actually grant telepathy. instead, will either strengthen your telepathy (if you have telepathy from some other source) or entirely block telepathy (if you don't have it from some other source)
* if it strengthens your telepathy, will boost intrinsic to extrinsic, and make the extrinsic range stretch 4x as far as the normal range. in addition, any monsters that you can see with extrinsic telepathy (so not cross-level if you're blind) are treated as if they have telepathy of their own. this grants them all appropriate bonuses or vulnerabilities to identifying you, eating mind blasts, etc.
* if it blocks your telepathy, makes you immune to being seen by telepaths (so they don't know your location from telepathy at least), and nullifies any incoming sources of psionic bonus damage or mind blasts. ** todo: this does not check monster spells. there are probably some that should be blocked, esp for psi casters
* boosts charisma by it's enchantment when worn, grants a charisma bonus (same rules as dexterity bonus and is treated as such re armor etc.) to AC
* grants confusion+stun res (like hypernotus or crown of the percs) when worn, sleep res when carried (your mind is a temple)

would appreciate suggestions/feedback before it gets merged. it's tested to function, not playtested yet, though I'm about to do a android clairvoyant changed lightsaber (psionic lesser magic living) run to see how it goes. 