### PR TITLE
Put kamerel vajra unlit form dice back in line with small mace dice after mace buff

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -925,7 +925,7 @@ struct monst *magr;
 		else {
 			/* equivalent to small mace */
 			ocn = 1;
-			ocd = 4;
+			ocd = 8;
 			flat = (large ? 0 : 1);
 		}
 	}


### PR DESCRIPTION
Was d4+1/d4 which is what a small mace used to do, but now a small mace does d8+1/d8, so make it do that.