### PR TITLE
Handle cloud glyphs in auto_describe instead of impossibling

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -168,6 +168,8 @@ auto_describe(int cx, int cy)
 	} else if (glyph_is_monster(glyph)) {
 		/* takes care of pets, detected, ridden, and regular mons */
 		sym = monsyms[(int)mons[glyph_to_mon(glyph)].mlet];
+	} else if (glyph_is_cloud(glyph)) {
+		sym = showsyms[S_cloud];
 	} else if (glyph_is_swallow(glyph)) {
 		sym = showsyms[glyph_to_swallow(glyph)+S_sw_tl];
 	} else if (glyph_is_invisible(glyph)) {


### PR DESCRIPTION
Currently this happens when you #terrain and move the cursor over a generic cloud. For whatever reason, regions get rendered in #terrain overviews which seems like it shouldn't happen. This happens with non generic non cloud glyph clouds, and I don't think that the addition of generic clouds caused this bad behavior.