### PR TITLE
Finally fix dnh using .nethackrc not .dnethackrc

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -1591,7 +1591,7 @@ const char *filename;
 
 const char *configfile =
 #ifdef UNIX
-			".nethackrc";
+			".dnethackrc";
 #else
 # if defined(MAC) || defined(__BEOS__)
 			"NetHack Defaults";


### PR DESCRIPTION
genuinely no clue why this hasn't been changed, a quick grep says this is hte only meaningful source of `.nethackrc` in the code so idk maybe its just not an issue for other ppl but this has bugged me for literal years LOL

also no clue why k2 never mentioned this but idk maybe he has a script that ignores the files.c setting