### PR TITLE
Adjust plane of water to use PUDDLE terrain for the inside of bubbles

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -223,7 +223,7 @@
  * "cover" any objects or traps that might be there.
  */
 #define covers_objects(xx,yy)						      \
-    ((is_pool(xx,yy, FALSE) && !Underwater && !Is_waterlevel(&u.uz)) || (levl[xx][yy].typ == LAVAPOOL))
+    ((is_pool(xx,yy, FALSE) && !Underwater) || (levl[xx][yy].typ == LAVAPOOL))
 
 #define covers_traps(xx,yy)	covers_objects(xx,yy)
 

--- a/src/do.c
+++ b/src/do.c
@@ -69,7 +69,7 @@ boolean pushing;
 {
 	if (!otmp || !is_boulder(otmp))
 	    impossible("Not a boulder?");
-	else if (!Is_waterlevel(&u.uz) && (is_pool(rx,ry, FALSE) || is_lava(rx,ry))) {
+	else if (is_pool(rx,ry, FALSE) || is_lava(rx,ry)) {
 	    boolean lava = is_lava(rx,ry), cubewater = is_3dwater(rx, ry), fills_up;
 	    const char *what = waterbody_name(rx,ry);
 	    schar ltyp = levl[rx][ry].typ;

--- a/src/hack.c
+++ b/src/hack.c
@@ -2025,32 +2025,22 @@ stillinwater:;
 		} else if (!Wwalking && drown())
 		    return;
 	    } else if (IS_PUDDLE(levl[u.ux][u.uy].typ) && !Wwalking) {
-
-		/*You("%s through the shallow water.",
-		    verysmall(youmonst.data) ? "wade" : "splash");
-		if (!verysmall(youmonst.data) && !rn2(4)) wake_nearby();*/
-
-		if(u.umonnum == PM_GREMLIN)
-		    (void)split_mon(&youmonst, (struct monst *)0);
-		else if (is_iron(youracedata) &&
-			/* mud boots keep the feet dry */
-			(!uarmf || strncmp(OBJ_DESCR(objects[uarmf->otyp]), "mud ", 4))
-		) {
-		    int dam = rnd(6);
-		    Your("%s rust!", makeplural(body_part(FOOT)));
-		    if (u.mhmax > dam) u.mhmax -= dam;
-		    losehp(dam, "rusting away", KILLED_BY);
-		// } else if (is_longworm(youmonst.data)) { /* water is lethal to Shai-Hulud */
-		    // int dam = d(3,12);
-		    // if (u.mhmax > dam) u.mhmax -= (dam+1) / 2;
-	            // pline_The("water burns your flesh!");
-		    // losehp(dam,"contact with water",KILLED_BY);
-		}
-		if (verysmall(youmonst.data)) water_damage(invent, FALSE,FALSE,FALSE,(struct monst *) 0);
+			if(u.umonnum == PM_GREMLIN)
+				(void)split_mon(&youmonst, (struct monst *)0);
+			else if (is_iron(youracedata) &&
+				/* mud boots keep the feet dry */
+				(!uarmf || strncmp(OBJ_DESCR(objects[uarmf->otyp]), "mud ", 4))
+			) {
+				int dam = rnd(6);
+				Your("%s rust!", makeplural(body_part(FOOT)));
+				if (u.mhmax > dam) u.mhmax -= dam;
+				losehp(dam, "rusting away", KILLED_BY);
+			}
+			if (verysmall(youmonst.data)) water_damage(invent, FALSE,FALSE,FALSE,(struct monst *) 0);
 #ifdef STEED
-		if (!u.usteed)
+			if (!u.usteed && (is_rustprone(uarmf) && !uarmf->oerodeproof && uarmf->oeroded != MAX_ERODE))
 #endif
-			(void)rust_dmg(uarmf, "boots", 1, TRUE, &youmonst, FALSE);
+				(void)rust_dmg(uarmf, "boots", 1, TRUE, &youmonst, FALSE);
 	    }
 		if (uarmf && uarmf->oartifact == ART_FROST_TREADS
 			&& is_pool(u.ux, u.uy, TRUE) && !is_3dwater(u.ux, u.uy) && !Is_waterlevel(&u.uz)) {
@@ -2495,7 +2485,7 @@ dopickup()
 		return loot_mon(u.ustuck, &tmpcount, (boolean *)0);
 	    }
 	}
-	if(is_pool(u.ux, u.uy, FALSE) && !is_3dwater(u.ux, u.uy) && !Is_waterlevel(&u.uz)) {//pools (bubble interior) on water level are special
+	if(is_pool(u.ux, u.uy, FALSE) && !is_3dwater(u.ux, u.uy)) {
 	    if (Wwalking || mon_resistance(&youmonst,LEVITATION) || is_clinger(youracedata)
 			|| (Flying && !Breathless)) {
 		You("cannot dive into the water to pick things up.");

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1843,7 +1843,7 @@ register xchar x, y;
 		|| IS_FURNITURE(levl[x][y].typ)
 		|| IS_ROCK(levl[x][y].typ)
 		|| is_lava(x,y)
-		|| (is_pool(x,y, FALSE) && (!Is_waterlevel(&u.uz) || is_3dwater(x,y)))
+		|| is_pool(x,y, FALSE)
 		|| invocation_pos(x,y)
 		));
 }

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -2359,13 +2359,14 @@ boolean ini;
 
 	/* void positions inside bubble */
 
-	for (i = 0, x = b->x; i < (int) b->bm[0]; i++, x++)
+	for (i = 0, x = b->x; i < (int) b->bm[0]; i++, x++){
 	    for (j = 0, y = b->y; j < (int) b->bm[1]; j++, y++)
 		if (b->bm[j + 2] & (1 << i)) {
-		    levl[x][y].typ = MOAT;//was ROOM;// was AIR
+		    levl[x][y].typ = PUDDLE;//was ROOM;// was AIR
 		    levl[x][y].lit = 1;
 		    // unblock_point(x,y);
 		}
+	}
 
 	/* replace contents of bubble */
 	for (cons = b->cons; cons; cons = ctemp) {

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -3209,7 +3209,7 @@ postmov:
 			(mtmp->mcanmove && mtmp->mnotlaugh && !mtmp->msleeping && rn2(5)))
 		    mtmp->mundetected = (!is_underswimmer(ptr)) ?
 			OBJ_AT(mtmp->mx, mtmp->my) :
-			(is_pool(mtmp->mx, mtmp->my, FALSE) && !Is_waterlevel(&u.uz));
+			is_pool(mtmp->mx, mtmp->my, FALSE);
 		newsym(mtmp->mx, mtmp->my);
 	    }
 	    if (mtmp->isshk) {


### PR DESCRIPTION
Also change the behavior of rust damage via puddle to NOT message when you step in them with non-rustable boots on, since it's really message spammy in certain areas (like the new plane of water bubble puddles).

Fixes up a bunch of other now-unnecessary `is_pool` checks, since `PUDDLE` is a different terrain type, and only is checked if you're calling `is_pool(..., TRUE)`. A bunch of these were things that assume real pools are water you fall into or similar, or 3d water rules, which obviously don't matter on the water plane.