### PR TITLE
Prevent EQ from destroying altars, and temple priests from casting it

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -6535,6 +6535,14 @@ int tary;
 	if ((spellnum == EARTHQUAKE || spellnum == TREMOR || spellnum == EARTH_CRACK) && In_endgame(&u.uz))
 		return TRUE;
 
+	/* earthquake should never be cast by a priest in their own temple (or presumably around it), since they wouldn't want to mess it up
+	 * this does assume that the priest hasn't left that level for some reason but who cares
+	 * could also check histemple_at for tremor etc. to see if target is there, but that can still overlap with the temple
+	 * note - if a monster has ispriest set, it has a shrine, see exstruct.h
+	*/
+	if ((spellnum == EARTHQUAKE || spellnum == TREMOR || spellnum == EARTH_CRACK) && !youagr && magr->ispriest)
+		return TRUE;
+
 	/* don't do strangulation if there's no room in player's inventory */
 	if (spellnum == STRANGLE && 
 		(youdef && inv_cnt() == 52 && (!uamul || uamul->oartifact || uamul->otyp == AMULET_OF_YENDOR)))

--- a/src/music.c
+++ b/src/music.c
@@ -1546,12 +1546,22 @@ struct monst *mon;
 				pline_The("kitchen sink falls into a chasm.");
 			goto do_pit;
 #endif
+
+		  /* altars being removed by eq is honestly more problematic than it should be
+		   * this is also helped by temple priests not casting eq, but then
+		   * non-temple aligned priests in places like temple of moloch still do it,
+		   * or any potential clerical casters summoned by the altar/the priest
+		   * and it's easier to just disable this all together
+		   */
+
+		  /*
 		  case ALTAR :
 			if (Is_astralevel(&u.uz) || Is_sanctum(&u.uz) || (Role_if(PM_EXILE) && Is_nemesis(&u.uz))) break;
 
 			if (cansee(x,y))
 				pline_The("altar falls into a chasm.");
 			goto do_pit;
+		  */
 		  case GRAVE :
 			if (cansee(x,y))
 				pline_The("headstone topples into a chasm.");


### PR DESCRIPTION
EQ sources (drum, EQ spell, earth crack spell, tremors spell, etc.) never destroy altars. Sometimes this is reasonable, other times it's not. Furthermore, temple priests never cast EQ or its ilk themselves - where temple priests are defined by having `ispriest` set, so they have some assigned shrine somewhere. This should cut down on both the self-destructive priests who see nothing wrong with immediately shattering their own temple in response to a minor inconvenience, and also cut down on the amount of times the altar itself is destroyed even if it's a summon or some other angry dipshit nearby instead of the shrine priest itself.