### PR TITLE
Fix fuzz crashes - losing knight skills and eating magic whistles

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -941,18 +941,15 @@ int oldlevel, newlevel;
 			lose_weapon_skill(skillslots);
 		}
 	}
-	int message = 0;
-	if ((oldlevel >= 14 && newlevel < 14) || (newlevel >= 14 && oldlevel < 14)){
+	boolean message = FALSE;
+	if (newlevel >= 14 && oldlevel < 14){
 		for (int i = 0; i < P_NUM_SKILLS; i++) {
 			if (roleSkill(i)){
-				message = oldlevel - newlevel;
-				if (oldlevel > newlevel) restrict_weapon_skill(i);
-				else expert_weapon_skill(i);
+				message = TRUE;
+				expert_weapon_skill(i);
 			}
 	    }
-		if (message != 0){
-			You_feel("your skills %s!", (message > 0) ? "slipping away" : "increasing");
-		}
+		if (message) You_feel("like you've unlocked new potential!");
 	}
 }
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -2932,7 +2932,7 @@ doeat()		/* generic "eat" command funtion (see cmd.c) */
 			case TOOL_CLASS:
 				u.uconduct.food++;
 				if (otmp->otyp == MAGIC_WHISTLE){
-					poly_obj(otmp, WHISTLE);
+					otmp = poly_obj(otmp, WHISTLE);
 					You("drain the %s of its magic.", xname(otmp));
 				} else {
 					curspe = otmp->spe;


### PR DESCRIPTION
The knight skills are no longer removed on dropping back below xp14 - I definitely didn't think that through very well, and it does bad things with lose_weapon_skill.

Incantifiers eating magic whistles no longer tries to eat a freed object.