### PR TITLE
Give magic missile wands a 90% free-use chance (instead of many charges)

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3464,6 +3464,7 @@ E boolean FDECL(obj_shudders, (struct obj *));
 E void FDECL(do_osshock, (struct obj *));
 E int FDECL(bhito, (struct obj *,struct obj *));
 E int FDECL(bhitpile, (struct obj *,int (*)(OBJ_P,OBJ_P),int,int));
+E int FDECL(zapcostchance, (struct obj *, struct monst *));
 E int FDECL(zappable, (struct obj *));
 E void FDECL(zapnodir, (struct obj *));
 E int NDECL(dozap);

--- a/src/invent.c
+++ b/src/invent.c
@@ -3555,6 +3555,24 @@ winid *datawin;
 			OBJPUTSTR(buf);
 			printed_type = TRUE;
 		}
+		if (obj) {
+			int freechance = 100 - zapcostchance(obj, &youmonst);
+			if (freechance > 0) {
+				Sprintf(buf, "You have a %d%% chance not to use a charge each zap.", freechance);
+				OBJPUTSTR(buf);
+			}
+		}
+		else {
+			struct obj * fakeobj = mksobj(otyp, MKOBJ_NOINIT);
+			fakeobj->oartifact = oartifact;
+
+			int freechance = 100 - zapcostchance(fakeobj, (struct monst *)0);
+			if (freechance > 0) {
+				Sprintf(buf, "%d%% chance not to use a charge each zap.", freechance);
+				OBJPUTSTR(buf);
+			}
+			delobj(fakeobj);
+		}
 	}
 	if (olet == RING_CLASS) {
 		if (oc.oc_charged && otyp != RIN_WISHES)

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1425,8 +1425,6 @@ int mkflags;
 		case WAND_CLASS:
 			if (otmp->otyp == WAN_WISHING)
 				otmp->spe = rnd(3);
-			else if(otmp->otyp == WAN_MAGIC_MISSILE)
-				otmp->spe = rn1(80, 31);
 			else
 				otmp->spe = rn1(5, (objects[otmp->otyp].oc_dir == NODIR) ? 11 : 4);
 			blessorcurse(otmp, 17);

--- a/src/muse.c
+++ b/src/muse.c
@@ -615,7 +615,8 @@ struct monst *mtmp;
 		       || mtmp->isgd || mtmp->ispriest) return 2;
 		m_flee(mtmp);
 		mzapmsg(mtmp, otmp, TRUE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		how = WAN_TELEPORTATION;
 mon_tele:
 		if (tele_restrict(mtmp)) {	/* mysterious force... */
@@ -642,7 +643,8 @@ mon_tele:
 	case MUSE_WAN_TELEPORTATION:
 		zap_oseen = oseen;
 		mzapmsg(mtmp, otmp, FALSE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		m_using = TRUE;
 		mbhit(mtmp,rn1(8,6),mbhitm,bhito,otmp);
 		/* monster learns that teleportation isn't useful here */
@@ -689,7 +691,8 @@ mon_tele:
 
 		m_flee(mtmp);
 		mzapmsg(mtmp, otmp, FALSE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		if (oseen) makeknown(WAN_DIGGING);
 		if (IS_FURNITURE(levl[mtmp->mx][mtmp->my].typ) ||
 		    IS_DRAWBRIDGE(levl[mtmp->mx][mtmp->my].typ) ||
@@ -724,7 +727,8 @@ mon_tele:
 	case MUSE_WAN_CREATE_MONSTER:
 		if(DimensionalLock){
 			mzapmsg(mtmp, otmp, FALSE);
-			otmp->spe--;
+			if (rn2(100) < zapcostchance(otmp, mtmp))
+				otmp->spe--;
 			if (oseen)
 				pline("Nothing happens.");
 			return 2;
@@ -737,7 +741,8 @@ mon_tele:
 
 			if (!enexto(&cc, mtmp->mx, mtmp->my, pm)) return 0;
 			mzapmsg(mtmp, otmp, FALSE);
-			otmp->spe--;
+			if (rn2(100) < zapcostchance(otmp, mtmp))
+				otmp->spe--;
 			mon = makemon((struct permonst *)0, cc.x, cc.y, NO_MM_FLAGS);
 			if (mon && canspotmon(mon) && oseen)
 				makeknown(WAN_CREATE_MONSTER);
@@ -1559,7 +1564,8 @@ struct monst *mtmp;
 	case MUSE_WAN_LIGHTNING:
 	case MUSE_WAN_MAGIC_MISSILE:
 		mzapmsg(mtmp, otmp, FALSE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		if (oseen) makeknown(otmp->otyp);
 		m_using = TRUE;
 		
@@ -1595,7 +1601,8 @@ struct monst *mtmp;
 	case MUSE_WAN_CANCELLATION:  /* Lethe */
 		zap_oseen = oseen;
 		mzapmsg(mtmp, otmp, FALSE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		m_using = TRUE;
 		mbhit(mtmp,rn1(8,6),mbhitm,bhito,otmp);
 		m_using = FALSE;
@@ -2272,7 +2279,8 @@ skipmsg:
 	case MUSE_POT_INVISIBILITY:
 		if (otmp->otyp == WAN_MAKE_INVISIBLE) {
 		    mzapmsg(mtmp, otmp, TRUE);
-		    otmp->spe--;
+			if (rn2(100) < zapcostchance(otmp, mtmp))
+				otmp->spe--;
 		} else
 		    mquaffmsg(mtmp, otmp);
 		/* format monster's name before altering its visibility */
@@ -2294,7 +2302,8 @@ skipmsg:
 		return 2;
 	case MUSE_WAN_SPEED_MONSTER:
 		mzapmsg(mtmp, otmp, TRUE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		mon_adjust_speed(mtmp, 1, otmp, TRUE);
 		return 2;
 	case MUSE_POT_SPEED:
@@ -2378,7 +2387,8 @@ museamnesia:
 		return 2;
 	case MUSE_WAN_POLYMORPH:
 		mzapmsg(mtmp, otmp, TRUE);
-		otmp->spe--;
+		if (rn2(100) < zapcostchance(otmp, mtmp))
+			otmp->spe--;
 		if(!resists_poly(mtmp->data)) newcham(mtmp, NON_PM, TRUE, FALSE);
 		if (oseen) makeknown(WAN_POLYMORPH);
 		return 2;

--- a/src/read.c
+++ b/src/read.c
@@ -1223,7 +1223,6 @@ int curse_bless;
 		stripspe(obj);
 	    } else {
 		int lim = (obj->otyp == WAN_WISHING) ? 3 :
-			(obj->otyp == WAN_MAGIC_MISSILE) ? 110 :
 			(objects[obj->otyp].oc_dir != NODIR) ? 8 : 15;
 
 		n = (lim == 3) ? 3 : rn1(5, lim + 1 - 5);

--- a/src/zap.c
+++ b/src/zap.c
@@ -2368,6 +2368,32 @@ bhitpile(obj,fhito,tx,ty)
 #endif /*OVLB*/
 #ifdef OVL1
 
+/* returns an int from 0-100 meaning chance to use a charge when zapping
+ * 100 => always uses a charge
+ * 0   => never uses a charge
+ * 
+ * if (rn2(100) < zapcost(wand, magr)) spe--;
+ */
+int
+zapcostchance(wand, magr)
+struct obj * wand;		/* wand being zapped */
+struct monst * magr;	/* creature zapping the wand (if any) */
+{
+	int base;	/* base chance */
+	switch (wand->otyp)
+	{
+	case WAN_MAGIC_MISSILE:
+		base = 10;
+		break;
+	
+	default:
+		base = 100;
+		break;
+	}
+
+	return base;
+}
+
 /*
  * zappable - returns 1 if zap is available, 0 otherwise.
  *	      it removes a charge from the wand if zappable.
@@ -2386,7 +2412,9 @@ register struct obj *wand;
 			return 0;
 		if(wand->spe == 0)
 			You("wrest one last charge from the worn-out wand.");
-		wand->spe--;
+
+		if (rn2(100) < zapcostchance(wand, &youmonst))
+			wand->spe--;
 		return 1;
 	}
 	else if(wand->otyp == ROD_OF_FORCE){


### PR DESCRIPTION
Fixes most/all of the issues that were caused by a really-high charge amount, like incantifier food, inventory shock damage, polymorph, etc.

Chance to get a free zap is displayed in inspection.

Potential for future extensions: discounts based on wand wielder, or wand obj.