### PR TITLE
Minor misc bugfixes for various minor misc bugs

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2348,7 +2348,7 @@ struct obj * otmp;
 		break;
 	case ART_SCORPION_CARAPACE:
 		if(check_carapace_mod(otmp, CPROP_PLATES))
-			def = 7;
+			def += 5;
 		else if(check_carapace_mod(otmp, CPROP_HARD_SCALE))
 			def += 1;//offsetting the chitin material
 		break;
@@ -2449,7 +2449,7 @@ struct obj * otmp;
 		break;
 	case ART_SCORPION_CARAPACE:
 		if(check_carapace_mod(otmp, CPROP_PLATES))
-			def = 7;
+			def += 5;
 		else if(check_carapace_mod(otmp, CPROP_HARD_SCALE))
 			def += 1;//offsetting the chitin material
 		break;

--- a/src/mon.c
+++ b/src/mon.c
@@ -5127,6 +5127,9 @@ boolean was_swallowed;			/* digestion */
 	if(Role_if(PM_ANACHRONONAUT) && (mon->mpeaceful || (has_lifesigns(mon) && mon->mvar_lifesigns)) && In_quest(&u.uz) && Is_qstart(&u.uz)){
 		if(!cansee(mon->mx,mon->my)) map_invisible(mon->mx, mon->my);
 	}
+	/* bypass anything about templates, etc. just always make a corpse*/
+	if (is_rider(mdat)) return TRUE;
+
 	/* Liches and Vlad and his wives have a fancy death message, and leave no corpse */
 	if ((mdat->mlet == S_LICH) ||
 		(mdat->mlet == S_VAMPIRE && mdat->geno & G_UNIQ)) {
@@ -6310,7 +6313,7 @@ xkilled(mtmp, dest)
 		goto cleanup;
 	}
 
-	if((dest & 2) || LEVEL_SPECIFIC_NOCORPSE(mdat))
+	if(!is_rider(mdat) && ((dest & 2) || LEVEL_SPECIFIC_NOCORPSE(mdat)))
 		goto cleanup;
 
 #ifdef MAIL

--- a/src/monst.c
+++ b/src/monst.c
@@ -5997,7 +5997,7 @@ struct permonst _mons2[] = {
 	SIZ(WT_HUMAN, 400, MS_GUARD, MZ_HUMAN), 0, 0,
 	MM_WALLWALK /*MM*/, MT_OMNIVORE|MT_PEACEFUL|MT_COLLECT /*MT*/, MF_MARTIAL_S /*MF*/,
 	MB_HUMANOID|MB_STRONG /*MB*/, MG_NOWISH|MG_NOPOLY|MG_MERC|MG_INFRAVISIBLE /*MG*/,
-	MA_HUMAN /*MA*/,  MV_NORMAL /*MV*/, 0 /*MW*/, CLR_BLUE),
+	MA_HUMAN /*MA*/,  MV_NORMAL|MV_SEE_INVIS /*MV*/, 0 /*MW*/, CLR_BLUE),
     MON("prisoner", S_HUMAN,//14
 	LVL(12, 12, 0, 0),  G_NOGEN,          /* for special levels */
 	DEF(NAT_AC(0)),

--- a/src/spell.c
+++ b/src/spell.c
@@ -746,12 +746,14 @@ struct obj *spellbook;
 		if (RoSbook == READ_SPELL){
 			char qbuf[QBUFSZ];
 			Sprintf(qbuf, "You know \"%s\" quite well already. Try to refresh your memory anyway?", OBJ_NAME(objects[booktype]));
-			/* identify the book in case you learnt the spell from an artifact book or aphanactonan archive */
-			makeknown(booktype);
 
-			for (int i = 0; i < MAXSPELL; i++)
-				if (spellid(i) == booktype && spellknow(i) > KEEN/10 && yn(qbuf) == 'n')
+			for (int i = 0; i < MAXSPELL; i++){
+				if (spellid(i) == booktype && spellknow(i) > KEEN/10 && yn(qbuf) == 'n'){
+					/* identify the book in case you learnt the spell from an artifact book or aphanactonan archive */
+					makeknown(booktype);
 					return MOVE_CANCELLED;
+				}
+			}
 		}		
 		spellbook->in_use = TRUE;
 		
@@ -817,9 +819,10 @@ struct obj *spellbook;
 			You("begin to study the ward.");
 		else if (spellbook->otyp == SPE_BOOK_OF_THE_DEAD)
 			You("begin to recite the runes.");
-		else
+		else {
 			You("begin to memorize the runes.");
-			
+			makeknown(spellbook->otyp);
+		}
 	}
 
 	book = spellbook;

--- a/src/vault.c
+++ b/src/vault.c
@@ -514,8 +514,8 @@ register struct monst *grd;
 			verbalize("You've been warned, knave!");
 			mnexto(grd);
 			levl[m][n].typ = egrd->fakecorr[0].ftyp;
-			newsym(m,n);
 			grd->mpeaceful = 0;
+			newsym(m,n);
 			return(-1);
 		}
 		/* not fair to get mad when (s)he's fainted or paralyzed */

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -13501,11 +13501,11 @@ int vis;						/* True if action is at all visible to the player */
 		sneak_dice++;
 	if (weapon && weapon->owornmask && weapon->oartifact == ART_SPINESEEKER)
 		sneak_dice++;
-	if (weapon && weapon->oartifact == ART_LOLTH_S_FANG)
+	if (weapon && weapon->owornmask && weapon->oartifact == ART_LOLTH_S_FANG)
 		sneak_dice++;
 	if (weapon && weapon->owornmask && weapon->otyp == BESTIAL_CLAW && active_glyph(BEASTS_EMBRACE))
 		sneak_dice++;
-	if (weapon && weapon->owornmask && weapon->oartifact == ART_PEN_OF_THE_VOID && weapon->ovar1_seals&SEAL_ANDROMALIUS)
+	if (weapon && weapon->oartifact == ART_PEN_OF_THE_VOID && weapon->ovar1_seals&SEAL_ANDROMALIUS)
 		sneak_dice++;
 
 	/* check sneak attack conditions -- defender's conditions must allow sneak attacking */
@@ -13578,7 +13578,7 @@ int vis;						/* True if action is at all visible to the player */
 		/* some things increase the number of sneak dice even further */
 		if (weapon && weapon->owornmask && weapon->oartifact == ART_SPINESEEKER && (sneak_attack&SNEAK_BEHIND))
 			sneak_dice++;
-		if (weapon && weapon->oartifact == ART_LOLTH_S_FANG && (sneak_attack&SNEAK_TRAPPED) && t_at(x(mdef), y(mdef)) && t_at(x(mdef), y(mdef))->ttyp == WEB)
+		if (weapon && weapon->owornmask && weapon->oartifact == ART_LOLTH_S_FANG && (sneak_attack&SNEAK_TRAPPED) && t_at(x(mdef), y(mdef)) && t_at(x(mdef), y(mdef))->ttyp == WEB)
 			sneak_dice++;
 		if (weapon && weapon->oartifact == ART_PEN_OF_THE_VOID && weapon->ovar1_seals&SEAL_ANDROMALIUS && (mvitals[PM_ACERERAK].died > 0))
 			sneak_dice++;

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -290,6 +290,10 @@ curses_display_nhwindow(winid wid, BOOLEAN_P block)
 
     /* actually display the window */
     wnoutrefresh(curses_get_nhwin(wid));
+	if (curses_window_has_border(wid)) {
+		WINDOW *win = curses_get_nhwin(wid);
+		box(win, 0, 0);
+	}
     /* flush pending writes from other windows too */
     doupdate();
     if ((wid == MAP_WIN) && block) {


### PR DESCRIPTION
Squashed commit of a bunch of one-line changes that I'm not going to separate out, but they have sufficient descriptions it should be searchable.

Update singing sword regen to properly function when polymorphed: Also fixes the rather egregious copypastes present here. It now duplicates minimal code and messages slightly better.

Riders always leave corpses even on "nocorpse" levels: Please don't make anything not leave corpses unless corpse_chance says it's ok :(

Vault guards now see invisible and re-render correctly: This prevents them from being weird because they can still detect you, since they can still detect you via various means. See invisible doesn't make much of a difference in existing behavior but it explains it better

Spellbooks don't ID unless you actually begin reading them: This means cursed spellbooks that fail immediately no longer formally type ID themselves

Fix wornmask checks for sneak attacks for POTV & Lolth's Fang: As-written, most sneak attack enabling items require wielding/offhanding/etc. - this means they do NOT work when thrown, since that wornmask is cleared as soon as it hits the air and leaves your person. This fixes that behavior to be consistent for Lolth's Fang, but disables it for the PotV with Andromalius inside. It can sneak attack when thrown or whatever, since both it's an actual throwable object type & this makes it get sneak attacks when theoretically miska offhanded (since no wornmask htere).

Draw initial window boxes correctly in curses with certain options: !legacy and some other ways could make this not render the box around the prev msg window & some other ones, without this.

Scorpion Carapace plates upgrade now correctly gets +5/5 from plates upgrade, not set to 7/7: Reported by Zoe on github