### PR TITLE
Clockwork Monk inspired fixes

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -835,6 +835,7 @@ E void NDECL(reset_uhunger);
 E boolean NDECL(satiate_uhunger);
 E double NDECL(get_uhungersizemod);
 E int NDECL(get_uhungermax);
+E int NDECL(get_satiationlimit);
 E int NDECL(Hear_again);
 E void NDECL(reset_eat);
 E int NDECL(doeat);

--- a/include/vision.h
+++ b/include/vision.h
@@ -53,7 +53,7 @@ extern char *viz_rmax;			/* max could see indices */
 
 #define unshadowed_square(x,y)	((levl[x][y].lit && !(viz_array[y][x]&TEMP_DRKMASK)) || (!levl[x][y].lit && !(viz_array[y][x]&TEMP_LITMASK)))
 
-#define xrayrange()	((Xray_vision ? 3 : -1) + (u.sealsActive&SEAL_ORTHOS ? spiritDsize() + 1 : 0))
+#define xrayrange()	((Xray_vision ? 3 : -1) + ((Role_if(PM_MONK) && ublindf && ublindf->oartifact == ART_EYES_OF_THE_OVERWORLD) ? ((u.ulevel+1)/10) : 0)+ (u.sealsActive&SEAL_ORTHOS ? spiritDsize() + 1 : 0))
 #define xraydist() (xrayrange() < 0 ? -1 : xrayrange()*xrayrange())
 
 /*

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -2765,13 +2765,15 @@ karemade:
 					}
 					
 					if(u.utemp >= MELTING && !(HFire_resistance || u.sealsActive&SEAL_FAFNIR)){
-						You("are melting!");
+						Your("boiler is melting!");
 						losehp(u.ulevel, "melting from extreme heat", KILLED_BY);
 						if(u.utemp >= MELTED){
+							Your("boiler has melted to slag!");
 							if(Upolyd) losehp(u.mhmax*2, "melting to slag", KILLED_BY);
 							else { /* May have been rehumanized by previous damage. In that case, still die from left over bronze on your skin! */
-								if(uclockwork) losehp((Upolyd ? u.mhmax : u.uhpmax)*2, "melting to slag", KILLED_BY);
-								else if(!(HFire_resistance || u.sealsActive&SEAL_FAFNIR)) losehp((Upolyd ? u.mhmax : u.uhpmax)*2, "molten bronze", KILLED_BY);
+								losehp((Upolyd ? u.mhmax : u.uhpmax)*2, "melting to slag", KILLED_BY);
+								u.utemp = 19; // don't get stuck in a loop of permanently dying, clear temp & stove
+								u.ustove = 0; // this can still kill due to you taking damage, just no instadeath
 							}
 						}
 					}

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -2758,9 +2758,11 @@ karemade:
 					}
 				} else if(u.utemp) u.utemp--;
 				if(u.utemp > BURNING_HOT){
-					if((u.utemp-5)*2 > rnd(10)) destroy_item(&youmonst, SCROLL_CLASS, AD_FIRE);
-					if((u.utemp-5)*2 > rnd(10)) destroy_item(&youmonst, POTION_CLASS, AD_FIRE);
-					if((u.utemp-5)*2 > rnd(10)) destroy_item(&youmonst, SPBOOK_CLASS, AD_FIRE);
+					if (!InvFire_resistance){
+						if((u.utemp-5)*2 > rnd(10)) destroy_item(&youmonst, SCROLL_CLASS, AD_FIRE);
+						if((u.utemp-5)*2 > rnd(10)) destroy_item(&youmonst, POTION_CLASS, AD_FIRE);
+						if((u.utemp-5)*2 > rnd(10)) destroy_item(&youmonst, SPBOOK_CLASS, AD_FIRE);
+					}
 					
 					if(u.utemp >= MELTING && !(HFire_resistance || u.sealsActive&SEAL_FAFNIR)){
 						You("are melting!");

--- a/src/apply.c
+++ b/src/apply.c
@@ -7769,7 +7769,7 @@ upgradeMenu()
 			MENU_UNSELECTED);
 		incntlet = (incntlet != 'z') ? (incntlet+1) : 'A';
 	}
-	if(!(u.clockworkUpgrades&PHASE_ENGINE) && !flags.beginner){
+	if(!(u.clockworkUpgrades&PHASE_ENGINE)){
 		Sprintf(buf, "phase engine");
 		any.a_int = 6;	/* must be non-zero */
 		add_menu(tmpwin, NO_GLYPH, &any,
@@ -7777,7 +7777,7 @@ upgradeMenu()
 			MENU_UNSELECTED);
 		incntlet = (incntlet != 'z') ? (incntlet+1) : 'A';
 	}
-	if(!(u.clockworkUpgrades&MAGIC_FURNACE) && u.clockworkUpgrades&OIL_STOVE && !flags.beginner){
+	if(!(u.clockworkUpgrades&MAGIC_FURNACE) && u.clockworkUpgrades&OIL_STOVE){
 		Sprintf(buf, "magic furnace");
 		any.a_int = 7;	/* must be non-zero */
 		add_menu(tmpwin, NO_GLYPH, &any,
@@ -7785,7 +7785,7 @@ upgradeMenu()
 			MENU_UNSELECTED);
 		incntlet = (incntlet != 'z') ? (incntlet+1) : 'A';
 	}
-	if(!(u.clockworkUpgrades&HELLFIRE_FURNACE) && u.clockworkUpgrades&OIL_STOVE && !flags.beginner){
+	if(!(u.clockworkUpgrades&HELLFIRE_FURNACE) && u.clockworkUpgrades&OIL_STOVE){
 		Sprintf(buf, "hellfire furnace");
 		any.a_int = 8;	/* must be non-zero */
 		add_menu(tmpwin, NO_GLYPH, &any,
@@ -7793,7 +7793,7 @@ upgradeMenu()
 			MENU_UNSELECTED);
 		incntlet = (incntlet != 'z') ? (incntlet+1) : 'A';
 	}
-	if(!(u.clockworkUpgrades&SCRAP_MAW && !flags.beginner)){
+	if(!(u.clockworkUpgrades&SCRAP_MAW)){
 		Sprintf(buf, "scrap maw");
 		any.a_int = 9;	/* must be non-zero */
 		add_menu(tmpwin, NO_GLYPH, &any,

--- a/src/apply.c
+++ b/src/apply.c
@@ -8291,7 +8291,7 @@ struct obj **optr;
 						// return MOVE_CANCELLED;
 					// }
 					You("use the components in the upgrade kit to increase the maximum tension in your mainspring.");
-					u.uhungermax += DEFAULT_HMAX;
+					u.uhungermax += DEFAULT_HMAX; // 2000 per, capped at 9 kits for 20,000 max
 					if(u.uhungermax >= DEFAULT_HMAX*10) u.clockworkUpgrades |= upgrade;
 					// useup(comp);
 					useup(obj);

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -8430,7 +8430,13 @@ arti_invoke(obj)
 	    if (!otmp) goto nothing_special;
 	    otmp->blessed = obj->blessed;
 	    otmp->cursed = obj->cursed;
-	    otmp->bknown = obj->bknown;
+
+	    otmp->bknown |= obj->bknown;
+		otmp->known |= obj->known;
+		otmp->rknown |= obj->rknown;
+		otmp->dknown |= obj->dknown;
+		otmp->sknown |= obj->sknown;
+
 	    if (obj->blessed) {
 			if (otmp->spe < 0) otmp->spe = 0;
 			otmp->quan += rnd(10);
@@ -10296,7 +10302,12 @@ arti_invoke(obj)
 						if (!otmp) break;
 						otmp->blessed = obj->blessed;
 						otmp->cursed = obj->cursed;
-						otmp->bknown = obj->bknown;
+
+						otmp->bknown |= obj->bknown;
+						otmp->known |= obj->known;
+						otmp->rknown |= obj->rknown;
+						otmp->dknown |= obj->dknown;
+						otmp->sknown |= obj->sknown;
 						if (obj->blessed) {
 							if (otmp->spe < 0) otmp->spe = 0;
 							otmp->quan += rnd(10);
@@ -10422,7 +10433,11 @@ arti_invoke(obj)
 						otmp = mksobj(SILVER_BULLET, NO_MKOBJ_FLAGS);
 						otmp->blessed = obj->blessed;
 						otmp->cursed = obj->cursed;
-						otmp->bknown = obj->bknown;
+						otmp->bknown |= obj->bknown;
+						otmp->known |= obj->known;
+						otmp->rknown |= obj->rknown;
+						otmp->dknown |= obj->dknown;
+						otmp->sknown |= obj->sknown;
 						if (obj->blessed) {
 							if (otmp->spe < 0) otmp->spe = 0;
 							otmp->quan += 10+rnd(10);
@@ -10439,7 +10454,11 @@ arti_invoke(obj)
 						otmp = mksobj(ROCKET, NO_MKOBJ_FLAGS);
 						otmp->blessed = obj->blessed;
 						otmp->cursed = obj->cursed;
-						otmp->bknown = obj->bknown;
+						otmp->bknown |= obj->bknown;
+						otmp->known |= obj->known;
+						otmp->rknown |= obj->rknown;
+						otmp->dknown |= obj->dknown;
+						otmp->sknown |= obj->sknown;
 						if (obj->blessed) {
 							if (otmp->spe < 0) otmp->spe = 0;
 						} else if (obj->cursed) {

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -469,7 +469,7 @@ exerper()
 	if(!(moves % 10)) {
 		/* Hunger Checks */
 
-		int hs = (YouHunger > (Race_if(PM_INCANTIFIER) ? max(u.uenmax/2,200) : get_uhungermax()/2)) ? SATIATED :
+		int hs = (YouHunger > get_satiationlimit()) ? SATIATED :
 			 (YouHunger > 150*get_uhungersizemod()) ? NOT_HUNGRY :
 			 (YouHunger > 50*get_uhungersizemod()) ? HUNGRY :
 			 (YouHunger > 0) ? WEAK : FAINTING;
@@ -1882,8 +1882,8 @@ acurrstr(str)
 	int str;
 {
 	if (str <= 18) return((schar)str);
-	if (str <= 41) return((schar)(19 + str / 10)); /* map to 19-21 */
-	else return((schar)(str - 20));
+	if (str <= 38) return((schar)(18)); /* map to 18 */
+	return((schar)(str - 20));
 }
 
 #endif /* OVL0 */

--- a/src/enlighten.c
+++ b/src/enlighten.c
@@ -978,11 +978,17 @@ boolean dumping;
 			enl_msg("Your internal boiler ", "is", "was", " running rather hot");
 		else if (u.utemp < MELTING)
 			enl_msg("Your internal boiler ", "is", "was", " burning hot");
-		else if (u.utemp < MELTED)
-			enl_msg(Fire_resistance ? "Your thermal sinks " : "Your boiler ", "is", "was", Fire_resistance ? " nearly at capacity" : " melting to slag");
-		else 
-			enl_msg(Fire_resistance ? "Your thermal sinks " : "Your internal boiler ", "is", "was", Fire_resistance ? 
-				" are well beyond capacity, but miraculously intact" : " nothing but molten bronze");
+		else if (u.utemp < MELTED){
+			if (Fire_resistance)
+				enl_msg("Your thermal sinks ", "are", "were", " nearly at capacity");
+			else
+				enl_msg("Your intenal boiler ", "is", "was", " melting to slag");
+		} else {
+			if (Fire_resistance)
+				enl_msg("Your thermal sinks ", "are", "were", " well beyond capacity, but miraculously intact");
+			else
+				enl_msg("Your intenal boiler ", "is", "was", " nothing but molten bronze");
+		}
 		if (wizard) {
 			Sprintf(buf, " %d", u.utemp);
 			enl_msg("Your boiler temperature ", "is", "was", buf);

--- a/src/enlighten.c
+++ b/src/enlighten.c
@@ -970,6 +970,23 @@ boolean dumping;
 		if(u.ucspeed==NORM_CLOCKSPEED) you_are("set to normal clockspeed");
 		if(u.ucspeed==SLOW_CLOCKSPEED) you_are("set to low clockspeed");
 		if(u.phasengn) you_are("in phase mode");
+		if (u.utemp < WARM)
+			enl_msg("Your internal boiler ", "is", "was", " under control");
+		else if (u.utemp < HOT)
+			enl_msg("Your internal boiler ", "is", "was", " running mildly warm");
+		else if (u.utemp < BURNING_HOT)
+			enl_msg("Your internal boiler ", "is", "was", " running rather hot");
+		else if (u.utemp < MELTING)
+			enl_msg("Your internal boiler ", "is", "was", " burning hot");
+		else if (u.utemp < MELTED)
+			enl_msg(Fire_resistance ? "Your thermal sinks " : "Your boiler ", "is", "was", Fire_resistance ? " nearly at capacity" : " melting to slag");
+		else 
+			enl_msg(Fire_resistance ? "Your thermal sinks " : "Your internal boiler ", "is", "was", Fire_resistance ? 
+				" are well beyond capacity, but miraculously intact" : " nothing but molten bronze");
+		if (wizard) {
+			Sprintf(buf, " %d", u.utemp);
+			enl_msg("Your boiler temperature ", "is", "was", buf);
+		}
 	}
 	if (uandroid){
 		if(u.ucspeed==HIGH_CLOCKSPEED) you_are("set to emergency speed");
@@ -1147,6 +1164,26 @@ resistances_enlightenment()
 		if(u.ucspeed==NORM_CLOCKSPEED) putstr(en_win, 0, "Your clock is set to normal speed.");
 		if(u.ucspeed==SLOW_CLOCKSPEED) putstr(en_win, 0, "Your clock is set to low speed.");
 		if(u.phasengn) putstr(en_win, 0, "Your phase engine is activated.");
+		if (u.utemp < WARM)
+			putstr(en_win, 0, "Your internal boiler is under control.");
+		else if (u.utemp < HOT)
+			putstr(en_win, 0, "Your internal boiler is running mildly warm.");
+		else if (u.utemp < BURNING_HOT)
+			putstr(en_win, 0, "Your internal boiler is running rather hot.");
+		else if (u.utemp < MELTING)
+			putstr(en_win, 0, "Your internal boiler is burning hot!");
+		else if (u.utemp < MELTED){
+			if (Fire_resistance)
+				putstr(en_win, 0, "Your thermal sinks are nearly at capacity!");
+			else
+				putstr(en_win, 0, "Your internal boiler is melting to slag!");
+		}
+		else {
+			if (Fire_resistance)
+				putstr(en_win, 0, "Your thermal sinks are well beyond capacity, but miraculously intact!");
+			else // man, if you manage to see this one i'll be impressed
+				putstr(en_win, 0, "Your internal boiler is nothing but molten bronze.");
+		}
 	}
 	if (uandroid){
 		if(u.ucspeed==HIGH_CLOCKSPEED) putstr(en_win, 0, "You are set to emergency speed.");
@@ -1740,11 +1777,15 @@ spirits_enlightenment()
 	putstr(en_win, 0, "Currently bound spirits:");
 	putstr(en_win, 0, "");
 
-#define addseal(id) do {if(u.sealTimeout[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)] > moves)\
-	Sprintf(buf, "  %-23s (timeout:%ld)", sealNames[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)], \
-		u.sealTimeout[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)] - moves); \
+#define addseal(id) do {\
+	if(u.sealTimeout[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)] > moves){\
+		if (u.spiritT[id] == u.sealTimeout[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)])\
+			Sprintf(buf, "  %-23s (timeout:%ld)", sealNames[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)], \
+				u.sealTimeout[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)] - moves); \
+		else Sprintf(buf, "  %-23s (duration:%ld, timeout:%ld)", sealNames[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)], \
+				u.spiritT[id]-moves, u.sealTimeout[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)] - moves); }\
 	else\
-	Sprintf(buf, "  %-23s", sealNames[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)]); \
+		Sprintf(buf, "  %-23s", sealNames[decode_sealID(u.spirit[(id)]) - (FIRST_SEAL)]); \
 	putstr(en_win, 0, buf); } while (0)
 #define addpen(seal) do {\
 	Sprintf(buf, "  %-23s (timeout:%ld)", sealNames[decode_sealID(seal) - (FIRST_SEAL)], \

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -620,7 +620,7 @@ nh_timeout()
 			}
 		}
 	}
-	if(u.spirit[ALIGN_SPIRIT] == SEAL_YOG_SOTHOTH && carrying_art(ART_SILVER_KEY))
+	if(u.spirit[ALIGN_SPIRIT] & SEAL_YOG_SOTHOTH && carrying_art(ART_SILVER_KEY))
 		u.spiritT[ALIGN_SPIRIT]++;
 	if(!u.voidChime){
 		while(u.spirit[0] && u.spiritT[0] < moves) unbind(u.spirit[0],0);

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -14947,7 +14947,7 @@ int vis;						/* True if action is at all visible to the player */
 						tmp = min(0, tmp);
 					bonsdmg += tmp;
 				}
-				else if (fired)
+				else if (fired || thrown)
 				{
 					/* slings get STR bonus */
 					if (launcher && objects[launcher->otyp].oc_skill == P_SLING)

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -200,12 +200,12 @@ print_statdiff(const char *append, nhstat *stat, int new, int type)
     wattron(win, attr);
     wprintw(win, "%s", append);
     if (type == STAT_STR && new > 18) {
-        if (new > 118)
-            wprintw(win, "%d", new - 100);
-        else if (new == 118)
+        if (new > STR18(100))
+            wprintw(win, "%d", new - 20);
+        else if (new == STR18(100))
             wprintw(win, "18/**");
         else
-            wprintw(win, "18/%02d", new - 18);
+            wprintw(win, "18/%02d", (new - 18)*5);
     } else
         wprintw(win, "%d", new);
 


### PR DESCRIPTION
Local clockwork monk, descendent silver starlight + yog, unearthed a bunch of weird bugs + enhancements.

- thrown weapons get dbon as they should
- clockworks/incantifiers have their satiation limit set to 3/4 (and their "hard to force down" limit at 7/8), since they incentivize staying close to hungermax more than normal
- clockwork heat is now visible in both ctrl-x and in enlightenment (exact temp in wizmode enlightenment), since it's weird it wasn't before.
- spirit duration being different from timeout is now shown in ctrl-x, since this is noteable if you're yogging all over the place and kept increasing those binding durations. this does not apply to the view when you go to engrave a seal, only the ctrl-x.
- monks get an extra 3 squares radius (so 6) from EOTO xray because 3 squares of xray kinda sucks in comparison to like, nenya, orthos, scent, idk a lot of things. now they have more.
- curses display fixed for bonus str. i dont know if this made it to your local yet.
- create ammo invokes will ID the ammo created up to what you know of the original artifact. so if you have a fully ID'd silver starlight it makes fully ID'd shuriken, for example.

originally this was on top of my other PR but i dont believe it depends on it. it doesn't seem to when rebased at least

EDIT - next commit

- fixes enl bad wording from previous commit, see scienceball's comment
- don't hide upgrades behind beginner status - this very rarely makes a difference, you'll almost always get out of beginner zone before this. for reference - assuming you've gained score only via kills, that's just after xp6 - 500 xp worth of kills total. Scrap maw & phase engine are now 'visible', since it's highly unlikely that a 'beginner' would throw an upgrade kit into oil stove and have another one already there, again before xp7.
- fix an infinite-ish loop where melting down and lifesaving would just. keep melting down every turn until you chuffed water.... except that adding more water wouldn't immediately fix it, since you lose 1 temp/turn. lifesaving now sets you just under melted, so you're still taking damage, but you won't get any hotter and die for now. also adds a message about what killed you lol not just "you are melting" for 30 dmg, 30 dmg, 30 dmg, whoops theres literally 500 hp in one go