### PR TITLE
ScienceBall's misc dnh fixes

### DIFF
--- a/dat/neutrality.des
+++ b/dat/neutrality.des
@@ -1068,6 +1068,7 @@ MONSTER[10%]:'s',"man-faced millipede",random
 MONSTER[10%]:'{',"mirrored moonflower",random
 MONSTER[10%]:'w',"crimson writher",random
 MONSTER[10%]:'p',"radiant pyramid",random
+MONSTER[10%]:'g',"grotesque peeper",random
 
 #
 #	The Ogre Stockade for the Lethe branch.
@@ -2845,6 +2846,7 @@ MONSTER[75%]:'s',"man-faced millipede",random
 MONSTER[75%]:'{',"mirrored moonflower",random
 MONSTER[75%]:'w',"crimson writher",random
 MONSTER[75%]:'p',"radiant pyramid",random
+MONSTER[75%]:'g',"grotesque peeper",random
 
 #
 # An alternate introductory level...
@@ -2991,6 +2993,7 @@ MONSTER[75%]:'s',"man-faced millipede",random
 MONSTER[75%]:'{',"mirrored moonflower",random
 MONSTER[75%]:'w',"crimson writher",random
 MONSTER[75%]:'p',"radiant pyramid",random
+MONSTER[75%]:'g',"grotesque peeper",random
 
 #
 # The level with the alhoon's fortress...
@@ -3176,6 +3179,7 @@ MONSTER[75%]:'s',"man-faced millipede",random
 MONSTER[75%]:'{',"mirrored moonflower",random
 MONSTER[75%]:'w',"crimson writher",random
 MONSTER[75%]:'p',"radiant pyramid",random
+MONSTER[75%]:'g',"grotesque peeper",random
 
 #
 # A third gulf level...
@@ -3347,6 +3351,7 @@ MONSTER[75%]:'s',"man-faced millipede",random
 MONSTER[75%]:'{',"mirrored moonflower",random
 MONSTER[75%]:'w',"crimson writher",random
 MONSTER[75%]:'p',"radiant pyramid",random
+MONSTER[75%]:'g',"grotesque peeper",random
 
 #
 #
@@ -3497,6 +3502,7 @@ MONSTER[75%]:'s',"man-faced millipede",random
 MONSTER[75%]:'{',"mirrored moonflower",random
 MONSTER[75%]:'w',"crimson writher",random
 MONSTER[75%]:'p',"radiant pyramid",random
+MONSTER[75%]:'g',"grotesque peeper",random
 
 #	Cthulhu's Sanctum
 #

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -2524,7 +2524,7 @@ u_init()
 			HTelepat |= FROMOUTSIDE;
 			skill_add(Skill_Elf_Ana);
 		}
-		if(Race_if(PM_ELF)){
+		if(Role_if(PM_HEALER)){
 			u.ualign.type = A_NEUTRAL;
 			u.ualign.god = u.ugodbase[UGOD_CURRENT] = u.ugodbase[UGOD_ORIGINAL] = align_to_god(u.ualign.type);
 			flags.initalign = 1; // 1 == neutral

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -13675,8 +13675,8 @@ int vis;						/* True if action is at all visible to the player */
 			(mdef->mattackedu || !rn2(5))) ||	// (odds reduced by 80% when not counterattacking)
 			// Juyo 
 			(ulightsaberhit && activeFightingForm(FFORM_JUYO) &&
-			(snekdmg > 0) && (dieroll < min(P_SKILL(P_JUYO), P_SKILL(weapon_type(uwep)))) &&
-			((sneak_attack&SNEAK_JUYO) || (rn2(5) < 2)))	// (odds reduced by 60% when not sneak attacking)
+			(dieroll < min(P_SKILL(P_JUYO), P_SKILL(weapon_type(uwep)))) &&
+			((sneak_attack&~SNEAK_JUYO) || (rn2(5) < 2)))	// (odds reduced by 60% when not sneak attacking)
 			)
 		{
 			staggering_strike = TRUE;
@@ -15160,7 +15160,7 @@ int vis;						/* True if action is at all visible to the player */
 					if ((activeFightingForm(FFORM_SHII_CHO) ||
 						(activeFightingForm(FFORM_JUYO))
 						) &&
-						(sneak_attack != 0)	/* attacking a disadvantaged target, but might not have sneak dice */
+						(sneak_attack&~SNEAK_JUYO)	/* attacking a disadvantaged target, but might not have sneak dice */
 						) use_skill(P_JUYO, 1);
 				}
 			}


### PR DESCRIPTION
code by riker, bug detection entirely by ScienceBall, they're a real one

juyo training & stagger logic was bad - needs to check sneak attacks not counting itself properly, and also not check sneak damage so that we can stagger on non-sneak-attacks

gross peepers didn't spawn, even though they now worked. the most unremarkable glyph is now back (+9/+6/+4 accuracy at xp30 for full/three-quarters/half BAB roles?)

all elves are not neutral.