### PR TITLE
Naberius restricted fix

### DIFF
--- a/src/sounds.c
+++ b/src/sounds.c
@@ -6103,7 +6103,9 @@ boolean inc_penalties;
 		if(OLD_P_SKILL(P_SHIEN) >= P_SKILLED) curskill++;
 		if(OLD_P_SKILL(P_SHIEN) >= P_EXPERT) curskill++;
 	}
-	
+
+	curskill = min(curskill, maxskill);
+
 	if(Air_crystal){
 		if(WIND_SKILL(p_skill))
 			INCR_CURSKILL;
@@ -6144,9 +6146,7 @@ boolean inc_penalties;
 			delta = 1; /* Want Should have SOME effect */
 		curskill = max(curskill - delta, P_UNSKILLED);
 	}
-	
-	curskill = min(curskill, maxskill);
-	
+
 	return curskill;
 }
 


### PR DESCRIPTION
There's a line to cap current skill at max skill, so I just moved that above Naberius, IMA, and the chaos crystals. That should allow them to surpass typical maximums - most notably probably, making Naberius actually unrestrict lightsaber forms, or work for Binders without any skills lol