### PR TITLE
First Binder/strange corpse encyclopedia entries

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -2143,6 +2143,32 @@ dagon
 	translucent.
 		[ Hordes of the Abyss,
 			by Ed Stark, James Jacobs, and Erik Mona ]
+dahlver-nar
+strange corpse
+	[...] Binder scholars know a different story—that Dahlver-Nar
+	was a powerful cleric who forsook his deity to pursue the power 
+	of pact magic. The fabled teeth of Dahlver-Nar, to which all 
+	the legends attribute miraculous powers, were neither his own nor
+	those of the dragon he battled. They were the teeth of beings 
+	that became vestiges after death, and they could grant abilities 
+	similar to those that the vestiges themselves imparted. Pact magic
+	treatises relate that Dahlver-Nar pulled out his own teeth and
+	replaced them with those of the vestiges, but that using them all 
+	drove him mad. What happened thereafter is a matter of debate, but 
+	the texts maintain that Dahlver-Nar eventually died, and the teeth 
+	were lost, divided up among the squabbling followers he had managed
+	to gain and then spread across the world. Today, Dahlver-Nar exists
+	as a vestige in his own right—perhaps brought to that state through
+	his close association with so many others.
+		[ Tome of Magic,
+			by Matthew Sernett et al. ]
+
+	Thirty-two horses on a red hill,
+	First they champ,
+	Then they stamp,
+	Then they stand still.    
+		[ Adapted from the Hobbit,
+			by J. R. R. Tolkien ]
 damned pirate
 	These memories were bought with the lives of good men
 	A price that I paid without scruple


### PR DESCRIPTION
Was gonna update the strange corpse wiki entry using the gist, article notes that it doesn't have an entry but the spirit does, search data.base and find neither - fixing that posthaste.