### PR TITLE
Constellation pets should not be mindless

### DIFF
--- a/src/mondata.c
+++ b/src/mondata.c
@@ -911,7 +911,7 @@ int template;
 			ptr->mresists = MR_ALL|MR_MAGIC;
 			ptr->mflagsm |= MM_FLY|MM_BREATHLESS|MM_FLOAT;
 			ptr->mflagst &= ~(MT_ANIMAL | MT_PEACEFUL | MT_CARNIVORE | MT_HERBIVORE | MT_TRAITOR);
-			ptr->mflagst |= MT_WANDER|MT_STALK|MT_HOSTILE|MT_MINDLESS;
+			ptr->mflagst |= MT_WANDER|MT_STALK|MT_HOSTILE;
 			ptr->mflagsb |= MB_UNSOLID|MB_INSUBSTANTIAL;
 			ptr->mflagsg &= ~(MG_PNAME);
 			ptr->mflagsg |= MG_NASTY|MG_HATESUNHOLY;


### PR DESCRIPTION
This makes a lot of really good pets otherwise really useless, since they don't understand the concept of things like "use a unicorn horn so you stop hitting me" or "put on the fucking armor goddamnit holy shit" consistently. I hate pet AI so that second one might not be true but the unicorn horn one sure is - try tossing it, they'll never catch it or pick it up. Mindless ki-rins or unicorns won't even use a built-in horn, if you wanted a mount.

I understand that there's probably very good lore reasons so this is definitely open to revision, and it's not like I decide how they behave anyway, but I tried using them and was VERY underwhelmed until I hacked out MT_MINDLESS (intoner and ootaos if you were curious). 