### PR TITLE
Add engulf/grab attacks to avoidable attacks

### DIFF
--- a/include/you.h
+++ b/include/you.h
@@ -328,8 +328,10 @@ struct you {
 #define FFORM_LISTSIZE	(LAST_FFORM/32 + 1)
 	unsigned long int fightingForm[FFORM_LISTSIZE];/* special properties */
 	int ueldritch_style;
-	boolean uavoid_passives;
-	boolean uavoid_msplcast;
+	Bitfield(uavoid_passives,1);
+	Bitfield(uavoid_msplcast,1);
+	Bitfield(uavoid_grabattk,1);
+	Bitfield(uavoid_englattk,1);
 	int umystic;	/*Monk mystic attacks active*/
 #define monk_style_active(style) (u.umystic & (1 << (style-1)))
 #define toggle_monk_style(style) (u.umystic  = u.umystic ^ (1 << (style-1)))

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -5288,7 +5288,7 @@ boolean printmessages; /* print generic elemental damage messages */
 	/* The Grappler's Grasp has a chance to begin grapples.  */
 	if (oartifact == ART_GRAPPLER_S_GRASP || (otmp->otyp == IMPERIAL_ELVEN_GAUNTLETS && check_imp_mod(otmp, IEA_STRANGLE))) {
 		/* check if we can begin a grapple -- Damage is done by adding an AT_HUGS to your attack chain, NOT here. */
-		if ((youagr || youdef) && !u.ustuck && !sticks(mdef))
+		if ((youagr || youdef) && !u.ustuck && !sticks(mdef) && !(youagr && u.uavoid_grabattk))
 		{
 			int newres = xmeleehurty(magr, mdef, &grapple, &grapple, &otmp, (youagr || youdef), 0, dieroll, -1, FALSE);
 

--- a/src/enlighten.c
+++ b/src/enlighten.c
@@ -100,7 +100,8 @@ char *outbuf;
 	bonus = (incamt > 0) ? "bonus" : "penalty";
 	/* "bonus to hit" vs "damage bonus" */
 	if (!strcmp(inctyp, "damage") || !strcmp(inctyp, "spell damage") ||
-	    !strcmp(inctyp, "AC") || !strcmp(inctyp, "protection")) {
+	    !strcmp(inctyp, "AC") || !strcmp(inctyp, "protection") ||
+		!strcmp(inctyp, "morale")) {
 	    const char *ctmp = inctyp;
 	    inctyp = bonus;
 	    bonus = ctmp;
@@ -461,6 +462,8 @@ boolean dumping;
 		Sprintf(buf, "%d weakness from being studied", u.ustdy);
 		you_have(buf);
 	}
+	
+	if(u.uencouraged) you_have(enlght_combatinc("morale", u.uencouraged, 1, buf));
 	
 	if(u.sealsActive || u.specialSealsActive){
 		int i,j,numBound,numFound=0;

--- a/src/pline.c
+++ b/src/pline.c
@@ -559,7 +559,10 @@ register struct monst *mtmp;
 
 	info[0] = 0;
 	//This comes up often enough for debug that it's worth it.
-	if (mtmp->female && !is_neuter(mtmp->data)) Strcat(info, ", female");
+	if (!is_neuter(mtmp->data)) {
+		if (mtmp->female) Strcat(info, ", female");
+		else Strcat(info, ", male");
+	}
 	if (mtmp->mtame) {	  Strcat(info, ", tame");
 #ifdef WIZARD
 	    if (wizard) {

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -1679,6 +1679,8 @@ u_init()
 
 	u.uavoid_passives = 0; // don't start out using only starblades lol
 	u.uavoid_msplcast = 0; // by default, allow mspellcasting
+	u.uavoid_grabattk = 0; // by default, allow grabbing attacks
+	u.uavoid_englattk = 0; // by default, allow engulfing attacks
 	u.umystic = ~0; //By default, all monk style attacks are active
 
 	u.summonMonster = FALSE;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -920,6 +920,9 @@ int tary;
 			/* ahazu protects the player from engulfing */
 			if (youdef && u.sealsActive&SEAL_AHAZU)
 				continue;
+			/* the player can out out of making engulf attacks */
+			if (youagr && u.uavoid_englattk)
+				continue;
 			/* check for wild misses */
 			if (missedyou) {
 				wildmiss(magr, attk, otmp, ranged);
@@ -4526,10 +4529,7 @@ boolean ranged;
 		&& attk->adtyp != AD_WRAP)
 	{
 		/* are grabs possible? */
-		if (!(youagr || youdef)
-			|| sticks(mdef)
-			)
-		{
+		if (!(youagr || youdef) || sticks(mdef) || (youagr && u.uavoid_grabattk)){
 			/* no grabs allowed, substitute basic claw attack */
 			alt_attk.aatyp = AT_CLAW;
 			return xmeleehurty(magr, mdef, &alt_attk, &alt_attk, weapon_p, dohitmsg, dmg, dieroll, vis, ranged);
@@ -5359,7 +5359,8 @@ boolean ranged;
 			&& !(result & MM_AGR_DIED)
 			&& (youagr || youdef)					/* the player must be involved in a sticking situation (gameplay limitation) */
 			&& !u.ustuck							/* can't already be stuck */
-			&& !(sticks(magr) && sticks(mdef)))		/* creatures can't grab other grabbers (gameplay limitation)  */
+			&& !(sticks(magr) && sticks(mdef))		/* creatures can't grab other grabbers (gameplay limitation)  */
+			&& !(youagr && u.uavoid_grabattk))		/* the player can opt out of grabbing monsters */
 		{
 			if (pa->mtyp == PM_TOVE)
 				pline("%s %s much too slithy to stick to %s!",
@@ -6703,7 +6704,8 @@ boolean ranged;
 		if ((youagr || youdef)					/* the player must be involved in a sticking situation (gameplay limitation) */
 			&& !u.ustuck						/* can't already be stuck */
 			&& !(sticks(magr) && sticks(mdef))	/* grabbers can't grab other grabbers (gameplay limitation)  */
-			){
+			&& !(youagr && u.uavoid_grabattk)	/* the player can opt out of grabbing monsters */
+		){
 			if (pd->mtyp == PM_TOVE)
 			{
 				/* note: assumes player is either agr or def, vis is true */
@@ -8262,8 +8264,7 @@ boolean ranged;
 		 * If the player isn't involved,
 		 * or if either creature could be the one doing the grabbing,
 		 * substitute simple physical damage */
-		if (!(youagr || youdef)
-			|| (sticks(mdef))){
+		if (!(youagr || youdef) || (sticks(mdef)) || (youagr && u.uavoid_grabattk)){
 			/* make physical attack */
 			alt_attk.adtyp = AD_PHYS;
 			return xmeleehurty(magr, mdef, &alt_attk, originalattk, weapon_p, dohitmsg, dmg, dieroll, vis, ranged);
@@ -8791,7 +8792,7 @@ boolean ranged;
 		}
 		else if(youagr){
 			if(u.ustuck != mdef ){
-				if(!sticks(mdef)){
+				if(!sticks(mdef) && !(youagr && u.uavoid_grabattk)){
 					pline("You begin to ooze around %s!", mon_nam(mdef));
 					u.ustuck = magr;
 				}


### PR DESCRIPTION
Similarly to passives/mspells, only shown if you have a grab attack (in current attack chain or wearing grappler's grasp) or an engulf attack (only attack chain). Engulf attacks are easy to avoid, grabs less so.

Normal grab attacks fall back to the case as if the target was also a grabber, which for old nethack sanity code assumes can't be grappled (I guess to avoid you getting stuck to somebody stuck to you. Fair enough, that's ugly). This does have slightly different behaviors in different places - for things like hug attacks, this falls back to a physical damage thing. For something like AD_LAVA, it just fails the grapple check mostly silently. There is unfortunately no exhaustive list of "everytime you try to grab something", but I think I got everything in xhity + artifact.c - there might be stragglers though, unfortunately.

Also fixes the incidental bug of #style options not showing up in #ability unless you have a lightsaber - now, the hasfightingforms function exists to check the form status and properly pass that on to the appropriate place. Also tones down the way it's checked - it's a little bitmask now instead of a bunch of ugly booleans. Works better too.

Thanks to Noisy for some of this code, and for pointing out that the boolean uavoid_x can be made into bitfields - I didn't realize that option was enabled, I thought that was only on like weird compiler setups or something

Second commit is much more minor - morale is shown in enlightenment & male gender by stethoscope. Fixes by noisy.