### PR TITLE
Allow Rogue-Gear Spirits to fire oversized crossbow bolts

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -740,7 +740,7 @@ struct obj {
 			   (ltmp->otyp == MASS_SHADOW_PISTOL && ltmp->cobj && (otmp->otyp == ltmp->cobj->otyp)) ||\
 			   (ltmp->otyp == ATLATL && is_spear(otmp)) ||\
 			   (\
-			    (otmp->objsize == (ltmp)->objsize || objects[(ltmp)->otyp].oc_skill == P_SLING) &&\
+			    (otmp->objsize == (ltmp)->objsize || objects[(ltmp)->otyp].oc_skill == P_SLING || (ltmp)->oartifact == ART_ROGUE_GEAR_SPIRITS) &&\
 			    (objects[(otmp)->otyp].w_ammotyp & objects[(ltmp)->otyp].w_ammotyp) && \
 			    (objects[(otmp)->otyp].oc_skill == -objects[(ltmp)->otyp].oc_skill)\
 			   )\


### PR DESCRIPTION
It doubles as a ballista now because... it's cool. And it's also ungodly annoying that you can't fire normal bolts from it, only small bolts, so you have to collect them from your kinsmen I think.