### PR TITLE
Fix some places where window slots could get leaked 

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -955,6 +955,7 @@ int how;			/* type of query */
 	    pack++;
 	    if (invlet >= 'u') {
 		impossible("query_category: too many categories");
+		destroy_nhwindow(win);
 		return 0;
 	    }
 	} while (*pack);

--- a/src/shk.c
+++ b/src/shk.c
@@ -6122,10 +6122,10 @@ int mat;
 		}
 		end_menu(tmpwin, "Items Available:");
 		n = select_menu(tmpwin, PICK_ONE, &selected);
+		destroy_nhwindow(tmpwin);
 		if(n <= 0){
 			return -1;
 		}
-		destroy_nhwindow(tmpwin);
 		int picked = selected[0].item.a_int;
 		free(selected);
 		return picked;
@@ -6216,10 +6216,10 @@ pickeladrin()
 	}
 	end_menu(tmpwin, "Followers Available:");
 	n = select_menu(tmpwin, PICK_ONE, &selected);
+	destroy_nhwindow(tmpwin);
 	if(n <= 0){
 		return -1;
 	}
-	destroy_nhwindow(tmpwin);
 	int picked = selected[0].item.a_int;
 	free(selected);
 	return picked;
@@ -6452,11 +6452,11 @@ struct monst *smith;
 	}
 	end_menu(tmpwin, sbuf);
 	n = select_menu(tmpwin, PICK_ONE, &selected);
+	destroy_nhwindow(tmpwin);
 	if(n <= 0){
 		pline("Never mind.");
 		return;
 	}
-	destroy_nhwindow(tmpwin);
 	int picked = selected[0].item.a_int;
 	free(selected);
 	switch(picked){
@@ -6735,11 +6735,11 @@ struct monst *smith;
 	}
 	end_menu(tmpwin, sbuf);
 	n = select_menu(tmpwin, PICK_ONE, &selected);
+	destroy_nhwindow(tmpwin);
 	if(n <= 0){
 		pline("Never mind.");
 		return;
 	}
-	destroy_nhwindow(tmpwin);
 	int picked = selected[0].item.a_int;
 	free(selected);
 	switch(picked){
@@ -6961,11 +6961,11 @@ int threshold;
 	}
 	end_menu(tmpwin, sbuf);
 	n = select_menu(tmpwin, PICK_ONE, &selected);
+	destroy_nhwindow(tmpwin);
 	if(n <= 0){
 		pline("Never mind.");
 		return;
 	}
-	destroy_nhwindow(tmpwin);
 	int picked = selected[0].item.a_int;
 	free(selected);
 	switch(picked){


### PR DESCRIPTION
Smith menus all needed to destroy_nhwindow before returning based on selected result. Also fixed a case where if an impossible occurred, an early return would happen without cleaning up the created window.
If too many window slots leak, the game panics when trying to create a window slot when the window slots are all occupied.