### PR TITLE
Add classic_colors, SETCOLOR, and RESETCOLOR options to better handle custom colors in Curses

### DIFF
--- a/include/color.h
+++ b/include/color.h
@@ -98,5 +98,13 @@ struct text_color_option {
 };
 #endif
 
+struct rgb_color_option {
+	int color;
+	int r;
+	int g;
+	int b;
+
+	struct rgb_color_option *next;
+};
 
 #endif /* COLOR_H */

--- a/include/flag.h
+++ b/include/flag.h
@@ -248,6 +248,7 @@ struct instance_flags {
 	boolean  cbreak;	/* in cbreak mode, rogue format */
 #ifdef CURSES_GRAPHICS
 	boolean  classic_status;	/* What kind of horizontal statusbar to use */
+	boolean  classic_colors; 	/* Use traditional curses colors (normally terminal settings)? */
 	boolean  cursesgraphics;	/* Use portable curses extended characters */
 #endif
 	boolean  DECgraphics;	/* use DEC VT-xxx extended character set */

--- a/include/wintty.h
+++ b/include/wintty.h
@@ -151,6 +151,8 @@ E int FDECL(has_color,(int color));
 
 #ifdef STATUS_COLORS
 E boolean FDECL(parse_status_color_options, (char *));
+E boolean FDECL(parse_setcolor, (char *));
+E boolean FDECL(parse_resetcolor, (char *));
 #endif /* STATUS_COLOR */
 
 /* ### topl.c ### */

--- a/src/files.c
+++ b/src/files.c
@@ -2086,6 +2086,10 @@ char		*tmp_levels;
 #if defined(STATUS_COLORS) && defined(TEXTCOLOR)
             (void) parse_status_color_options(bufp);
 #endif
+	} else if (match_varname(buf, "SETCOLOR", 8)) {
+	    (void) parse_setcolor(bufp);
+	} else if (match_varname(buf, "RESETCOLOR", 10)) {
+	    (void) parse_resetcolor(bufp);
 	} else if (match_varname(buf, "DUNGEON", 4)) {
 	    len = get_uchars(fp, buf, bufp, translate, FALSE,
 			     MAXDCHARS, "DUNGEON");

--- a/src/options.c
+++ b/src/options.c
@@ -80,6 +80,7 @@ static struct Bool_Opt
 #endif
 #ifdef CURSES_GRAPHICS
 	{"classic_status", &iflags.classic_status, TRUE, SET_IN_FILE},
+	{"classic_colors", &iflags.classic_colors, TRUE, SET_IN_FILE},
 #endif
 	{"cmdassist", &iflags.cmdassist, TRUE, SET_IN_GAME},
 # if defined(MICRO) || defined(WIN32) || defined(CURSES_GRAPHICS)

--- a/win/curses/cursinit.c
+++ b/win/curses/cursinit.c
@@ -34,6 +34,10 @@ static void set_window_position(int *, int *, int *, int *, int,
 
 /* array to save initial terminal colors for later restoration */
 
+extern struct rgb_color_option *setcolor_opts;
+extern struct rgb_color_option *resetcolor_opts;
+
+
 typedef struct nhrgb_type {
     short r;
     short g;
@@ -426,11 +430,14 @@ curses_init_nhcolors()
         }
 
         if (can_change_color()) {
-            if (iflags.classic_colors == TRUE){
-                for (int nclr = 0; nclr < cnum; nclr++){
-                    color_content(clr_remap[nclr], &(orig_colors[nclr].r), &(orig_colors[nclr].g), &(orig_colors[nclr].b));
+            for (int nclr = 0; nclr < cnum; nclr++){
+                color_content(clr_remap[nclr], &(orig_colors[nclr].r), &(orig_colors[nclr].g), &(orig_colors[nclr].b));
+                if (iflags.classic_colors == TRUE)
                     init_color(clr_remap[nclr], default_colors[nclr].r, default_colors[nclr].g, default_colors[nclr].b);
-                }
+            }
+
+            for (struct rgb_color_option* curr = setcolor_opts; curr; curr = curr->next){
+                init_color(curr->color, curr->r, curr->g, curr->b);
             }
 # ifdef USE_DARKGRAY
             if (COLORS > 16) {
@@ -1130,10 +1137,12 @@ curses_cleanup()
             COLOR_BLUE + 8,
             COLOR_MAGENTA + 8, COLOR_CYAN + 8, COLOR_WHITE + 8
         };
-        if (iflags.classic_colors == TRUE){
-            for (int nclr = 0; nclr < cnum; nclr++){
-                init_color(clr_remap[nclr], orig_colors[nclr].r, orig_colors[nclr].g, orig_colors[nclr].b);
-            }
+        for (int nclr = 0; nclr < cnum; nclr++){
+            init_color(clr_remap[nclr], orig_colors[nclr].r, orig_colors[nclr].g, orig_colors[nclr].b);
+        }
+
+        for (struct rgb_color_option* curr = resetcolor_opts; curr; curr = curr->next){
+            init_color(curr->color, curr->r, curr->g, curr->b);
         }
 # ifdef USE_DARKGRAY
         if (COLORS > 16) {

--- a/win/curses/cursinit.c
+++ b/win/curses/cursinit.c
@@ -10,7 +10,7 @@
 
 /* Global curses variables extern'd in wincurs.h */
 boolean counting;
-int orig_cursor;	         /* Preserve initial cursor state */
+int orig_cursor;             /* Preserve initial cursor state */
 int term_rows, term_cols; /* size of underlying terminal */
 
 WINDOW *base_term;    /* underlying terminal window */
@@ -41,6 +41,27 @@ typedef struct nhrgb_type {
 } nhrgb;
 
 nhrgb orig_darkgray;
+
+nhrgb default_colors[16] = {
+    {50  , 50  , 50  }, // black
+    {1000, 0   , 0   }, // red
+    {75  , 630 , 55  }, // green
+    {480 , 290 , 0   }, // yellow (brown)
+    {0   , 215 , 855 }, // blue
+    {530 , 90  , 600  }, // magenta (purple)
+    {215 , 560 , 823 }, // cyan
+    {800 , 800 , 800 }, // white
+    {0   , 0   , 0   }, // bright black (no color)
+    {1000, 500 , 0   }, // bright red (orange)
+    {0   , 1000, 0   }, // bright green
+    {1000, 1000, 0   }, // bright yellow (yellow)
+    {0   , 0   , 1000}, // bright blue
+    {1000, 0   , 1000}, // bright magenta
+    {0   , 1000, 1000}, // bright cyan
+    {1000, 1000, 1000}  // bright white
+};
+
+nhrgb orig_colors[16];
 
 /* Banners used for an optional ASCII splash screen */
 
@@ -405,6 +426,12 @@ curses_init_nhcolors()
         }
 
         if (can_change_color()) {
+            if (iflags.classic_colors == TRUE){
+                for (int nclr = 0; nclr < cnum; nclr++){
+                    color_content(clr_remap[nclr], &(orig_colors[nclr].r), &(orig_colors[nclr].g), &(orig_colors[nclr].b));
+                    init_color(clr_remap[nclr], default_colors[nclr].r, default_colors[nclr].g, default_colors[nclr].b);
+                }
+            }
 # ifdef USE_DARKGRAY
             if (COLORS > 16) {
                 color_content(CURSES_DARK_GRAY, &orig_darkgray.r,
@@ -796,34 +823,34 @@ curses_choose_character()
         }
     }
 
-	/* Select descendant status, if necessary */
+    /* Select descendant status, if necessary */
     if (flags.descendant < 0){
-		if (flags.descendant == ROLE_RANDOM || flags.randomall || flags.initrole < 0 || !validdescendant(flags.initrole)) {
+        if (flags.descendant == ROLE_RANDOM || flags.randomall || flags.initrole < 0 || !validdescendant(flags.initrole)) {
            flags.descendant = 0; // never randomly roll descendant
         } else {
             /* Always 2 options - yn */
             choices = (const char **) alloc(sizeof (char *) * (3));
             pickmap = (int *) alloc(sizeof (int) * (3));
-			char * terms[] = {"Inherit from a past adventurer (start with an heirloom artifact but low stats and dangerous foes)",
-								"No past inheritance", '\0'};
+            char * terms[] = {"Inherit from a past adventurer (start with an heirloom artifact but low stats and dangerous foes)",
+                                "No past inheritance", '\0'};
 
             for (i = 0; i < 2; i++) {
-				choices[i] = terms[i];
-				pickmap[i] = i;
+                choices[i] = terms[i];
+                pickmap[i] = i;
             }
             choices[i] = (const char *) 0;
 
-			sel = curses_character_dialog(choices, "Choose one of the following inheritances:");
+            sel = curses_character_dialog(choices, "Choose one of the following inheritances:");
             if (sel >= 0) sel = pickmap[sel];
             else if (sel == ROLE_NONE) {        /* Quit */
                 clearlocks();
                 curses_bail(0);
             }
 
-			/* invert y/n for the sanity for putting "yes" as the first option, but 0 as the default */
-			if (sel == 0) sel = 1;
-			else if (sel == 1) sel = 0;
-			else if (sel == ROLE_RANDOM) sel = rn2(2);
+            /* invert y/n for the sanity for putting "yes" as the first option, but 0 as the default */
+            if (sel == 0) sel = 1;
+            else if (sel == 1) sel = 0;
+            else if (sel == ROLE_RANDOM) sel = rn2(2);
 
             flags.descendant = sel;
             free(choices);
@@ -1094,6 +1121,20 @@ curses_cleanup()
 {
 #ifdef TEXTCOLOR
     if (has_colors() && can_change_color()) {
+        int cnum = COLORS >= 16 ? 16 : 8;
+        int clr_remap[16] = {
+            COLOR_BLACK, COLOR_RED, COLOR_GREEN, COLOR_YELLOW,
+            COLOR_BLUE,
+            COLOR_MAGENTA, COLOR_CYAN, -1, COLOR_WHITE,
+            COLOR_RED + 8, COLOR_GREEN + 8, COLOR_YELLOW + 8,
+            COLOR_BLUE + 8,
+            COLOR_MAGENTA + 8, COLOR_CYAN + 8, COLOR_WHITE + 8
+        };
+        if (iflags.classic_colors == TRUE){
+            for (int nclr = 0; nclr < cnum; nclr++){
+                init_color(clr_remap[nclr], orig_colors[nclr].r, orig_colors[nclr].g, orig_colors[nclr].b);
+            }
+        }
 # ifdef USE_DARKGRAY
         if (COLORS > 16) {
             init_color(CURSES_DARK_GRAY, orig_darkgray.r,


### PR DESCRIPTION
[Add classic_colors option for curses to use "classic" nethack colors](https://github.com/Chris-plus-alphanumericgibberish/dNAO/commit/591c9510b6d5e082d962dc4eb1893a8d23a33ad3)

This adds an option to ignore terminal color settings and instead default to 'normal' colors as far as nethack is concerned.

This mostly includes specific definitions for yellow (as brown) and bright red (as orange) which are decidedly non-standard for 16 color terminals, and some specific ideas of 'bright' colors as saturated rather than pastel - so cyan is teal and bright cyan is cyan, for example.

This should cleanup & restore fine on terminals that read 16 colors into curses, but has the same extant bug of not resetting the 8 bright colors for some terminals that only read colors 0-7 into curses. There is no clean solution for this, curses does not support one. Noisy suggested a potential solution of adding a RESETCOLOR option to set which color to restore state to, which is probably the best option. I'll probably implement that later.

[Add SETCOLOR/RESETCOLOR options for custom-defined colors](https://github.com/Chris-plus-alphanumericgibberish/dNAO/commit/6757a181bc7cc214d37a244340ccf60ac015f5f5)

Now, you can override certain colors to be your desired colors, and set RESETCOLOR to make up for curses' inability to figure out what your terminal looked like beforehand.

Syntax for both is 
```py
RESETCOLOR=lightblue:#00FF99
SETCOLOR=magenta:255 0 180
```

They accept both hex codes (prefixed with #, should be case insensitive I believe) or a triad of decimal numbers. The decimal numbers are NOT clamped, but are cast to ints immediately (read as longs) and then multiplied by a factor of 1000/255 to turn them into curses-approved colors. Curses handles any OOB numbers - they'll just fail silently. Hex codes physically can't be out of bounds, since they just only look at certain bits. No clue what happens if you try to feed it a number bigger than a C long. I also decided to not allow varying scales for inputs, just use 255 based colors.

The color names are identical to what nethack uses, but accept either `light` or `bright` for the brighter versions of each color. Any order will work for these options, you don't need to put any colors before others. Set colors will override terminal default or the classic colors option, and reset colors will override whatever your terminal started with before.

List of color names: (first word is the name, second word is the 'palette name' for the color)
```css
black
red
green
brown (dark yellow)
blue
magenta
cyan
gray (dark white)

orange (bright red)
brightgreen
lightgreen (also bright green)
yellow (bright yellow)
brightblue
lightblue (also bright blue)
brightmagenta
lightmagenta (also bright magenta)
brightcyan
lightcyan (also bright cyan)
white (bright white)
```

Note that nethack doesn't use 'bright black' for anything, so any attempts to set it will give a bad option message. Redefining the same color, by either a duplicate line with the same color name or another name for the same color (like bright foo & light foo) will use the latter of the wto lines.

----

Note: none of this does anything for tty. All of this is entirely based around the Curses handling for custom colors - I don't think tty supports that very well, but I personally don't use it and haven't looked at the code, so there's probably a reasonable alternative.