### PR TITLE
minor tweaks - gwf, tty descendant random, sflmable body armor

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1041,7 +1041,10 @@ struct weapon_dice * wdie;
 boolean youdef;
 {
 	int tmp = 0;
-	int igrolls = wdie->ignore_rolls;
+	// on a d6 this is 3d
+	// 16%,33%,50% at i_r 1,2,3
+	// on a d6 this is 1/2/3 + d3, on a d10 its 1/3/5 + d5, d20 is 1/6/10 + d10, etc.
+	int igrolls = (x*wdie->ignore_rolls)/6;
 
 	/* verify there are appropriate dice to roll */
 	if (!n)

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -708,7 +708,7 @@ give_up:	/* Quit */
 	/* Select descendant status, if necessary */
 	if (flags.descendant < 0) {
 	    if (pick4u == 'y' || flags.descendant == ROLE_RANDOM || flags.randomall) {
-			flags.descendant = rn2(2);
+			flags.descendant = 0; // never randomly roll descendant
 	    } else {	/* pick4u == 'n' */
 		tty_clear_nhwindow(BASE_WINDOW);
 		tty_putstr(BASE_WINDOW, 0, "Choosing inheritance");


### PR DESCRIPTION
sflmable now chekcs body armor, so cglz works
tty can't random into descendant (curses already couldn't)

gwf now rerolls bottom 16%, 33%, 50% of rolls, not just 1/2/3 - so its not absolutely awful for larger weapons. I realized that like, oversized weapons have larger dice sizes, so this should _probably_ synergize better with them. Go figure. This will maxroll d2s, fun fact, but it probably did really bad things before this, since I didn't actually ever test that and I think it was doing n*3 + d(n, -1) or something stupid. Now it won't.