### PR TITLE
Implement handling of generic AD type clouds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,11 +2,11 @@ GAMEDIR = dnethackdir
 
 # gprof flags
 # CFLAGS = -pg
-CFLAGS = -g3 -fsanitize=address
+CFLAGS = -g
 
 # gprof flags
 # LDFLAGS += -pg -Wno-knr-promoted-parameter
-LDFLAGS += -Wno-knr-promoted-parameter -fsanitize=address
+LDFLAGS += -Wno-knr-promoted-parameter
 
 GAMELIBS = -lncurses -lm
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,11 +2,11 @@ GAMEDIR = dnethackdir
 
 # gprof flags
 # CFLAGS = -pg
-CFLAGS = -g
+CFLAGS = -g3 -fsanitize=address
 
 # gprof flags
 # LDFLAGS += -pg -Wno-knr-promoted-parameter
-LDFLAGS += -Wno-knr-promoted-parameter
+LDFLAGS += -Wno-knr-promoted-parameter -fsanitize=address
 
 GAMELIBS = -lncurses -lm
 

--- a/include/display.h
+++ b/include/display.h
@@ -307,6 +307,8 @@
  *		The beam type is shifted over 2 positions and the direction
  *		is stored in the lower 2 bits.	Count: NUM_ZAP << 2
  *
+ * cloud	A unqiue cloud type
+ *
  * swallow	A set of eight for each monster.  The eight positions rep-
  *		resent those surrounding the hero.  The monster number is
  *		shifted over 3 positions and the swallow position is stored
@@ -317,6 +319,7 @@
  * The following are offsets used to convert to and from a glyph.
  */
 #define NUM_ZAP CLR_MAX	/* number of zap beam types */
+#define NUM_CLOUDS NUM_AD_TYPES	/* number of cloud display types */
 
 #define GLYPH_MON_OFF		0
 #define GLYPH_PET_OFF		(NUMMONS	+ GLYPH_MON_OFF)
@@ -330,7 +333,8 @@
 #define GLYPH_CMAP_OFF		((NUM_OBJECTS << 4)	+ GLYPH_OBJ_OFF)
 #define GLYPH_EXPLODE_OFF	((MAXPCHARS - MAXEXPCHARS) + GLYPH_CMAP_OFF)
 #define GLYPH_ZAP_OFF		((MAXEXPCHARS * EXPL_MAX) + GLYPH_EXPLODE_OFF)
-#define GLYPH_SWALLOW_OFF	((NUM_ZAP << 2) + GLYPH_ZAP_OFF)
+#define GLYPH_CLOUD_OFF		((NUM_ZAP << 2) + GLYPH_ZAP_OFF)
+#define GLYPH_SWALLOW_OFF	((NUM_CLOUDS) + GLYPH_CLOUD_OFF)
 #define GLYPH_WARNING_OFF	((NUMMONS << 3) + GLYPH_SWALLOW_OFF)
 #define MAX_GLYPH		(WARNCOUNT      + GLYPH_WARNING_OFF)
 
@@ -339,6 +343,7 @@
 #define GLYPH_INVISIBLE GLYPH_INVIS_OFF
 
 #define warning_to_glyph(mwarnlev) ((mwarnlev)+GLYPH_WARNING_OFF)
+#define cloud_to_glyph(adtyp) ((adtyp)+GLYPH_CLOUD_OFF)
 #define mon_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_MON_OFF)
 #define detected_mon_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_DETECT_OFF)
 #define ridden_mon_to_glyph(mon) ((int) what_mon((mon)->mtyp, mon)+GLYPH_RIDDEN_OFF)
@@ -401,6 +406,9 @@
 #define glyph_to_cmap(glyph)						\
 	(glyph_is_cmap(glyph) ? ((glyph) - GLYPH_CMAP_OFF) :		\
 	NO_GLYPH)
+#define glyph_to_cloud_type(glyph)						\
+	(glyph_is_cloud(glyph) ? (((glyph) - GLYPH_CLOUD_OFF)) : \
+	0)
 #define glyph_to_swallow(glyph)						\
 	(glyph_is_swallow(glyph) ? (((glyph) - GLYPH_SWALLOW_OFF) & 0x7) : \
 	0)
@@ -444,6 +452,8 @@
      (glyph) <	(GLYPH_CMAP_OFF+trap_to_defsym(1)+TRAPNUM))
 #define glyph_is_cmap(glyph)						\
     ((glyph) >= GLYPH_CMAP_OFF && (glyph) < (GLYPH_CMAP_OFF+MAXPCHARS))
+#define glyph_is_cloud(glyph)	\
+    ((glyph) >= GLYPH_CLOUD_OFF && (glyph) < (GLYPH_CLOUD_OFF + NUM_CLOUDS))
 #define glyph_is_swallow(glyph) \
     ((glyph) >= GLYPH_SWALLOW_OFF && (glyph) < (GLYPH_SWALLOW_OFF+(NUMMONS << 3)))
 #define glyph_is_warning(glyph)	\

--- a/include/extern.h
+++ b/include/extern.h
@@ -3432,6 +3432,7 @@ E int FDECL(xmeleehurty, (struct monst *, struct monst *, struct attack *, struc
 E void FDECL(getgazeinfo, (int, int, struct permonst *, struct monst *, struct monst *, boolean *, boolean *, boolean *));
 E int FDECL(xgazey, (struct monst *, struct monst *, struct attack *, int));
 E int FDECL(xengulfhity, (struct monst *, struct monst *, struct attack *, int));
+E int FDECL(xengulfhurty, (struct monst *, struct monst *, struct attack *, int));
 E void FDECL(passive_obj2, (struct monst *, struct monst *, struct obj *, struct attack *, struct attack *));
 E void FDECL(breakobj, (struct obj *, XCHAR_P, XCHAR_P, BOOLEAN_P, BOOLEAN_P));
 E int FDECL(hmon_with_unowned_obj, (struct monst *, struct obj **, int));

--- a/include/extern.h
+++ b/include/extern.h
@@ -2534,6 +2534,7 @@ E NhRegion *FDECL(visible_region_at, (XCHAR_P,XCHAR_P));
 E void FDECL(show_region, (NhRegion*, XCHAR_P, XCHAR_P));
 E void FDECL(save_regions, (int,int));
 E void FDECL(rest_regions, (int,BOOLEAN_P));
+E NhRegion* FDECL(create_generic_cloud, (XCHAR_P, XCHAR_P, int, struct region_arg *, boolean));
 E NhRegion* FDECL(create_gas_cloud, (XCHAR_P, XCHAR_P, int, int, boolean));
 E NhRegion* FDECL(create_fog_cloud, (XCHAR_P, XCHAR_P, int, int, boolean));
 E NhRegion* FDECL(create_dust_cloud, (XCHAR_P, XCHAR_P, int, int));

--- a/include/monattk.h
+++ b/include/monattk.h
@@ -264,6 +264,8 @@
 #define AD_CURS		AD_CLRC+6	/* random curse (ex. gremlin) */
 #define AD_SQUE		AD_CLRC+7	/* hits, may steal Quest Art or Amulet (Nemeses) */
 
+#define NUM_AD_TYPES AD_SQUE+1
+
 #define real_spell_adtyp(adtyp) \
 	((adtyp) == AD_SPEL || (adtyp) == AD_CLRC || (adtyp) == AD_PSON)
 

--- a/include/region.h
+++ b/include/region.h
@@ -30,6 +30,11 @@ typedef boolean FDECL((*callback_proc), (genericptr_t, genericptr_t));
 #define set_heros_fault(r)	((r)->player_flags &= ~REG_NOT_HEROS)
 #define clear_heros_fault(r)	((r)->player_flags |= REG_NOT_HEROS)
 
+struct region_arg {
+	int damage;
+	uchar adtyp;	
+};
+
 typedef struct {
   NhRect bounding_box;		/* Bounding box of the region */
   NhRect *rects;		/* Rectangles composing the region */
@@ -61,7 +66,7 @@ typedef struct {
 
   boolean visible;		/* Is the region visible ? */
   int glyph;			/* Which glyph to use if visible */
-  genericptr_t arg;		/* Optional user argument (Ex: strength of
+  struct region_arg arg;		/* Optional user argument (Ex: strength of
 				   force field, damage of a fire zone, ...*/
 } NhRegion;
 

--- a/src/display.c
+++ b/src/display.c
@@ -1458,6 +1458,8 @@ show_glyph(x,y,glyph)
 	    text = "warning";		offset = glyph - GLYPH_WARNING_OFF;
 	} else if (glyph >= GLYPH_SWALLOW_OFF) {	/* swallow border */
 	    text = "swallow border";	offset = glyph - GLYPH_SWALLOW_OFF;
+	} else if (glyph >= GLYPH_CLOUD_OFF) {		/* cloud */
+	    text = "cloud";		offset = glyph - GLYPH_CLOUD_OFF;
 	} else if (glyph >= GLYPH_ZAP_OFF) {		/* zap beam */
 	    text = "zap beam";		offset = glyph - GLYPH_ZAP_OFF;
 	} else if (glyph >= GLYPH_EXPLODE_OFF) {	/* explosion */
@@ -1622,6 +1624,8 @@ int glyph;
     } else if ((offset = (glyph - GLYPH_SWALLOW_OFF)) >= 0) {	/* swallow */
 	/* see swallow_to_glyph() in display.c */
 	ch = (uchar) defsyms[S_sw_tl + (offset & 0x7)].sym;
+    } else if ((offset = (glyph - GLYPH_ZAP_OFF)) >= 0) {	/* cloud */
+	ch = defsyms[S_cloud].sym;
     } else if ((offset = (glyph - GLYPH_ZAP_OFF)) >= 0) {	/* zap beam */
 	/* see zapdir_to_glyph() in display.c */
 	ch = defsyms[S_vbeam + (offset & 0x3)].sym;

--- a/src/mapglyph.c
+++ b/src/mapglyph.c
@@ -142,6 +142,15 @@ unsigned int *obgcolor;
 	else
 #endif
 	    mon_color(offset >> 3);
+    } else if ((offset = (glyph - GLYPH_CLOUD_OFF)) >= 0) {	/* zap beam */
+	/* see zapdir_to_glyph() in display.c */
+	ch = showsyms[S_cloud];
+#ifdef ROGUE_COLOR
+	if (HAS_ROGUE_IBM_GRAPHICS && iflags.use_color)
+	    color = NO_COLOR;
+	else
+#endif
+	color = iflags.use_color ? zap_glyph_color(offset) : NO_COLOR;
     } else if ((offset = (glyph - GLYPH_ZAP_OFF)) >= 0) {	/* zap beam */
 	/* see zapdir_to_glyph() in display.c */
 	ch = showsyms[S_vbeam + (offset & 0x3)];

--- a/src/pager.c
+++ b/src/pager.c
@@ -736,8 +736,9 @@ lookat(x, y, buf, monbuf, shapebuff)
 			Sprintf(shapebuff, "%s%s%s", an(sizeStr[rn2(SIZE(sizeStr))]), headStr[rn2(SIZE(headStr))], bodyStr[rn2(SIZE(bodyStr))]);
 		}
 	}
-    }
-    else if (glyph_is_object(glyph)) {
+    } else if glyph_is_cloud(glyph) {
+	Sprintf(buf, "%s cloud", get_description_of_damage_type(glyph_to_cloud_type(glyph)));
+    } else if (glyph_is_object(glyph)) {
 	struct obj *otmp = 0;
 	boolean fakeobj = object_from_map(glyph, x, y, &otmp);
 
@@ -1477,6 +1478,8 @@ do_look(quick)
 	    } else if (glyph_is_monster(glyph)) {
 		/* takes care of pets, detected, ridden, and regular mons */
 		sym = monsyms[(int)mons[glyph_to_mon(glyph)].mlet];
+	    } else if (glyph_is_cloud(glyph)) {
+		sym = showsyms[S_cloud];
 	    } else if (glyph_is_swallow(glyph)) {
 		sym = showsyms[glyph_to_swallow(glyph)+S_sw_tl];
 	    } else if (glyph_is_invisible(glyph)) {

--- a/src/read.c
+++ b/src/read.c
@@ -24,6 +24,7 @@ boolean	known;
 static NEARDATA const char readable[] =
 		   { ALL_CLASSES, SCROLL_CLASS, TILE_CLASS, SPBOOK_CLASS, 0 };
 static const char all_count[] = { ALLOW_COUNT, ALL_CLASSES, 0 };
+static const int random_cloud_types[] = { AD_FIRE, AD_COLD, AD_ELEC, AD_ACID};
 
 static void FDECL(wand_explode, (struct obj *));
 static void NDECL(do_class_genocide);
@@ -2793,7 +2794,14 @@ struct obj	*sobj;
 		    You("smell rotten eggs.");
 		    return 0;
 		}
-		(void) create_gas_cloud(cc.x, cc.y, 3+bcsign(sobj), 8+4*bcsign(sobj), TRUE);
+		if(confused){
+			struct region_arg cloud_data;
+			cloud_data.damage = 8+4*bcsign(sobj);
+			cloud_data.adtyp = random_cloud_types[rn2(SIZE(random_cloud_types))];
+			(void) create_generic_cloud(cc.x, cc.y, 3+bcsign(sobj), &cloud_data, TRUE);
+		} else {
+			(void) create_gas_cloud(cc.x, cc.y, 3+bcsign(sobj), 8+4*bcsign(sobj), TRUE);
+		}
 		break;
 	}
 	case SCR_ANTIMAGIC:{

--- a/src/region.c
+++ b/src/region.c
@@ -19,6 +19,8 @@ static int max_regions = 0;
 
 #define NO_CALLBACK (-1)
 
+boolean FDECL(inside_generic_cloud, (genericptr,genericptr));
+boolean FDECL(expire_generic_cloud, (genericptr,genericptr));
 boolean FDECL(inside_gas_cloud, (genericptr,genericptr));
 boolean FDECL(expire_gas_cloud, (genericptr,genericptr));
 boolean FDECL(inside_fog_cloud, (genericptr,genericptr));
@@ -52,18 +54,10 @@ NhRegion *FDECL(create_force_field, (XCHAR_P,XCHAR_P,int,int));
 static void FDECL(reset_region_mids, (NhRegion *));
 
 static callback_proc callbacks[] = {
-#define INSIDE_GAS_CLOUD 0
-    inside_gas_cloud,
-#define EXPIRE_GAS_CLOUD 1
-    expire_gas_cloud, 
-#define INSIDE_FOG_CLOUD 2
-    inside_fog_cloud,
-#define EXPIRE_FOG_CLOUD 3
-    expire_fog_cloud,
-#define INSIDE_DUST_CLOUD 4
-    inside_dust_cloud,
-#define EXPIRE_DUST_CLOUD 5
-    expire_dust_cloud
+#define INSIDE_GENERIC_CLOUD 0
+    inside_generic_cloud,
+#define EXPIRE_GENERIC_CLOUD 1
+    expire_generic_cloud
 };
 
 /* Should be inlined. */
@@ -144,7 +138,8 @@ int nrect;
     reg->n_monst = 0;
     reg->max_monst = 0;
     reg->monsters = NULL;
-    reg->arg = NULL;
+    reg->arg.damage = 0;
+    reg->arg.adtyp = AD_PHYS;
     return reg;
 }
 
@@ -434,21 +429,17 @@ In_fog_cloud(mon)
 	struct monst *mon;
 {
 	register int i, j, k;
-	int f_indx;
 	/* Process regions */
 	if(mon == &youmonst){
 		for (i = 0; i < n_regions; i++) {
 			/* Check if player is inside region */
-			f_indx = regions[i]->inside_f;
-			if (f_indx == INSIDE_FOG_CLOUD && hero_inside(regions[i]))
+			if (regions[i]->arg.adtyp == AD_SLOW && hero_inside(regions[i]))
 			    return TRUE;
 		}
 	} else {
 		for (i = 0; i < n_regions; i++) {
 			/* Check if player is inside region */
-			f_indx = regions[i]->inside_f;
-			// if (f_indx == INSIDE_FOG_CLOUD && mon_in_region(regions[i], mon)){
-			if (f_indx == INSIDE_FOG_CLOUD && inside_region(regions[i], mon->mx, mon->my)){
+			if (regions[i]->arg.adtyp == AD_SLOW && inside_region(regions[i], mon->mx, mon->my)){
 			    return TRUE;
 			}
 		}
@@ -514,7 +505,7 @@ xchar x, y;
 	int i;
     for (i = 0; i < n_regions; i++) {
 		if (inside_region(regions[i], x, y) &&
-			regions[i]->inside_f == INSIDE_GAS_CLOUD
+			regions[i]->arg.adtyp == AD_POSN
 		) {
 			return TRUE;
 		}
@@ -528,7 +519,7 @@ xchar x, y;
 {
 	int i;
     for (i = 0; i < n_regions; i++) {
-		if (regions[i]->inside_f == INSIDE_FOG_CLOUD &&
+		if (regions[i]->arg.adtyp == AD_SLOW &&
 			inside_region(regions[i], x, y)
 		) {
 			return TRUE;
@@ -544,7 +535,7 @@ xchar x, y;
 	int i;
     for (i = 0; i < n_regions; i++) {
 		if (inside_region(regions[i], x, y) &&
-			regions[i]->inside_f == INSIDE_DUST_CLOUD
+			regions[i]->arg.adtyp == AD_DESC
 		) {
 			return TRUE;
 		}
@@ -742,7 +733,7 @@ int mode;
 	     sizeof (unsigned));
 	bwrite(fd, (genericptr_t) &regions[i]->visible, sizeof (boolean));
 	bwrite(fd, (genericptr_t) &regions[i]->glyph, sizeof (int));
-	bwrite(fd, (genericptr_t) &regions[i]->arg, sizeof (genericptr_t));
+	bwrite(fd, (genericptr_t) &regions[i]->arg, sizeof (struct region_arg));
     }
 
 skip_lots:
@@ -827,7 +818,7 @@ boolean ghostly; /* If a bones file restore */
 		  sizeof (unsigned));
 	mread(fd, (genericptr_t) &regions[i]->visible, sizeof (boolean));
 	mread(fd, (genericptr_t) &regions[i]->glyph, sizeof (int));
-	mread(fd, (genericptr_t) &regions[i]->arg, sizeof (genericptr_t));
+	mread(fd, (genericptr_t) &regions[i]->arg, sizeof (struct region_arg));
     }
     /* remove expired regions, do not trigger the expire_f callback (yet!);
        also update monster lists if this data is coming from a bones file */
@@ -959,6 +950,63 @@ boolean yours
  *								*
  *--------------------------------------------------------------*/
 
+boolean
+expire_generic_cloud(p1, p2)
+genericptr_t p1;
+genericptr_t p2;
+{
+    NhRegion *reg;
+    int damage;
+    struct region_arg *cloud_data;
+
+    reg = (NhRegion *) p1;
+    cloud_data = (struct region_arg *) &reg->arg;
+    
+    switch(cloud_data->adtyp){
+	case AD_POSN:
+		return expire_gas_cloud(p1, p2);
+	case AD_DESC:
+		return expire_dust_cloud(p1, p2);
+	case AD_SLOW:
+		return expire_fog_cloud(p1, p2);
+    }
+
+    damage = cloud_data->damage;
+    /* If it was a thick cloud, it dissipates a little first */
+    if (damage >= 5) {
+	damage /= 2;		/* It dissipates, let's do less damage */
+	cloud_data->damage = damage;
+	reg->ttl = 2;		/* Here's the trick : reset ttl */
+	return FALSE;		/* THEN return FALSE, means "still there" */
+    }
+    return TRUE;		/* OK, it's gone, you can free it! */
+}
+boolean
+inside_generic_cloud(p1, p2)
+genericptr_t p1;
+genericptr_t p2;
+{
+    NhRegion *reg;
+    struct monst *mdef;
+    struct region_arg *cloud_data;
+
+    reg = (NhRegion *) p1;
+    cloud_data = (struct region_arg *) &reg->arg;
+    switch(cloud_data->adtyp){
+	case AD_POSN:
+		return inside_gas_cloud(p1, p2);
+	case AD_DESC:
+		return inside_dust_cloud(p1, p2);
+	case AD_SLOW:
+		return inside_fog_cloud(p1, p2);
+    }
+    /* If not a specially handled type, do generic handling */
+    mdef = p2 ? (struct monst *) p2: &youmonst;
+    return FALSE;
+}
+
+
+
 /*
  * Here is an example of an expire function that may prolong
  * region life after some mods...
@@ -970,20 +1018,21 @@ genericptr_t p2;
 {
     NhRegion *reg;
     int damage;
+    struct region_arg *cloud_data;
 
     reg = (NhRegion *) p1;
-    damage = (int)(intptr_t)reg->arg;
+    cloud_data = (struct region_arg *) &reg->arg;
+    damage = cloud_data->damage;
 
     /* If it was a thick cloud, it dissipates a little first */
     if (damage >= 5) {
 	damage /= 2;		/* It dissipates, let's do less damage */
-	reg->arg = (genericptr_t)(intptr_t)damage;
+	cloud_data->damage = damage;
 	reg->ttl = 2;		/* Here's the trick : reset ttl */
 	return FALSE;		/* THEN return FALSE, means "still there" */
     }
     return TRUE;		/* OK, it's gone, you can free it! */
 }
-
 boolean
 inside_gas_cloud(p1, p2)
 genericptr_t p1;
@@ -991,10 +1040,12 @@ genericptr_t p2;
 {
     NhRegion *reg;
     struct monst *mtmp;
-    int dam;
+    int damage;
+    struct region_arg *cloud_data;
 
     reg = (NhRegion *) p1;
-    dam = (int)(intptr_t)reg->arg;
+    cloud_data = (struct region_arg *) &reg->arg;
+    damage = cloud_data->damage;
     if (p2 == NULL) {		/* This means *YOU* Bozo! */
 		if (Invulnerable)
 			return FALSE;
@@ -1007,7 +1058,7 @@ genericptr_t p2;
 		if (!Poison_resistance) {
 			pline("%s is burning your %s!", Something, makeplural(body_part(LUNG)));
 			You("cough and spit blood!");
-			losehp(rnd(dam) + 5, "gas cloud", KILLED_BY_AN);
+			losehp(rnd(damage) + 5, "gas cloud", KILLED_BY_AN);
 			return FALSE;
 		} else {
 			You("cough!");
@@ -1029,7 +1080,7 @@ genericptr_t p2;
 			}
 			if (resists_poison(mtmp))
 				return FALSE;
-			mtmp->mhp -= rnd(dam) + 5;
+			mtmp->mhp -= rnd(damage) + 5;
 			if (mtmp->mhp <= 0) {
 				if (heros_fault(reg))
 					killed(mtmp);
@@ -1045,10 +1096,10 @@ genericptr_t p2;
 }
 
 NhRegion *
-create_gas_cloud(x, y, radius, damage, yours)
+create_generic_cloud(x, y, radius, cloud_data, yours)
 xchar x, y;
 int radius;
-int damage;
+struct region_arg *cloud_data;
 boolean yours;
 {
     NhRegion *cloud;
@@ -1074,9 +1125,52 @@ boolean yours;
 	if (yours)
 		set_heros_fault(cloud);		/* assume player has created it */
 	else clear_heros_fault(cloud);
-    cloud->inside_f = INSIDE_GAS_CLOUD;
-    cloud->expire_f = EXPIRE_GAS_CLOUD;
-    cloud->arg = (genericptr_t)(intptr_t)damage;
+    cloud->inside_f = INSIDE_GENERIC_CLOUD;
+    cloud->expire_f = EXPIRE_GENERIC_CLOUD;
+    cloud->arg = *cloud_data;
+    cloud->visible = TRUE;
+    cloud->glyph = cmap_to_glyph(S_cloud);
+    add_region(cloud);
+    return cloud;
+
+}
+
+NhRegion *
+create_gas_cloud(x, y, radius, damage, yours)
+xchar x, y;
+int radius;
+int damage;
+boolean yours;
+{
+    NhRegion *cloud;
+    int i, nrect;
+    NhRect tmprect;
+    struct region_arg cloud_data;
+    cloud_data.damage = damage;
+    cloud_data.adtyp = AD_POSN;
+
+    cloud = create_region((NhRect *) 0, 0);
+    nrect = radius;
+    tmprect.lx = x;
+    tmprect.hx = x;
+    tmprect.ly = y - (radius - 1);
+    tmprect.hy = y + (radius - 1);
+    for (i = 0; i < nrect; i++) {
+	add_rect_to_reg(cloud, &tmprect);
+	tmprect.lx--;
+	tmprect.hx++;
+	tmprect.ly++;
+	tmprect.hy--;
+    }
+    cloud->ttl = rn1(3,4);
+	cloud->rx = x;
+	cloud->ry = y;
+	if (yours)
+		set_heros_fault(cloud);		/* assume player has created it */
+	else clear_heros_fault(cloud);
+    cloud->inside_f = INSIDE_GENERIC_CLOUD;
+    cloud->expire_f = EXPIRE_GENERIC_CLOUD;
+    cloud->arg = cloud_data;
     cloud->visible = TRUE;
     cloud->glyph = cmap_to_glyph(S_cloud);
     add_region(cloud);
@@ -1109,6 +1203,9 @@ boolean yours;
     NhRegion *cloud;
     int i, nrect;
     NhRect tmprect;
+    struct region_arg cloud_data;
+    cloud_data.damage = damage;
+    cloud_data.adtyp = AD_SLOW;
 
     cloud = create_region((NhRect *) 0, 0);
     nrect = radius;
@@ -1129,9 +1226,9 @@ boolean yours;
 	if (yours)
 		set_heros_fault(cloud);		/* assume player has created it */
 	else clear_heros_fault(cloud);
-    cloud->inside_f = INSIDE_FOG_CLOUD;
-    cloud->expire_f = EXPIRE_FOG_CLOUD;
-    cloud->arg = (genericptr_t)(intptr_t)damage;
+    cloud->inside_f = INSIDE_GENERIC_CLOUD;
+    cloud->expire_f = EXPIRE_GENERIC_CLOUD;
+    cloud->arg = cloud_data;
     cloud->visible = TRUE;
     cloud->glyph = cmap_to_glyph(S_fog);
     add_region(cloud);
@@ -1144,11 +1241,13 @@ genericptr_t p1;
 genericptr_t p2;
 {
     NhRegion *reg;
+    int nx, ny;
     int damage;
-	int nx, ny;
+    struct region_arg *cloud_data;
 
     reg = (NhRegion *) p1;
-    damage = (int)(intptr_t)reg->arg;
+    cloud_data = (struct region_arg *) &reg->arg;
+    damage = cloud_data->damage;
 	
 	nx = reg->rx - 1 + rn2(3);
 	ny = reg->ry - 1 + rn2(3);
@@ -1179,15 +1278,17 @@ genericptr_t p2;
 {
     NhRegion *reg;
     struct monst *mtmp;
-    int dam;
+    int damage;
+    struct region_arg *cloud_data;
 
     reg = (NhRegion *) p1;
-    dam = (int)(intptr_t)reg->arg;
+    cloud_data = (struct region_arg *) &reg->arg;
+    damage = cloud_data->damage;
     if (p2 == NULL) {		/* This means *YOU* Bozo! */
 		if (Invulnerable)
 			return FALSE;
 		if (youracedata->mtyp == PM_SENTINEL_OF_MITHARDIR){
-			healup(dam, 0, FALSE, FALSE);
+			healup(damage, 0, FALSE, FALSE);
 		}
 		if (nonliving(youracedata) || Breathless)
 			return FALSE;
@@ -1200,23 +1301,23 @@ genericptr_t p2;
 		}
 		if (!Blind)
 			make_blinded(1L, FALSE);
-		if(dam > 3 && !rn2(20) && !Sick_resistance){ //Only a large dust storm
+		if(damage > 3 && !rn2(20) && !Sick_resistance){ //Only a large dust storm
 			//Dormant spores
 			make_sick(Sick ? Sick/2L + 1L : ACURR(A_CON)*300L, //~3000 turns
 				"white spores", TRUE, SICK_NONVOMITABLE);
 			You("are covered with dust and can barely breathe!");
-			losehp(rnd(dam), "dust storm", KILLED_BY_AN);
+			losehp(rnd(damage), "dust storm", KILLED_BY_AN);
 			nomul(0, NULL);
 		} else if(!rn2(10) && !is_anhydrous(youracedata)){
 			//Salt
 			You("are covered with dust and can barely breathe!");
 			pline("Salt dust burns your %s!", makeplural(body_part(LUNG)));
 			You("cough and spit blood!");
-			losehp(rnd(dam)+5, "dust storm", KILLED_BY_AN);
+			losehp(rnd(damage)+5, "dust storm", KILLED_BY_AN);
 			nomul(0, NULL);
 		} else {
 			You("are covered with dust and can barely breathe!");
-			losehp(rnd(dam), "dust storm", KILLED_BY_AN);
+			losehp(rnd(damage), "dust storm", KILLED_BY_AN);
 			nomul(0, NULL);
 		}
 		return FALSE;
@@ -1224,7 +1325,7 @@ genericptr_t p2;
 		mtmp = (struct monst *) p2;
 
 		if (mtmp->mtyp == PM_SENTINEL_OF_MITHARDIR){
-			mtmp->mhp = min(mtmp->mhp+dam, mtmp->mhpmax);
+			mtmp->mhp = min(mtmp->mhp+damage, mtmp->mhpmax);
 		}
 		struct obj *otmp = which_armor(mtmp, W_ARMH);
 		
@@ -1242,7 +1343,7 @@ genericptr_t p2;
 				//Dormant spores
 				if (cansee(mtmp->mx, mtmp->my))
 					pline("%s looks sick!", Monnam(mtmp));
-				mtmp->mhp -= rnd(dam)+5+mtmp->m_lev;
+				mtmp->mhp -= rnd(damage)+5+mtmp->m_lev;
 				if (mtmp->mhp <= 0) {
 					if (heros_fault(reg))
 						killed(mtmp);
@@ -1256,7 +1357,7 @@ genericptr_t p2;
 				//Salt
 				if (cansee(mtmp->mx, mtmp->my))
 					pline("%s coughs!", Monnam(mtmp));
-				mtmp->mhp -= rnd(dam) + 5;
+				mtmp->mhp -= rnd(damage) + 5;
 				if (mtmp->mhp <= 0) {
 					if (heros_fault(reg))
 						killed(mtmp);
@@ -1269,7 +1370,7 @@ genericptr_t p2;
 			} else {
 				if (cansee(mtmp->mx, mtmp->my))
 					pline("%s struggles to breathe!", Monnam(mtmp));
-				mtmp->mhp -= rnd(dam);
+				mtmp->mhp -= rnd(damage);
 				if (mtmp->mhp <= 0) {
 					if (heros_fault(reg))
 						killed(mtmp);
@@ -1294,6 +1395,9 @@ int damage;
     NhRegion *cloud;
     int i, nrect;
     NhRect tmprect;
+    struct region_arg cloud_data;
+    cloud_data.damage = damage;
+    cloud_data.adtyp = AD_DESC;
 
     cloud = create_region((NhRect *) 0, 0);
     nrect = radius;
@@ -1312,9 +1416,9 @@ int damage;
 	cloud->rx = x;
 	cloud->ry = y;
 	clear_heros_fault(cloud);/* assumes never the player's fault */
-    cloud->inside_f = INSIDE_DUST_CLOUD;
-    cloud->expire_f = EXPIRE_DUST_CLOUD;
-    cloud->arg = (genericptr_t)(intptr_t)damage;
+    cloud->inside_f = INSIDE_GENERIC_CLOUD;
+    cloud->expire_f = EXPIRE_GENERIC_CLOUD;
+    cloud->arg = cloud_data;
     cloud->visible = TRUE;
     cloud->glyph = cmap_to_glyph(S_dust);
     add_region(cloud);

--- a/src/region.c
+++ b/src/region.c
@@ -1139,7 +1139,7 @@ boolean yours;
     cloud->expire_f = EXPIRE_GENERIC_CLOUD;
     cloud->arg = *cloud_data;
     cloud->visible = TRUE;
-    cloud->glyph = cmap_to_glyph(S_cloud);
+    cloud->glyph = cloud_to_glyph(cloud_data->adtyp);
     add_region(cloud);
     return cloud;
 

--- a/src/region.c
+++ b/src/region.c
@@ -505,7 +505,7 @@ xchar x, y;
 	int i;
     for (i = 0; i < n_regions; i++) {
 		if (inside_region(regions[i], x, y) &&
-			regions[i]->arg.adtyp == AD_POSN
+			regions[i]->arg.adtyp == AD_DRST
 		) {
 			return TRUE;
 		}
@@ -963,7 +963,7 @@ genericptr_t p2;
     cloud_data = (struct region_arg *) &reg->arg;
     
     switch(cloud_data->adtyp){
-	case AD_POSN:
+	case AD_DRST:
 		return expire_gas_cloud(p1, p2);
 	case AD_DESC:
 		return expire_dust_cloud(p1, p2);
@@ -989,11 +989,14 @@ genericptr_t p2;
     NhRegion *reg;
     struct monst *mdef;
     struct region_arg *cloud_data;
+    struct attack attk;
+    int vis;
+    int result;
 
     reg = (NhRegion *) p1;
     cloud_data = (struct region_arg *) &reg->arg;
     switch(cloud_data->adtyp){
-	case AD_POSN:
+	case AD_DRST:
 		return inside_gas_cloud(p1, p2);
 	case AD_DESC:
 		return inside_dust_cloud(p1, p2);
@@ -1002,7 +1005,14 @@ genericptr_t p2;
     }
     /* If not a specially handled type, do generic handling */
     mdef = p2 ? (struct monst *) p2: &youmonst;
-    return FALSE;
+    boolean youdef = (mdef == &youmonst);
+    attk.aatyp = AT_ENGL;
+    attk.adtyp = cloud_data->adtyp;
+    attk.damn = cloud_data->damage;
+    attk.damd = 1;
+    vis = getvis((struct monst *) 0, mdef, 0, 0);
+    result = xengulfhurty((struct monst *) 0, mdef, &attk, vis);
+    return result & MM_DEF_DIED;
 }
 
 
@@ -1147,7 +1157,7 @@ boolean yours;
     NhRect tmprect;
     struct region_arg cloud_data;
     cloud_data.damage = damage;
-    cloud_data.adtyp = AD_POSN;
+    cloud_data.adtyp = AD_DRST;
 
     cloud = create_region((NhRect *) 0, 0);
     nrect = radius;

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -16,7 +16,6 @@ STATIC_DCL void FDECL(xymissmsg, (struct monst *, struct monst *, struct attack 
 STATIC_DCL int FDECL(do_weapon_multistriking_effects, (struct monst *, struct monst *, struct attack *, struct obj *, int));
 STATIC_DCL int FDECL(xcastmagicy, (struct monst *, struct monst *, struct attack *, int));
 STATIC_DCL int FDECL(xtinkery, (struct monst *, struct monst *, struct attack *, int));
-STATIC_DCL int FDECL(xengulfhurty, (struct monst *, struct monst *, struct attack *, int));
 STATIC_DCL int FDECL(xexplodey, (struct monst *, struct monst *, struct attack *, int));
 STATIC_DCL int FDECL(hmoncore, (struct monst *, struct monst *, struct attack *, struct attack *, struct obj **, void *, int, int, int, boolean, int, boolean, int));
 STATIC_DCL void FDECL(add_silvered_art_sear_adjectives, (char *, struct obj*));
@@ -9898,14 +9897,14 @@ int vis;
 
 int
 xengulfhurty(magr, mdef, attk, vis)
-struct monst * magr;
+struct monst * magr; /* May be NULL if being used for generic cloud damage handling (engulfed by a cloud) */
 struct monst * mdef;
 struct attack * attk;
 int vis;
 {
 	boolean youagr = (magr == &youmonst);
 	boolean youdef = (mdef == &youmonst);
-	struct permonst * pa = youagr ? youracedata : magr->data;
+	struct permonst * pa = magr ? (youagr ? youracedata : magr->data) : (struct permonst *) 0;
 	struct permonst * pd = youdef ? youracedata : mdef->data;
 	int result = MM_MISS;
 	int dmg = d(attk->damn, attk->damd);
@@ -9921,7 +9920,7 @@ int vis;
 		/* the most important and most special case */
 	case AD_DGST:
 		if (youdef) {
-			if (pa->mtyp == PM_METROID_QUEEN && !Drain_resistance) {
+			if (pa && pa->mtyp == PM_METROID_QUEEN && !Drain_resistance) {
 				losexp("life force drain", TRUE, FALSE, FALSE);
 				magr->mhpmax += d(1, 4);
 				magr->mhp += d(1, 6);
@@ -9941,7 +9940,7 @@ int vis;
 			}
 			else {
 				*hp(mdef) -= *hp(mdef)/(u.uswldtim+1); //Floored and current HP, so never fatal. 
-				pline("%s%s digests you!", Monnam(magr),
+				pline("%s%s digests you!", magr ? Monnam(magr): "Something",
 					(u.uswldtim == 2) ? " thoroughly" :
 					(u.uswldtim == 1) ? " utterly" : "");
 				exercise(A_STR, FALSE);
@@ -10051,7 +10050,7 @@ int vis;
 		}
 		else { //mvm
 			/* eating a Rider or its corpse is fatal */
-			if (is_rider(mdef->data)) {
+			if (is_rider(mdef->data) && magr) {
 				if (vis)
 					pline("%s %s!", Monnam(magr),
 					mdef->mtyp == PM_FAMINE ?
@@ -10070,7 +10069,7 @@ int vis;
 				}
 			}
 			else if(is_indigestible(mdef->data)){
-				if(canspotmon(magr) || canspotmon(mdef)){
+				if(magr && (canspotmon(magr) || canspotmon(mdef))){
 					pline("%s regurgitates %s.", Monnam(magr), mon_nam(mdef));
 				}
 				dmg = 0;
@@ -10078,7 +10077,7 @@ int vis;
 			}
 			else if(is_delouseable(mdef->data)){
 				mdef = delouse(mdef, AD_DGST);
-				if(canspotmon(magr) || canspotmon(mdef)){
+				if(magr && (canspotmon(magr) || canspotmon(mdef))){
 					pline("%s regurgitates %s.", Monnam(magr), mon_nam(mdef));
 				}
 				dmg = 0;
@@ -10099,7 +10098,7 @@ int vis;
 						dmg = mdef->mhpmax*(20-resist)/20;
 					if(dmg < mdef->mhp){
 						mdef->mhp -= dmg;//Will not kill defender
-						if(canspotmon(magr) || canspotmon(mdef)){
+						if(magr && (canspotmon(magr) || canspotmon(mdef))){
 							pline("%s regurgitates %s.", Monnam(magr), mon_nam(mdef));
 						}
 						dmg = 0;
@@ -10123,10 +10122,10 @@ int vis;
 				}
 
 				/* Is a corpse for nutrition possible?  It may kill magr */
-				if (!corpse_chance(mdef, magr, TRUE)) {
+				if (magr && !corpse_chance(mdef, magr, TRUE)) {
 					break;
 				}
-				if (*hp(magr) < 1) {
+				if (magr && *hp(magr) < 1) {
 					result |= MM_AGR_DIED;
 					break;
 				}
@@ -10135,7 +10134,7 @@ int vis;
 				* DGST monsters don't die from undead corpses
 				*/
 				int num = monsndx(mdef->data);
-				if (get_mx(magr, MX_EDOG) && 
+				if (magr && get_mx(magr, MX_EDOG) && 
 					!((mvitals[num].mvflags & G_NOCORPSE) || get_mx(mdef, MX_ESUM))) {
 					struct obj *virtualcorpse = mksobj(CORPSE, MKOBJ_NOINIT);
 					int nutrit;
@@ -10221,7 +10220,7 @@ int vis;
 		if (can_blnd(magr, mdef, attk->aatyp, (struct obj*)0)) {
 			if (youdef) {
 			
-				if (uarmh && uarmh->otyp == SHEMAGH && 
+				if (uarmh && uarmh->otyp == SHEMAGH && magr && 
 					(magr->mtyp == PM_DUST_VORTEX || magr->mtyp == PM_SINGING_SAND || magr->mtyp == PM_PYROCLASTIC_VORTEX))
 				{
 					pline("The %s protects you from the dust!", simple_typename(uarmh->otyp));
@@ -10238,7 +10237,7 @@ int vis;
 			else {
 				struct obj *otmp = which_armor(mdef, W_ARMH);
 				
-				if (otmp && otmp->otyp == SHEMAGH && (magr->mtyp == PM_DUST_VORTEX || magr->mtyp == PM_SINGING_SAND)){
+				if (otmp && otmp->otyp == SHEMAGH && magr && (magr->mtyp == PM_DUST_VORTEX || magr->mtyp == PM_SINGING_SAND)){
 					if (vis&VIS_MDEF)
 						pline("The %s protects %s from the dust!", simple_typename(otmp->otyp), Monnam(mdef));
 				} else {
@@ -10295,9 +10294,11 @@ int vis;
 					/* KMH -- this is okay with unchanging */
 					rehumanize();
 					result = MM_DEF_LSVD;
-					magr->mhp = 1;
-					expels(magr, pa, FALSE);
-					pline("Rusting your iron body took a severe toll on the cloud!");
+					if(magr){
+						magr->mhp = 1;
+						expels(magr, pa, FALSE);
+						pline("Rusting your iron body took a severe toll on the cloud!");
+					}
 				}
 				else {
 					if (vis&VIS_MDEF) {
@@ -10314,7 +10315,9 @@ int vis;
 					else {
 						if (mdef->mtame && !vis && !youagr)
 							pline("May %s rust in peace.", mon_nam(mdef));
-						result = (MM_HIT | MM_DEF_DIED | (youagr || grow_up(magr, mdef) ? 0 : MM_AGR_DIED));
+						result = (MM_HIT | MM_DEF_DIED);
+						if(magr)
+							result |= ((youagr || grow_up(magr, mdef)) ? 0 : MM_AGR_DIED);
 					}
 				}
 			}
@@ -10353,7 +10356,7 @@ int vis;
 		break;
 		/* basic damage engulf types */
 	case AD_PHYS:
-		if (pa->mtyp == PM_FOG_CLOUD || pa->mtyp == PM_STEAM_VORTEX) {
+		if (pa && (pa->mtyp == PM_FOG_CLOUD || pa->mtyp == PM_STEAM_VORTEX)) {
 			if (youdef) {
 				You("are laden with moisture and %s",
 					flaming(youracedata) ? "are smoldering out!" :
@@ -10376,7 +10379,7 @@ int vis;
 				}
 			}
 		}
-		else if (pa->mtyp == PM_DREADBLOSSOM_SWARM) {
+		else if (pa && pa->mtyp == PM_DREADBLOSSOM_SWARM) {
 			if (youdef) {
 				You("are sliced by the whirling stems!");
 				exercise(A_DEX, FALSE);
@@ -10444,7 +10447,7 @@ int vis;
 				dmg = 0;
 		}
 		/* message, special effects */
-		if (((attk->adtyp == AD_EELC) || (youagr || !magr->mcan)) &&
+		if (((attk->adtyp == AD_EELC) || (youagr || (!magr || !magr->mcan))) &&
 			(rn2(2) || !youdef || !u.uswallow))
 		{
 			/* message */
@@ -10461,9 +10464,9 @@ int vis;
 			}
 			/* destroy items */
 			if (!UseInvShock_res(mdef)){
-				if (mlev(magr) > rn2(20))
+				if (magr ? mlev(magr) > rn2(20) : !rn2(4))
 					destroy_item(mdef, WAND_CLASS, AD_ELEC);
-				if (mlev(magr) > rn2(20))
+				if (magr ? mlev(magr) > rn2(20) : !rn2(4))
 					destroy_item(mdef, RING_CLASS, AD_ELEC);
 			}
 			/* golem effects */
@@ -10499,7 +10502,7 @@ int vis;
 				dmg = 0;
 		}
 		/* message, special effects */
-		if (((attk->adtyp == AD_ECLD) || (youagr || !magr->mcan)) &&
+		if (((attk->adtyp == AD_ECLD) || (youagr || (!magr || !magr->mcan))) &&
 			(rn2(2) || !youdef || !u.uswallow))
 		{
 			/* message */
@@ -10519,7 +10522,7 @@ int vis;
 			}
 			/* destroy items */
 			if (!UseInvCold_res(mdef)){
-				if (mlev(magr) > rn2(20))
+				if (magr ? mlev(magr) > rn2(20): !rn2(4))
 					destroy_item(mdef, POTION_CLASS, AD_COLD);
 			}
 			/* golem effects */
@@ -10559,7 +10562,7 @@ int vis;
 		}
 		/* message, special effects */
 		/* This seems buggy mvm. They're really cold if YOU'RE swallowed! */
-		if (((attk->adtyp == AD_EFIR || attk->adtyp == AD_ACFR) || (youagr || !magr->mcan)) &&
+		if (((attk->adtyp == AD_EFIR || attk->adtyp == AD_ACFR) || (youagr || (!magr || !magr->mcan))) &&
 			(rn2(2) || !youdef || !u.uswallow))
 		{
 			/* message */
@@ -10587,11 +10590,11 @@ int vis;
 			}
 			/* destroy items */
 			if (!UseInvFire_res(mdef)) {
-				if (mlev(magr) > rn2(20))
+				if (magr ? mlev(magr) > rn2(20) : !rn2(4))
 					destroy_item(mdef, SCROLL_CLASS, AD_FIRE);
-				if (mlev(magr) > rn2(20))
+				if (magr ? mlev(magr) > rn2(20): !rn2(4))
 					destroy_item(mdef, POTION_CLASS, AD_FIRE);
-				if (mlev(magr) > rn2(25))
+				if (magr? mlev(magr) > rn2(25): !rn2(5))
 					destroy_item(mdef, SPBOOK_CLASS, AD_FIRE);
 			}
 			/* golem effects */
@@ -10620,7 +10623,7 @@ int vis;
 			dmg *= 2;
 		}
 		/* message, special effects */
-		if (youagr || !magr->mcan){
+		if (youagr || (!magr || !magr->mcan)){
 			/* message */
 			if (vis&VIS_MDEF) {
 				if (dmg) {
@@ -10656,7 +10659,8 @@ int vis;
 					);
 			}
 			/* heal from damage dealt*/
-			heal(magr, min(*hp(mdef), dmg));
+			if(magr)
+				heal(magr, min(*hp(mdef), dmg));
 		}
 		/* deal damage */
 		result = xdamagey(magr, mdef, attk, dmg);

--- a/src/zap.c
+++ b/src/zap.c
@@ -4091,8 +4091,12 @@ struct zapdata * zapdata;	/* lots of flags and data about the zap */
 				case AD_DRST:
 					create_gas_cloud(sx, sy, 1, 8, youagr);
 					break;
-				default:
-					impossible("Unhandled gascloud-leaving zap adtyp %d", zapdata->adtyp);
+				default:{
+					struct region_arg cloud_data;
+					cloud_data.damage = 8;
+					cloud_data.adtyp = zapdata->adtyp;
+					create_generic_cloud(sx, sy, 1, &cloud_data, youagr);
+				}
 				}
 			}
 


### PR DESCRIPTION
Allow specifying an AD type for generic clouds to do damage with, change display color, and change glyph description. Implement confused stinking cloud scroll effect creating one of these generic clouds from a small pool of elemental AD types.
Implemented handling of leaves_cloud zap_data zaps of non AD_DRST adtyp to use generic cloud handling instead of impossibling.
This maintains backwards compatibility with handling for old cloud types, including their cmap display glyphs.

![image](https://github.com/Chris-plus-alphanumericgibberish/dNAO/assets/8377693/daafeb2f-537e-4328-b9b9-1d5f7b95b333)


I did a lot of stuff to make this work that should be noted for technical reasons.
- Cloud glyph space exists for every AD type, there is now a NUM_AD_TYPES constant defined that needs to continue to represent this
- xengulfhurty was reworked to not require a magr. I may have missed a spot or two. I hope not. This is used for generic AD type cloud hurting monsters/players, and the cloud isn't a monster struct, so we just pass no magr.
     - I like that the vanilla nethack has well defined indicators for a static analyzer for what parameters of functions can be null. I think. we should get that. it would be cool.
- zap_glyph_color is used when displaying cloud glyphs to map their AD type to a CLR constant. This should probably be changed long term to have a more generic AD type to CLR constant lookup function that is used to back both of these use cases.
- get_description_of_damage_type is used when describing a cloud type glyph. This works for the simple elemental cases, but there are a ton it sounds awkward for. We need better adtyp->noun description of what it does mapping. The words used for those have no consistency in part of speech, plurality, etc.

To make sure a "new" AD type cloud is supportable and can actually see use in game without causing issues, here is what needs to happen:
- xengulfhurty for the AD type needs to be implemented and not rely on a magr ptr being present and message sanely for being in a cloud and not in a monster
- zap_glyph_color needs to support this AD type
- get_description_of_damage_type needs to have a relatively reasonable string for describing the glyph of a cloud of this type as a "%s cloud"