### PR TITLE
add paranoid_water option

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1133,6 +1133,7 @@ E char *FDECL(eos, (char *));
 E void FDECL(sanitizestr, (char *));
 E char *FDECL(strkitten, (char *,CHAR_P));
 E char *FDECL(s_suffix, (const char *));
+E char *FDECL(ing_suffix, (const char *));
 E char *FDECL(xcrypt, (const char *,char *));
 E boolean FDECL(onlyspace, (const char *));
 E char *FDECL(tabexpand, (char *));

--- a/include/flag.h
+++ b/include/flag.h
@@ -344,6 +344,7 @@ struct instance_flags {
 	boolean  paranoid_hit;  /* Ask for 'yes' when hitting peacefuls */
 	boolean  paranoid_quit; /* Ask for 'yes' when quitting */
 	boolean  paranoid_remove; /* Always show menu for 'T' and 'R' */
+	boolean  paranoid_swim; /* Require 'm' prefix to move into water/lava/air unless it's safe */
 #endif
 #ifdef USE_TILES
 	boolean  vt_nethack;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -11252,6 +11252,10 @@ nothing_special:
 	    else
 		Your("body seems to unfade...");
 	    break;
+	case WWALKING:
+		if (on) You_feel("more buoyant!");
+		else You_feel("heavier!");
+		break;
 #ifdef BARD
 	    /*
 	case HARMONIZE:

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -20,6 +20,7 @@ NetHack, except that rounddiv may call panic().
 	char *		eos		(char *)
 	char *		strkitten	(char *,char)
 	char *		s_suffix	(const char *)
+	char *		ing_suffix	(const char *)
 	char *		xcrypt		(const char *, char *)
 	boolean		onlyspace	(const char *)
 	char *		tabexpand	(char *)
@@ -176,6 +177,43 @@ s_suffix(s)		/* return a name converted to possessive */
 	Strcat(buf[i], "'s");
     return buf[i];
 #undef SSUFFIX_BUFFERS
+}
+
+/* construct a gerund (a verb formed by appending "ing" to a noun) */
+char *
+ing_suffix(const char *s)
+{
+    static const char vowel[] = "aeiouwy";
+    static char buf[BUFSZ];
+    char onoff[10];
+    char *p;
+
+    Strcpy(buf, s);
+    p = eos(buf);
+    onoff[0] = *p = *(p + 1) = '\0';
+    if ((p >= &buf[3] && !strcmpi(p - 3, " on"))
+        || (p >= &buf[4] && !strcmpi(p - 4, " off"))
+        || (p >= &buf[5] && !strcmpi(p - 5, " with"))) {
+        p = strrchr(buf, ' ');
+        Strcpy(onoff, p);
+        *p = '\0';
+    }
+    if (p >= &buf[2] && !strcmpi(p - 2, "er")) { /* slither + ing */
+        /* nothing here */
+    } else if (p >= &buf[3] && !strchr(vowel, *(p - 1))
+        && strchr(vowel, *(p - 2)) && !strchr(vowel, *(p - 3))) {
+        /* tip -> tipp + ing */
+        *p = *(p - 1);
+        *(p + 1) = '\0';
+    } else if (p >= &buf[2] && !strcmpi(p - 2, "ie")) { /* vie -> vy + ing */
+        *(p - 2) = 'y';
+        *(p - 1) = '\0';
+    } else if (p >= &buf[1] && *(p - 1) == 'e') /* grease -> greas + ing */
+        *(p - 1) = '\0';
+    Strcat(buf, "ing");
+    if (onoff[0])
+        Strcat(buf, onoff);
+    return buf;
 }
 
 char *

--- a/src/options.c
+++ b/src/options.c
@@ -210,6 +210,7 @@ static struct Bool_Opt
 	{"paranoid_hit", &iflags.paranoid_hit, FALSE, SET_IN_GAME},
 	{"paranoid_quit", &iflags.paranoid_quit, FALSE, SET_IN_GAME},
 	{"paranoid_remove", &iflags.paranoid_remove, FALSE, SET_IN_GAME},
+	{"paranoid_swim", &iflags.paranoid_swim, TRUE, SET_IN_GAME},
 #endif
 	{"perm_invent", &flags.perm_invent, FALSE, SET_IN_GAME},
        {"pickup_thrown", &iflags.pickup_thrown, FALSE, SET_IN_GAME},


### PR DESCRIPTION
credit to noisytoot/ron nazarov on IRC/discord

paranoid_water option now exists, on by default. when attempting to move into water while not on water while not m-moving or running, will try to warn you.

warns if you have no obvious means of not being affected (flying, visible ww*, etc), with hte message "u avoid stepping into it", followed by "use m move if u want to force" (cooldown on the 2nd msg is every 10 turns, it'll always print u avoid). no y/n prompt just avoids, doesn't take a turn

*note that i diverged from og patch by only checking against "visible" ww sources, so:
- worn type ID'd boots of wwalking
- extrinsic from artifact that's on-carry or on-invoke ww
- intrinsic ww
- eurynome
- nenya on ur fingers specifically
- DOES NOT CHECK other sources of worn ww, since they don't exist rn, and no easy way to check "an object that grants ww is worn and that obj is type ID'd" cleanly, so that'll just need to be added if one exists. go figure

see commit log for full log from noisy