### PR TITLE
pets avoid being displaced into water/traps intelligently

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1678,15 +1678,15 @@ domove()
 				boulder_at(trap->tx, trap->ty)
 			) || (
 				(trap->ttyp == VIVI_TRAP)
-			)
-		)) {
+			))
+		) {
 			/* can't swap places with pet pinned in a pit by a boulder, or one stuck in an essence trap */
 			u.ux = u.ux0,  u.uy = u.uy0;	/* didn't move after all */
 	    } else if (u.ux0 != x && u.uy0 != y &&
 		       bad_rock(mtmp, x, u.uy0) &&
 		       bad_rock(mtmp, u.ux0, y) &&
 		       (bigmonst(mtmp->data) || (curr_mon_load(mtmp) > 600))
-		){
+		) {
 			/* can't swap places when pet won't fit thru the opening */
 			u.ux = u.ux0,  u.uy = u.uy0;	/* didn't move after all */
 			You("stop.  %s won't fit through.", upstart(y_monnam(mtmp)));
@@ -1702,63 +1702,104 @@ domove()
 	    } else if (mtmp->mpeaceful && !mtmp->mtame
 		    && (!goodpos(u.ux0, u.uy0, mtmp, 0)
 			|| t_at(u.ux0, u.uy0) != NULL
-			|| mtmp->m_id == quest_status.leader_m_id
-		       )) {
-		u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-		You("stop. %s doesn't want to swap places.",
-			upstart(y_monnam(mtmp)));
+			|| mtmp->m_id == quest_status.leader_m_id)
+		) {
+			u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
+			You("stop. %s doesn't want to swap places.",
+				upstart(y_monnam(mtmp)));
 
 	    } else {
-		/* if trapped, there's a chance the pet goes wild */
-		if (mtmp->mtrapped) {
-		    abuse_dog(mtmp);
-		}
-		char pnambuf[BUFSZ];
+			char pnambuf[BUFSZ];
+			extern const int clockwisex[8];
+			extern const int clockwisey[8];
+			int newx = 0;
+			int newy = 0;
 
-		/* save its current description in case of polymorph */
-		Strcpy(pnambuf, y_monnam(mtmp));
-		mtmp->mtrapped = 0;
-		remove_monster(x, y);
-		place_monster(mtmp, u.ux0, u.uy0);
-		newsym(x, y);
-		newsym(u.ux0, u.uy0);
+			/* goodpos for pet? otherwise we shunt somewhere else
+			 * pet knowledge of pets checks tseen / searching. polytraps and */
 
-		/* check for displacing it into pools and traps */
-		trap = t_at(u.ux0, u.uy0);
-		int switchcase = minliquid(mtmp) ? 2 : mintrap(mtmp);
-		switch (switchcase) {
-		case 0:
-		    You("%s %s.", mtmp->mpeaceful ? "displaced" : "frightened",
-			pnambuf);
-		    break;
-		case 1:		/* trapped */
-		case 3:		/* changed levels */
-		    /* there's already been a trap message, reinforce it */
-			if(!(switchcase == 3 && trap->ttyp == MAGIC_PORTAL)){
-			    abuse_dog(mtmp);
-			    adjalign(-3);
+			boolean pet_goodpos = goodpos(u.ux0, u.uy0, mtmp, 0);
+			
+			if (trap = t_at(x, y) != NULL && (trap->tseen || mon_resistance(mtmp, SEARCHING)) &&
+				!(trap->ttyp == MAGIC_PORTAL || trap->ttyp == POLY_TRAP))
+					pet_goodpos = FALSE;
+
+			/* save its current description in case of polymorph */
+			Strcpy(pnambuf, y_monnam(mtmp));
+
+			int i = rnd(8), j;
+#define tmpx clockwisex[(i + j) % 8] + x
+#define tmpy clockwisey[(i + j) % 8] + y
+			if (!pet_goodpos){
+				/* clear for goodpos */
+				u.ux = u.ux0, u.uy = u.uy0;
+				for (j = 8; j >= 1; j--){
+					if (!goodpos(tmpx, tmpy, mtmp, 0))
+						continue;
+					
+					trap = t_at(tmpx, tmpy);
+					if (trap != NULL && ((trap && trap->tseen) || mon_resistance(mtmp, SEARCHING)))
+						continue;
+
+					newx = tmpx;
+					newy = tmpy;
+					break;
+				}
+			} else {
+				newx = u.ux0;
+				newy = u.uy0;
 			}
-		    break;
-		case 2:
-		    /* it may have drowned or died.  that's no way to
-		     * treat a pet!  your god gets angry.
-		     */
-		    if (rn2(4)) {
-			You_feel("guilty about losing your pet like this.");
-			godlist[u.ualign.god].anger++;
-			adjalign(-15);
-		    }
-
-		    /* you killed your pet by direct action.
-		     * minliquid and mintrap don't know to do this
-		     */
-		    u.uconduct.killer++;
-			if(mtmp->mtyp == PM_CROW && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
-		    break;
-		default:
-		    pline("that's strange, unknown mintrap result!");
-		    break;
-		}
+#undef tmpx
+#undef tmpy
+			if (newx && newy){
+				u.ux = x, u.uy = y; /* re-move, cleared to check goodpos */
+				mtmp->mtrapped = 0;
+				remove_monster(x, y);
+				place_monster(mtmp, newx, newy);
+				newsym(newx, newy);
+				newsym(x, y);
+				newsym(u.ux0, u.uy0);
+			}
+			
+			if (mtmp->mx == x && mtmp->my == y){
+				You("stop. %s doesn't want to swap places.", upstart(y_monnam(mtmp)));
+			} else {
+				/* check for displacing it into pools and traps. 
+				 * pools should never happen due to goodpos - but just in case, not removing handling */
+				trap = t_at(u.ux0, u.uy0);
+				int switchcase = minliquid(mtmp) ? 2 : mintrap(mtmp);
+				switch (switchcase) {
+					case 0:
+						You("%s %s.", mtmp->mpeaceful ? "displaced" : "frightened", pnambuf);
+						break;
+					case 1:		/* trapped */
+					case 3:		/* changed levels */
+						/* there's already been a trap message, reinforce it */
+						if(!(switchcase == 3 && trap->ttyp == MAGIC_PORTAL)){
+							abuse_dog(mtmp);
+							adjalign(-3);
+						}
+						break;
+					case 2:
+						/* it may have drowned or died.  that's no way to
+						 * treat a pet!  your god gets angry.
+						 */
+						if (rn2(4)) {
+							You_feel("guilty about losing your pet like this.");
+							godlist[u.ualign.god].anger++;
+							adjalign(-15);
+						}
+						/* you killed your pet by direct action.
+						 * minliquid and mintrap don't know to do this
+						 */
+						u.uconduct.killer++;
+						if(mtmp->mtyp == PM_CROW && u.sealsActive&SEAL_MALPHAS) unbind(SEAL_MALPHAS,TRUE);
+						break;
+					default:
+						pline("that's strange, unknown mintrap result!");
+						break;
+				}
+			}
 	    }
 	}
 


### PR DESCRIPTION
they now check !goodpos or refuse to move, and also reject being displaced into traps. you can still swap places if you start on a polymorph trap or a magic portal, to try to force them onto them, but they won't randomly choose those spots. this fixes fatfinger drowning pet displaces, but more importantly, 'why the fuck did you take off your waterwalking boots' incidents