### PR TITLE
Fix handling for two weaponing with some weapons that it should have been allowed for, but wasn't, because they are edge cases

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -726,6 +726,11 @@ struct obj {
 #define is_launcher(otmp)	(otmp->oclass == WEAPON_CLASS && \
 			 ((objects[otmp->otyp].oc_skill >= P_BOW && \
 			 objects[otmp->otyp].oc_skill <= P_CROSSBOW) || otmp->otyp == ATLATL))
+#define is_melee_launcher(otmp)	(otmp->otyp == CARCOSAN_STING || \
+				otmp->oartifact == ART_LIECLEAVER || \
+				otmp->oartifact == ART_ROGUE_GEAR_SPIRITS  || \
+				check_oprop(otmp, OPROP_BLADED) || \
+				check_oprop(otmp, OPROP_SPIKED))
 #define is_ammo(otmp)	((otmp->oclass == WEAPON_CLASS || \
 			 otmp->oclass == GEM_CLASS) && \
 			 ((objects[otmp->otyp].oc_skill >= -P_CROSSBOW && \

--- a/src/wield.c
+++ b/src/wield.c
@@ -536,7 +536,7 @@ const char *verb;	/* "rub",&c */
 }
 
 /*Contains those parts of can_twoweapon() that DON'T change the game state.  Can be called anywhere the code needs to know if the player is capable of wielding two weapons*/
-#define NOT_WEAPON(obj) (obj && !is_weptool(obj) && obj->oclass != WEAPON_CLASS)
+#define NOT_WEAPON(obj) (obj && !is_weptool(obj) && obj->oclass != WEAPON_CLASS && obj->otyp != STILETTOS && obj->otyp != WIND_AND_FIRE_WHEELS && obj->oartifact != ART_WAND_OF_ORCUS)
 int
 test_twoweapon()
 {
@@ -560,7 +560,7 @@ test_twoweapon()
 			body_part(HAND), (!uwep && !uswapwep) ? "s are" : " is");
 	}
 	/* Objects must not be non-weapons */
-	else if ((NOT_WEAPON(uwep) || NOT_WEAPON(uswapwep)) && !(uwep && (uwep->otyp == STILETTOS || uwep->otyp == WIND_AND_FIRE_WHEELS))) {
+	else if ((NOT_WEAPON(uwep) || NOT_WEAPON(uswapwep))) {
 		otmp = NOT_WEAPON(uwep) ? uwep : uswapwep;
 		pline("%s %s.", Yname2(otmp),
 		    is_plural(otmp) ? "aren't weapons" : "isn't a weapon");
@@ -580,8 +580,8 @@ test_twoweapon()
 	}
 	/* not a launcher (guns and blasters are ok) */
 	else if (
-		(uwep && is_launcher(uwep) && !is_firearm(uwep)) ||
-		(uswapwep && is_launcher(uswapwep) && !is_firearm(uswapwep)))
+		(uwep && is_launcher(uwep) && !is_firearm(uwep) && !is_melee_launcher(uwep)) ||
+		(uswapwep && is_launcher(uswapwep) && !is_firearm(uswapwep) && !is_melee_launcher(uswapwep)))
 	{
 		You_cant("fight two-handed with this.");
 	}

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -13256,11 +13256,7 @@ int vis;						/* True if action is at all visible to the player */
 			(!attk || weapon_aatyp(attk->aatyp)) &&
 			/* isn't a misused launcher */
 			(!is_launcher(weapon) ||
-			check_oprop(weapon, OPROP_BLADED) ||
-			check_oprop(weapon, OPROP_SPIKED) ||
-			weapon->oartifact == ART_LIECLEAVER ||
-			weapon->oartifact == ART_ROGUE_GEAR_SPIRITS ||
-			weapon->otyp == CARCOSAN_STING
+			is_melee_launcher(weapon)
 			) &&
 			/* isn't a misused polearm */
 			(!is_bad_melee_pole(weapon) ||


### PR DESCRIPTION
Allow two weaponing with valid melee launchers and define a macro for this. This includes carcosan stings, Liecleaver, Rogue Gear-Spirits, and any bladed or spiked launchers. Move the special handling for trying to two weapon stiletto shoe weapons or wheels of wind and fire into the NOT_WEAPON check, and also allow the wand of orcus to be a valid weapon for two weaponing purposes.