### PR TITLE
If already marked as dead (by monstone(), most likely) don't reroll l…

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -4707,8 +4707,10 @@ register struct monst *mtmp;
 		 * the m_detach or there will be relmon problems later */
 		if(!grddead(mtmp)) return;
 	}
-	lifesaved_monster(mtmp);
-	if (mtmp->mhp > 0) return;
+	if (!DEADMONSTER(mtmp)) {
+		lifesaved_monster(mtmp);
+		if (mtmp->mhp > 0) return;
+	}
 	/* we did not lifesave */
 	mtmp->deadmonster |= DEADMONSTER_DEAD;
 	mtmp->mbdrown = 0;


### PR DESCRIPTION
…ifesaving

Otherwise the monster enters a limbo of being marked as dead and partly death-handled by monstone() (or monglassed, or mongolded), but revived. Would happen if mon is killed by monstone(), fails to lifesave there, but succeeds on the lifesaving check in mondead(). Which could happen, for an arch-lich or something casting flesh-to-stone at a player wearing the Mirrored Mask while in the Ana quest, having the spell reflect back, fail the 5% lifesave chance, but then succeed the erronerous 2nd 5% lifesaving attempt.