### PR TITLE
Fix figurines being able to generate any monster ever made ever

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -2289,9 +2289,9 @@ makecorpse:			if (mons[obj->corpsenm].geno &
 			}
 			(void) get_obj_location(obj, &oox, &ooy, 0);
 			refresh_x = oox; refresh_y = ooy;
-			mon = makemon(&mons[obj->corpsenm],
-				      oox, ooy, NO_MM_FLAGS);
+			mon = make_familiar(obj, oox, ooy, FALSE);
 			if (mon) {
+				(void) stop_timer(FIG_TRANSFORM, obj->timed);
 			    delobj(obj);
 			    if (cansee(mon->mx, mon->my))
 				pline_The("figurine animates!");


### PR DESCRIPTION
Figurines were patched a while ago so you could get unusable figurines (trophies etc. I guess) but unfortunately not all checks for them called the right functions. This led to makemon being called instead of animate_figurine, so you could wish for a figurine of demogorgon -> stone to flesh it -> die instantly probably but like, it's a legit copy of demogorgon not a doppelganger. Statues were fine, and now so are figurines.

Note that fossils can still be zapped into corpses and then unturn dead'd, but I'll leave that as-is, since you can't wish for fossils of uniques, nowish, etc. so it's not an actual gameplay problem.. yet.