### PR TITLE
add "detached from purpose" flag

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -262,8 +262,11 @@
 #define is_silent(ptr)		((ptr)->msound == MS_SILENT)
 #define is_silent_mon(mon)	(is_silent((mon)->data))
 #define unsolid(ptr)		(((ptr)->mflagsb & MB_UNSOLID) != 0L)
-#define mindless(ptr)		(((ptr)->mflagst & MT_MINDLESS) != 0L || on_level(&valley_level, &u.uz))
+#define mindless(ptr)		(((ptr)->mflagst & MT_MINDLESS) != 0L || ((ptr)->mflagst & MT_DETACHED) != 0L || on_level(&valley_level, &u.uz))
 #define mindless_mon(mon)		(mon && mindless((mon)->data))
+#define detached_from_purpose(ptr) (((ptr)->mflagst & MT_DETACHED) != 0)
+#define detached_from_purpose_mon(mon) (mon && detached_from_purpose((mon)->data))
+#define mindless_muse_mon(mon)	(mindless_mon(mon) && !(!on_level(&valley_level, &u.uz) && detached_from_purpose_mon(mon)))
 #define intelligent_mon(mon)	(!mindless_mon(mon) && !is_animal((mon)->data))
 #define murderable_mon(mon)	((mon) && ((intelligent_mon(mon) && always_peaceful((mon)->data) && !always_hostile_mon(mon)) || (mon)->isshk || (mon)->isgd || (mon)->ispriest))
 

--- a/include/monflag.h
+++ b/include/monflag.h
@@ -133,10 +133,9 @@
 #define MT_TRAITOR		0x00800000L	/* slash'em tag. */
 #define MT_NOTAKE		0x01000000L	/* doesn't pick up items. */
 #define MT_METALLIVORE	0x02000000L	/* eats metal. */
-
 #define MT_MAGIVORE		0x04000000L	/* eats magic */
-
 #define MT_BOLD			0x08000000L	/* recovers from fear quickly */
+#define MT_DETACHED		0x10000000L	/* detached from purpose/subsumed but intelligent, mindless but with muse roughly */
 
 #define MT_OMNIVORE		(MT_CARNIVORE|MT_HERBIVORE)	/* eats both */
 #define MT_MAID		(MT_MAGIC|MT_COLLECT|MT_JEWELS|MT_GREEDY)	/* tiddies up the dungeon */

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -919,7 +919,7 @@ int template;
 			ptr->mresists = MR_ALL|MR_MAGIC;
 			ptr->mflagsm |= MM_FLY|MM_BREATHLESS|MM_FLOAT;
 			ptr->mflagst &= ~(MT_ANIMAL | MT_PEACEFUL | MT_CARNIVORE | MT_HERBIVORE | MT_TRAITOR);
-			ptr->mflagst |= MT_WANDER|MT_STALK|MT_HOSTILE|MT_MINDLESS;
+			ptr->mflagst |= MT_WANDER|MT_STALK|MT_HOSTILE|MT_DETACHED;
 			ptr->mflagsb |= MB_UNSOLID|MB_INSUBSTANTIAL;
 			ptr->mflagsg &= ~(MG_PNAME);
 			ptr->mflagsg |= MG_NASTY|MG_HATESUNHOLY;
@@ -1993,9 +1993,11 @@ int level_bonus;
 		if (horror->mflagst & MT_NOTAKE)
 			horror->mflagst &= ~MT_MAID;
 		if (horror->mflagst & MT_MINDLESS)
-			horror->mflagst &= ~MT_ANIMAL;
+			horror->mflagst &= ~(MT_ANIMAL | MT_DETACHED);
+		if (horror->mflagst & MT_DETACHED)
+			horror->mflagst &= ~(MT_MINDLESS | MT_ANIMAL);
 		if (horror->mflagst & MT_ANIMAL)
-			horror->mflagst &= ~MT_MINDLESS;
+			horror->mflagst &= ~(MT_MINDLESS | MT_DETACHED);
 		if (horror->mflagsb & MB_MALE)
 			horror->mflagsb &= ~(MB_FEMALE | MB_NEUTER);
 		if (horror->mflagsb & MB_FEMALE)

--- a/src/muse.c
+++ b/src/muse.c
@@ -262,7 +262,7 @@ struct monst *mtmp;
 	boolean immobile = (mtmp->data->mmove == 0);
 	int fraction;
 
-	if (is_animal(mtmp->data) || mindless_mon(mtmp))
+	if (is_animal(mtmp->data) && mindless_muse_mon(mtmp))
 		return FALSE;
 	if(dist2(x, y, mtmp->mux, mtmp->muy) > 25 || (mtmp->mux == 0 && mtmp->muy == 0))
 		return FALSE;
@@ -1033,7 +1033,7 @@ struct monst *mtmp;
 	int difficulty = monstr[(monsndx(pm))];
 	int trycnt = 0;
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || nohands(mtmp->data)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || nohands(mtmp->data)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 
@@ -1146,7 +1146,7 @@ struct monst *mtmp;
 
 	m.offensive = (struct obj *)0;
 	m.has_offense = 0;
-	if (is_animal(mtmp->data) || mindless_mon(mtmp) ||
+	if (is_animal(mtmp->data) || mindless_muse_mon(mtmp) ||
 	    nohands(mtmp->data))
 		return FALSE;
 	if (target == &youmonst){
@@ -1832,7 +1832,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))], diesize;
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || nohands(mtmp->data) || get_mx(mtmp, MX_ESUM)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || nohands(mtmp->data) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	if (difficulty > 7 && !rn2(35)) return WAN_DEATH;
@@ -1871,7 +1871,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	if (difficulty > 7 && !rn2(35)) return rnd(20) > 10 ? WAN_DRAINING : WAN_DEATH;
@@ -1921,7 +1921,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	switch (rnd(6)) {
@@ -1943,7 +1943,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	switch (rnd(6)) {
@@ -1965,7 +1965,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST || pm->mlet == S_SHADE || pm->mlet == S_KETER
 		) return 0;
 	switch (rnd(16)) {
@@ -2028,7 +2028,7 @@ struct monst *mtmp;
 	
 	m.misc = (struct obj *)0;
 	m.has_misc = 0;
-	if (is_animal(mdat) || mindless_mon(mtmp))
+	if (is_animal(mdat) || mindless_muse_mon(mtmp))
 		return FALSE;
 	if (u.uswallow && stuck) return FALSE;
 
@@ -2704,7 +2704,7 @@ struct monst *mtmp;
 	struct permonst *pm = mtmp->data;
 	int difficulty = monstr[(monsndx(pm))];
 
-	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_mon(mtmp) || get_mx(mtmp, MX_ESUM)
+	if(is_animal(pm) || mon_attacktype(mtmp, AT_EXPL) || mindless_muse_mon(mtmp) || get_mx(mtmp, MX_ESUM)
 			|| pm->mlet == S_GHOST
 			|| pm->mlet == S_SHADE
 			|| pm->mlet == S_KETER
@@ -2829,7 +2829,7 @@ struct obj *obj;
 	int typ = obj->otyp;
 
 	if (is_animal(mon->data) ||
-		mindless_mon(mon) ||
+		mindless_muse_mon(mon) ||
 		mon->mtyp == PM_SHADE ||
 		mon->mtyp == PM_BROKEN_SHADOW ||
 		mon->mtyp == PM_GHOST)	/* don't loot bones piles */

--- a/src/pager.c
+++ b/src/pager.c
@@ -1674,9 +1674,10 @@ get_mt_description_of_monster_type(struct monst * mtmp, char * description)
 
 	many = append(description, bold(ptr)				, "fearless"					, many);
 	many = append(description, hides_under(ptr)			, "hides"						, many);
-	many = append(description, is_hider(ptr)			, "camoflauged"					, many);
+	many = append(description, is_hider(ptr)			, "camouflaged"					, many);
 	many = append(description, notake(ptr)				, "doesn't pick up items"		, many);
 	many = append(description, mindless_mon(mtmp)		, "mindless"					, many);
+	many = append(description, detached_from_purpose_mon(mtmp), "detached from original purpose", many);
 	many = append(description, is_animal(ptr)			, "animal minded"				, many);
 	eats = appendgroup(description, carnivorous(ptr)	, "eats",	"meat"				, many, eats);
 	eats = appendgroup(description, herbivorous(ptr)	, "eats",	"veggies"			, many, eats);


### PR DESCRIPTION
this is basically "mindless but allows muse", though they don't spawn with the misc items. they do know how to use and will use offensive, defensive, and misc (invis pots etc.) items.

the intent is to provide a "not intelligent, no brain, but either subsumed will or not really all there anymore". the intent is for constellation pets, and constellations are now marked as MT_DETACHED instead of MT_MINDLESS, and it's not used for anything else.

note that anything that wants to check mindless checks mindless_mon, so in lieu of going through every single instance, MT_DETACHED is just added there. for "mindless but not detached", check mindless_muse instead.