### PR TITLE
Fix a few behaviors that were broken in the dbon unification patch.

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -2755,72 +2755,71 @@ struct monst *mtmp;
 
 	if (!otmp){
 		if (youagr && u.umaniac && bare_bonus > 0)
-			return min_ints(bare_bonus, chabon);
-		else
-			return 0;
-	}
-	/* all of these ifs should almost always fire, it's for readability */
-	/* if two bonus sources can stack, they're in separate ifs so they can both fire*/
-	if (dexbon){
-		if (is_rakuyo(otmp)){
-			strbon = 0;
-			damage_bon += dexbon * 2;
-		} else if (is_rapier(otmp) || is_mercy_blade(otmp) || otmp->otyp == SET_OF_CROW_TALONS ||
-				(otmp->otyp == LIGHTSABER && !otmp->oartifact && otmp->ovar1_lightsaberHandle == 0)){
-			half_str = TRUE;
-			damage_bon += dexbon;
+			damage_bon +=  min_ints(bare_bonus, chabon);
+	} else {
+		/* all of these ifs should almost always fire, it's for readability */
+		/* if two bonus sources can stack, they're in separate ifs so they can both fire*/
+		if (dexbon){
+			if (is_rakuyo(otmp)){
+				strbon = 0;
+				damage_bon += dexbon * 2;
+			} else if (is_rapier(otmp) || is_mercy_blade(otmp) || otmp->otyp == SET_OF_CROW_TALONS ||
+					(otmp->otyp == LIGHTSABER && !otmp->oartifact && otmp->ovar1_lightsaberHandle == 0)){
+				half_str = TRUE;
+				damage_bon += dexbon;
+			}
+			if (otmp->oartifact == ART_LIFEHUNT_SCYTHE || otmp->oartifact == ART_YORSHKA_S_SPEAR || otmp->oartifact == ART_FRIEDE_S_SCYTHE){
+				if (otmp->oartifact != ART_YORSHKA_S_SPEAR) half_str = TRUE;
+				damage_bon += dexbon * 2;
+			}
 		}
-		if (otmp->oartifact == ART_LIFEHUNT_SCYTHE || otmp->oartifact == ART_YORSHKA_S_SPEAR || otmp->oartifact == ART_FRIEDE_S_SCYTHE){
-			if (otmp->oartifact != ART_YORSHKA_S_SPEAR) half_str = TRUE;
-			damage_bon += dexbon * 2;
-		}
-	}
 
-	if (conbon){
-		// no conbon items yet
-	}
+		if (conbon){
+			// no conbon items yet
+		}
 
-	if (intbon){
-		if (u.uinsight > 0 && check_oprop(otmp, OPROP_GSSDW)){
-			half_str = TRUE;
-			damage_bon += intbon;
+		if (intbon){
+			if (u.uinsight > 0 && check_oprop(otmp, OPROP_GSSDW)){
+				half_str = TRUE;
+				damage_bon += intbon;
+			}
+			if (otmp->oartifact == ART_VELKA_S_RAPIER || otmp->oartifact == ART_FRIEDE_S_SCYTHE){
+				half_str = TRUE;
+				damage_bon += intbon;
+			}
+			if (is_mercy_blade(otmp)){
+				half_str = TRUE;
+				damage_bon += intbon/2;
+			}
+			if (check_oprop(otmp, OPROP_ELFLW)){
+				damage_bon += intbon/2;
+			}
 		}
-		if (otmp->oartifact == ART_VELKA_S_RAPIER || otmp->oartifact == ART_FRIEDE_S_SCYTHE){
-			half_str = TRUE;
-			damage_bon += intbon;
-		}
-		if (is_mercy_blade(otmp)){
-			half_str = TRUE;
-			damage_bon += intbon/2;
-		}
-		if (check_oprop(otmp, OPROP_ELFLW)){
-			damage_bon += intbon/2;
-		}
-	}
 
-	if (wisbon){
-		if (otmp->oartifact == ART_YORSHKA_S_SPEAR){
-			damage_bon += wisbon;
+		if (wisbon){
+			if (otmp->oartifact == ART_YORSHKA_S_SPEAR){
+				damage_bon += wisbon;
+			}
+			if (check_oprop(otmp, OPROP_OCLTW)){
+				half_str = TRUE;
+				damage_bon += wisbon;
+			}
+			if (otmp->oartifact == ART_CRUCIFIX_OF_THE_MAD_KING){
+				half_str = TRUE;
+				damage_bon += wisbon/2;
+			}
+			if (check_oprop(otmp, OPROP_ELFLW)){
+				damage_bon += wisbon/2;
+			}
 		}
-		if (check_oprop(otmp, OPROP_OCLTW)){
-			half_str = TRUE;
-			damage_bon += wisbon;
-		}
-		if (otmp->oartifact == ART_CRUCIFIX_OF_THE_MAD_KING){
-			half_str = TRUE;
-			damage_bon += wisbon/2;
-		}
-		if (check_oprop(otmp, OPROP_ELFLW)){
-			damage_bon += wisbon/2;
-		}
-	}
 
-	if (chabon){
-		if (check_oprop(otmp, OPROP_ELFLW)){
-			damage_bon += chabon/2;
-		}
-		if (otmp->oartifact == ART_IBITE_ARM){
-			if(bare_bonus > 0) damage_bon += cha/5 + bare_bonus*2;
+		if (chabon){
+			if (check_oprop(otmp, OPROP_ELFLW)){
+				damage_bon += chabon/2;
+			}
+			if (otmp->oartifact == ART_IBITE_ARM){
+				if(bare_bonus > 0) damage_bon += cha/5 + bare_bonus*2;
+			}
 		}
 	}
 	if (damage_bon && armg && check_oprop(armg, OPROP_RWTH) && (

--- a/src/wield.c
+++ b/src/wield.c
@@ -979,7 +979,7 @@ struct monst * mon;
 	if (otmp->oartifact==ART_PEN_OF_THE_VOID && otmp->ovar1_seals&SEAL_MARIONETTE && mvitals[PM_ACERERAK].died > 0)
 		return 2;
 
-	if (otmp->otyp == FORCE_SWORD || otmp->otyp == DISKOS)
+	if (otmp->otyp == FORCE_SWORD || otmp->otyp == DISKOS || otmp->otyp == ROD_OF_FORCE || (youagr && weapon_type(otmp) == P_QUARTERSTAFF))
 		return 2;
 
 	if (is_spear(otmp))


### PR DESCRIPTION
Fixed a few inconsistencies between the rewrite and the original code.

- Unarmed attacks now no longer get 0 dbon from str. They now appropriately get str bon and potential glove RWTH modifier.
- Rod of Force now gets 2x str dbon when used one handed with an available extra hand, like it originally did before the rewrite.
- Quarterstaff skill weapons used one handed with an available extra hand now get 2x str dbon, like they did before the rewrite. (this is exclusively for players only, because weapon_type assumes a player context in determining skill to use)