### PR TITLE
fix binder astral rarely crashing constantly

### DIFF
--- a/src/pray.c
+++ b/src/pray.c
@@ -4711,7 +4711,7 @@ int fd;
 	godlist = malloc(sizeof(struct god) * (MAX_GOD+1));
 	mread(fd, (genericptr_t) godlist, sizeof(struct god) * (MAX_GOD+1));
 	/* fix name pointers -- assumes that god names do NOT get changed during the game */
-	for (i=1; i<MAX_GOD; i++)
+	for (i=1; i<MAX_GOD+1; i++)
 		godlist[i].name = base_godlist[i].name;
 }
 

--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -1565,7 +1565,7 @@ do_gods()
 		    else if (*c < 'A' || *c > 'Z') *c = '_';
 		Fprintf(ofp,"%s\t%d", limit(nam, 1), i);
 	}
-	Fprintf(ofp,"\n\n#define\tMAX_GOD\t%d\n", i);
+	Fprintf(ofp,"\n\n#define\tMAX_GOD\t%d\n", i-1);
 	Fprintf(ofp,"\n#endif /* GNAMES_H */\n");
 	Fclose(ofp);
 	return;


### PR DESCRIPTION
due to a never-interacted-with off-by-one in gnames, the value of MAX_GOD was actually being used as NUM_GODS, aka 1 higher than what it should.

this fixes that - MAX_GOD is now the last one (currently GOD_NYAR). this is the same situation as nrofartifacts (ART_TRAPPINGS_OF_THE_GRAVE & NROFARTIFACTS are both 324)

the various malloc calls are fine, previously they actually had one god struct's worth of extra space, so the only thing that needed adjustment is the save/restore code to change <MAX_GOD to <MAX_GOD+1

the actual bug here was that binder astral could rarely spawn (1/106 per applicable monster) minions/priests/whatever of null terminator gods due to maxrolling a d106. this was reported by klepto, poor fucker had it crash apparently 20+ times due to the walking segfault going on before finally successfully finishing his ascension