### PR TITLE
3.4.4 H2162 - topten handling of long names

### DIFF
--- a/src/topten.c
+++ b/src/topten.c
@@ -909,10 +909,15 @@ boolean so;
 		    !(*bp == ' ' && (bp-linebuf < hppos));
 		    bp--)
 		;
+	    /* special case: word is too long, wrap in the middle */
+	    if (linebuf+15 >= bp) bp = linebuf + hppos - 1;
 	    /* special case: if about to wrap in the middle of maximum
 	       dungeon depth reached, wrap in front of it instead */
 	    if (bp > linebuf + 5 && !strncmp(bp - 5, " [max", 5)) bp -= 5;
-	    Strcpy(linebuf3, bp+1);
+	    if (*bp != ' ')
+		Strcpy(linebuf3, bp);
+	    else
+		Strcpy(linebuf3, bp+1);
 	    *bp = 0;
 	    if (so) {
 		while (bp < linebuf + (COLNO-1)) *bp++ = ' ';


### PR DESCRIPTION
Take upstream patch for being killed by a monster with a long name can result in nethack going into an infinte loop printing spaces.  Handle this by detecting attempts to wrap the topten output on a word that is too long and just inserting breaks in the middle of the word in this case.

This lead to a 15 GB dumplog today and K2 wants this fixed.