### PR TITLE
Allow specifying figurine/statue gender and show more info in dump

### DIFF
--- a/include/hack.h
+++ b/include/hack.h
@@ -221,6 +221,8 @@ NEARDATA extern coord bhitpos;	/* place where throw or zap hits or stops */
 #define MM_NOGROUP          0x0400    /* don't generate its normal accompanying groupmates */
 #define MM_BIGGROUP         0x0800    /* do generate its larger size of accompanying groupmates */
 #define MM_GOODEQUIP        0x1000    /* do generate its better equipment sets (planar equip for angels) */
+#define MM_MALE             0x2000    /* make monster male */
+#define MM_FEMALE           0x4000    /* make monster female */
 
 /* flags to control mksobj() et al */
 #define NO_MKOBJ_FLAGS	0x00	/* use this rather than plain 0 */

--- a/src/dog.c
+++ b/src/dog.c
@@ -107,6 +107,7 @@ boolean quietly;
 	struct permonst *pm;
 	struct monst *mtmp = 0;
 	int chance, trycnt = 100;
+	int mmflags = MM_EDOG|MM_IGNOREWATER;
 
 
 	do {
@@ -127,6 +128,12 @@ boolean quietly;
 					pline("... into a pile of dust.");
 				break;	/* mtmp is null */
 			}
+			if(otmp->spe&FIGURINE_MALE){
+				mmflags |= MM_MALE;
+			}
+			if(otmp->spe&FIGURINE_FEMALE){
+				mmflags |= MM_FEMALE;
+			}
 	    } else if (!rn2(3)) {
 			pm = &mons[pet_type()];
 	    } else {
@@ -140,7 +147,7 @@ boolean quietly;
 				continue;
 		}
 
-		mtmp = makemon(pm, x, y, MM_EDOG|MM_IGNOREWATER);
+		mtmp = makemon(pm, x, y, mmflags);
 		if (otmp && !mtmp) { /* monster was genocided or square occupied */
 			if (!quietly)
 			   pline_The("figurine writhes and then shatters into pieces!");
@@ -158,12 +165,6 @@ boolean quietly;
 	if (otmp) { /* figurine; resulting monster might not become a pet */
 		if(check_fig_template(otmp->spe, FIGURINE_PSEUDO)){
 			set_template(mtmp, PSEUDONATURAL);
-		}
-		if(otmp->spe&FIGURINE_MALE){
-			mtmp->female = FALSE;
-		}
-		if(otmp->spe&FIGURINE_FEMALE){
-			mtmp->female = TRUE;
 		}
 
 		if(otmp->spe&FIGURINE_LOYAL){

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -13571,8 +13571,8 @@ int faction;
 		}
 	}
 
-	if (is_female(ptr)) mtmp->female = TRUE;
-	else if (is_male(ptr)) mtmp->female = FALSE;
+	if (is_female(ptr) || ((mmflags & MM_FEMALE) && !(mmflags & MM_MALE))) mtmp->female = TRUE;
+	else if (is_male(ptr) || ((mmflags & MM_MALE) && !(mmflags & MM_FEMALE))) mtmp->female = FALSE;
 	else mtmp->female = rn2(2);	/* ignored for neuters */
 
 	// if (ptr->mtyp == urole.ldrnum)		/* leader knows about portal */

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3490,6 +3490,10 @@ const char *oldstr;
 			    !BSTRCMP(bp, p-5, "shoes") ||
 				!BSTRCMPI(bp, p-9, "vs curses") ||
 				!BSTRCMPI(bp, p-13, "versus curses") ||
+			    !BSTRCMPI(bp, p-12, "vs evil eyes") ||
+			    !BSTRCMPI(bp, p-16, "versus evil eyes") ||
+			    !BSTRCMPI(bp, p-8, "vs gazes") ||
+			    !BSTRCMPI(bp, p-12, "versus gazes") ||
 			    !BSTRCMPI(bp, p-6, "scales") ||
 				!BSTRCMP(bp, p-6, "wishes") ||	/* ring */
 				!BSTRCMPI(bp, p-10, "Lost Names") || /* book */
@@ -3672,8 +3676,12 @@ struct alt_spellings {
 	{ "mattock", DWARVISH_MATTOCK },
 	{ "amulet of poison resistance", AMULET_VERSUS_POISON },
 	{ "amulet of curse resistance", AMULET_VERSUS_CURSES },
+	{ "amulet of gaze resistance", AMULET_VERSUS_EVIL_EYES },
 	{ "amulet vs poison", AMULET_VERSUS_POISON },
 	{ "amulet vs curses", AMULET_VERSUS_CURSES },
+	{ "amulet vs evil eyes", AMULET_VERSUS_EVIL_EYES },
+	{ "amulet vs gazes", AMULET_VERSUS_EVIL_EYES },
+	{ "amulet versus gazes", AMULET_VERSUS_EVIL_EYES },
 	{ "stone", ROCK },
 	{ "crystal", ROCK },
 #ifdef TOURIST
@@ -3838,7 +3846,9 @@ int wishflags;
 		lolth_symbol = FALSE,
 		kiaransali_symbol = FALSE,
 		eilistraee_symbol = FALSE,
-		sizewished = FALSE;
+		sizewished = FALSE,
+		male = FALSE,
+		female = FALSE;
 	int item_color = -1;
 	int objsize = (from_user ? youracedata->msize : MZ_MEDIUM);
 	long bodytype = 0L;
@@ -4583,6 +4593,10 @@ int wishflags;
 			mat = GEMSTONE; gemtype = AGATE;
 		} else if (!strncmpi(bp, "jade ", l=5) && strncmpi(bp, "jade ring", 9)) {
 			mat = GEMSTONE; gemtype = JADE;
+		} else if (!strncmpi(bp, "male ", l=5)) {
+			male = TRUE;
+		} else if (!strncmpi(bp, "female ", l=7)) {
+			female = TRUE;
 		} else
 			break;
 		bp += l;
@@ -5529,6 +5543,10 @@ typfnd:
 		case FIGURINE:
 			//if (!(mons[mntmp].geno & G_UNIQ) && !is_unwishable(&mons[mntmp]))
 			otmp->corpsenm = mntmp;
+			if (male && !female)
+				otmp->spe = FIGURINE_MALE;
+			if (female && !male)
+				otmp->spe = FIGURINE_FEMALE;
 			break;
 		case EGG:
 			mntmp = can_be_hatched(mntmp);
@@ -5549,6 +5567,10 @@ typfnd:
 			if (Has_contents(otmp) && verysmall(&mons[mntmp]))
 			    delete_contents(otmp);	/* no spellbook */
 			otmp->spe = ishistoric ? STATUE_HISTORIC : 0;
+			if (male && !female)
+				otmp->spe |= STATUE_MALE;
+			if (female && !male)
+				otmp->spe |= STATUE_FEMALE;			
 			break;
 		case FOSSIL:
 			if(wizwish)

--- a/src/read.c
+++ b/src/read.c
@@ -3630,13 +3630,13 @@ char *in_buff;
 	struct permonst *whichpm;
 	struct monst *mtmp = (struct monst *)0;
 	boolean madeany = FALSE;
-	boolean maketame, makeloyal, makepeaceful, makehostile, makesummoned;
+	boolean maketame, makeloyal, makepeaceful, makehostile, makesummoned, makemale, makefemale;
 	int l = 0;
 
 	tries = 0;
 	do {
 	    which = urole.malenum;	/* an arbitrary index into mons[] */
-	    maketame = makeloyal = makepeaceful = makehostile = makesummoned = FALSE;
+	    maketame = makeloyal = makepeaceful = makehostile = makesummoned = makemale = makefemale = FALSE;
 		if(in_buff){
 			Sprintf(buf, "%s", in_buff);
 		}
@@ -3729,6 +3729,12 @@ char *in_buff;
 			}
 			else if (!strncmpi(bufp, "noequip ", l = 8)) {
 				noequip = TRUE;
+			}
+			else if (!strncmpi(bufp, "male ", l = 5)) {
+				makemale = TRUE;
+			}
+			else if (!strncmpi(bufp, "female ", l = 7)) {
+				makefemale = TRUE;
 			}
 			else
 				break;
@@ -3908,6 +3914,10 @@ createmon:
 				mm_flags |= MM_ESUM;
 			if (noequip)
 				mm_flags |= NO_MINVENT;
+			if (makemale)
+				mm_flags |= MM_MALE;
+			if (makefemale)
+				mm_flags |= MM_FEMALE;
 
 			mtmp = makemon_full(whichpm, x, y, mm_flags, undeadtype ? undeadtype : -1, -1);
 


### PR DESCRIPTION
Statue/figurine gender changes:
-You can now specify the gender of figurines/statues in wishes, as
 well as the gender of pets summoned with candles of invocation.
--"male/female figurine/statue of an X" and
  "male/female X statue/figurine" both work, but
  "statue/figurine of a male/female X" does not
---NetHack 3.7 fixes this but its wish parser differs so I can't just
   copy from it.  3.7 also supports specifying gender of corpses but
   I don't know if dNetHack even stores that, and, if so, where.
-There are now MM_MALE/MM_FEMALE makemon flags.  These are required
 for gendered figurines to have the same starting inventory:
 previously gender was set after makemon so they would have the wrong
 starting inventory, but this wasn't an issue in practice because they
 were unobtainable outside of wizmode.  This isn't an issue for
 statues because they don't get starting inventory.

More info in enlightenment and end-of-game dump:
-uacinc is now shown, and exact uacinc and protection are always
 shown: the player always knows their own AC/DR so there is no reason
 to hide them.
--Study is also always shown for the same reason.
-Madnesses are now always shown in the end-of-game dump, even if you
 had clear thoughts or 100 sanity.
-Old wizmode spirit count is removed.  It's redundant. -Inherited artifact is shown in end-of-game dump.
-Information that was previously wizmode-only is shown in end-of-game
 dump.  There's no reason to hide information in the end-of-game dump.
--Exact alignment record, alignment max, sins, various keter counts,
  quest stag/leader backstab status.
---Should this even be restricted to wizmode/final only?

Other changes:
-Wishing for "amulet versus evil eyes" now works, along with several
 alternate spellings.