### PR TITLE
Add Dark Claymore crowning gift for chaotic knights

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1695,7 +1695,7 @@ A("The Dark Claymore",						TWO_HANDED_SWORD,				(const char *)0,
 	ATTK(AD_DARK, 1, 6), NOFLAG,
 	PROPS(), NOFLAG,
 	PROPS(), NOFLAG,
-	NOINVOKE, NOFLAG
+	LEADERSHIP, NOFLAG
 	),
 
 /*Needs encyc entry*/

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -1687,6 +1687,17 @@ A("Clarent",						LONG_SWORD,				(const char *)0,
 	LEADERSHIP, (ARTI_DIG)
 	),
 
+/* sdice are a copy of ldice, ocn +=1  */
+A("The Dark Claymore",						TWO_HANDED_SWORD,				(const char *)0,
+	4000L, OBSIDIAN_MT, MZ_LARGE, WT_DEFAULT,
+	A_CHAOTIC, PM_KNIGHT, NON_PM, TIER_A, (ARTG_NOGEN|ARTG_NOWISH|ARTG_MAJOR),
+	NO_MONS(),
+	ATTK(AD_DARK, 1, 6), NOFLAG,
+	PROPS(), NOFLAG,
+	PROPS(), NOFLAG,
+	NOINVOKE, NOFLAG
+	),
+
 /*Needs encyc entry*/
 A("Reaver",							SCIMITAR,				(const char *)0,
 	6000L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,

--- a/src/crown.c
+++ b/src/crown.c
@@ -86,8 +86,9 @@ static const struct crowning hand_of_elbereth[] = {
 {GOD_GWYN__LORD_OF_SUNLIGHT,     ART_DRAGONHEAD_SHIELD,			"the Dragon-slayer of Gwyn",			dub_thee_the,							became_the	},
 {GOD_GWYNEVERE__PRINCESS_OF_SUN, ART_CRUCIFIX_OF_THE_MAD_KING,	"the Guardian of the Old Lords",		dub_thee_the,							became_the	},
 {GOD_DARK_SUN_GWYNDOLIN,         ART_RINGED_BRASS_ARMOR,		"the Darkmoon Champion",				dub_thee_the,							became_the	},
-	/* Knight -- lawful only */
+	/* Knight -- lawful and chaotic  */
 {GOD_LUGH,                       ART_CLARENT,					"the King of the Angles",				dub_thee,								"crowned %s"	},
+{GOD_MANANNAN_MAC_LIR,                       ART_DARK_CLAYMORE,					"the Warrior of the Sea",				dub_thee,								"crowned %s"	},
 	/* Pirate -- all alignments are identical */
 {GOD_THE_LORD,                   ART_REAVER,					"the Pirate King",						(const char *)0,						became_the	},
 {GOD_THE_DEEP_BLUE_SEA,          ART_REAVER,					"the Pirate King",						(const char *)0,						became_the	},

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -466,10 +466,16 @@ struct monst *magr;
 		explode_amt =   (wdice->explode_amt);
 		ignore_rolls =   (wdice->ignore_rolls);
 	}
-
 	/* set dmod, if possible*/
 	if (obj){
 		dmod = obj->objsize - MZ_MEDIUM;
+
+		/* Use ldice for small cases as well and add 1 to ocn */
+		if(obj->oartifact == ART_DARK_CLAYMORE){
+			ocn = objects[otyp].oc_wldam.oc_damn + 1;
+			ocd = objects[otyp].oc_wldam.oc_damd;
+		}
+
 		if (obj->oartifact == ART_FRIEDE_S_SCYTHE)
 			dmod += 2;
 		else if (obj->oartifact == ART_HOLY_MOONLIGHT_SWORD && obj->lamplit)


### PR DESCRIPTION
Add Dark Claymore crowning gift for chaotic knights as well as crowing title. This weapon is meant to be used for GWF builds and gets +1 ocn die, is a large and obsidian two handed sword, and uses its ldice as its sdice, so in practice has 4d10 base dmg vs both large and small. Also gets +d6 AD_DARK damage. Pretty heavy, meant to encourage riding and be a drawback for the very nice base damage. Has same invoke as Clarent because it feels like a generally good knight utility.

Very open to reflavors and changes here. I am not quite happy with this, but it feels cool for GWF usage. I want to work out a neutral crowning gift shield meant for shield bashing. I also want to work out a mounted lance fighting style. Trying to make Knight styles and available gear fit together a bit better.