### PR TITLE
Change polyform max hp to factor in player level more directly and ad…

### DIFF
--- a/src/exper.c
+++ b/src/exper.c
@@ -290,10 +290,25 @@ boolean expdrain; /* attack drains exp as well */
 	u.uhprolled -= num;
 	if (u.uhprolled < 1) u.uhprolled = 1;
 	u.uhp -= num + conplus(ACURR(A_CON));
+
+	if (Upolyd) {
+		/* loosely - pretends you rolled exactly average on every hit die
+		 * will therefore average out over all levels, making it functionally impossible
+		 * to drain4gain with polyforms past a certain maximum value
+		 */
+		num = u.mhrolled / (u.ulevel + mons[u.umonnum].mlevel);
+		u.mhrolled -= num;
+		u.mh -= num + conplus(ACURR(A_CON));
+		if((int)(conplus(ACURR(A_CON))) != conplus(ACURR(A_CON))){
+			/* Remainder (just lose an extra HP of healing)*/
+			u.mh--;
+		}
+	}
+
 	calc_total_maxhp();
 	
 	if (u.uhp < 1) u.uhp = 1;
-
+	if (u.mh < 1) u.mh = 1;
 	
 	num = newen();
 	u.uenrolled -= num;

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -526,19 +526,21 @@ int	mntmp;
 	
 	if (nohands(youmonst.data) || nolimbs(youmonst.data)) Glib = 0;
 
-	/*
-	mlvl = adj_lev(&mons[mntmp]);
-	 * We can't do the above, since there's no such thing as an
-	 * "experience level of you as a monster" for a polymorphed character.
+	/* Combine both current level & monster base level when factoring initial polyform hp,
+	 * this is to allow for a 'correct' hp value for all players at lvl X and polyform Y to have,
+	 * regardless of when they polymorphed into that monster (since players gain polyform hp
+	 * from leveling up, this needs to be factored in).
 	 */
-	mlvl = (int)mons[mntmp].mlevel;
+	mlvl = (int)mons[mntmp].mlevel + (int)u.ulevel;
+	int hds = hd_size(&mons[mntmp]);
+
 	if (youmonst.data->mlet == S_DRAGON && mntmp >= PM_GRAY_DRAGON) {
-		u.mhrolled = In_endgame(&u.uz) ? (8*mlvl) : (4*mlvl + d(mlvl,4));
+		u.mhrolled = In_endgame(&u.uz) ? (hds*mlvl) : ((hds/2)*mlvl + d(mlvl,(hds/2)));
 	} else if (is_golem(youmonst.data)) {
 		u.mhrolled = golemhp(mntmp);
 	} else {
-		if (!mlvl) u.mhrolled = rnd(4);
-		else u.mhrolled = d(mlvl, 8);
+		if (!mlvl) u.mhrolled = rnd(hds/2);
+		else u.mhrolled = d(mlvl, hds);
 		if (is_home_elemental(&mons[mntmp])) u.mhrolled *= 3;
 	}
 	calc_total_maxhp();


### PR DESCRIPTION
…just drain mechanics

Polyself now takes into consideration both player level & form level when calculating hp. This has two major effects from the previous behavior:

- Polyforms now have more hp across the board,one hit die per player level, so on average 135 more hp at level 30 for d8 hit dice. This is a notable buff to certain polyforms, most notably very large ones (since this factors in hd_size, a lurking one gets 30d20 (315) more hp vs a dark young getting 30d12 (195) more hp). This also 'fixes' polyform hp to be based off of hit dice in general, previously the player always got d8s off the initial polyform but used the appropriate die size when leveling up while polymorphed
- Losing a level while polymorphed now reduces your hp by the average rolled hp across all of your levels. This means that you'll tend aggressively towards 'average' hp if you drain4gain. The alternative is losing a normal hit dice every level lost, but that can reduce hp a little too much if you roll poorly since hpmax is capped oddly I think.

In short - polyform max HP went up, drain4gain polyform max HP went wayyyy down.

Alternative solutions: detach player level & polyform level, so that gaining a player level does not affect your polyform hp. I considered this, but I decided on "~500 hp is cheap if you optimize, and there's no need to make low-level polymorph forms even more unusable than they currently are." I also considered trying to average the levels, or cap them at 45, but decided that was more trouble than it was worth.

Also, something's up with bonus HP & polyform max hp. I haven't touched that at ALL, but if when I drink !oFH until I stop getting HP as a lurking one human wiz with 25 con, I capped out at exactly 1778 hp. If you repoly, you'll cap out at 1221 or something. I don't know why, my guess is the "gain bonus hp" code vs. the 'recalc max hp on form shift' code disagree when polymorphed.