### PR TITLE
Adjust exclusivity for knight/gith forms, auto-clear stale fighting forms

### DIFF
--- a/include/artifact.h
+++ b/include/artifact.h
@@ -344,6 +344,7 @@ struct artinstance{
 #define SnSd3 avar3
 #define IbiteBoons avar3
 #define CarapacePoints avar3
+#define GithStylesSeen avar3
 	long avar4;
 #define SnSd3duration avar4
 #define CarapaceAura avar4

--- a/include/skills.h
+++ b/include/skills.h
@@ -118,7 +118,7 @@
 #define martial_bonus()	(u.umartial || Earth_crystal)
 
 /* Fighting form IDs */
-/* each batch of 32 is mutually exclusive, but not with other batches */
+/* each batch of 16 is mutually exclusive, but not with other batches */
 #define NO_FFORM		0
 
 #define FFORM_SHII_CHO	1
@@ -132,15 +132,17 @@
 #define FIRST_LS_FFORM	FFORM_SHII_CHO
 #define LAST_LS_FFORM	FFORM_JUYO
 
-#define FFORM_SHIELD_BASH 	(1 + 32)
-#define FFORM_GREAT_WEP		(2 + 32)
-#define FFORM_HALF_SWORD 	(3 + 32)
-#define FFORM_POMMEL 		(4 + 32)
-#define FFORM_KNI_SACRED	(5 + 32)
-#define FFORM_KNI_ELDRITCH	(6 + 32)
-#define FFORM_KNI_RUNIC		(7 + 32)
-#define FIRST_KNI_FFORM		FFORM_SHIELD_BASH
-#define LAST_KNI_FFORM		FFORM_KNI_RUNIC
+#define FFORM_SHIELD_BASH 	(1 + 16)
+#define FFORM_GREAT_WEP		(2 + 16)
+#define FFORM_HALF_SWORD 	(3 + 16)
+#define FFORM_POMMEL 		(4 + 16)
+#define FFORM_KNI_SACRED	(1 + 32)
+#define FFORM_KNI_ELDRITCH	(2 + 32)
+#define FFORM_KNI_RUNIC		(3 + 32)
+#define FIRST_BASIC_KNI_FFORM		FFORM_SHIELD_BASH
+#define LAST_BASIC_KNI_FFORM		FFORM_POMMEL
+#define FIRST_ADV_KNI_FFORM			FFORM_KNI_SACRED
+#define LAST_ADV_KNI_FFORM			FFORM_KNI_RUNIC
 
 #define LAST_FFORM		FFORM_KNI_RUNIC
 

--- a/include/you.h
+++ b/include/you.h
@@ -325,7 +325,7 @@ struct you {
 #define DEFAULT_HMAX	2000
 	unsigned uhs;		/* hunger state - see eat.c */
 
-#define FFORM_LISTSIZE	(LAST_FFORM/32 + 1)
+#define FFORM_LISTSIZE	(LAST_FFORM/16 + 1)
 	unsigned long int fightingForm[FFORM_LISTSIZE];/* special properties */
 	int ueldritch_style;
 	Bitfield(uavoid_passives,1);

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -483,6 +483,19 @@ mercurial_repair()
 
 STATIC_OVL
 void
+clear_stale_fforms()
+{
+	for(int fform = NO_FFORM+1; fform <= LAST_FFORM; fform++){
+		if (!!(u.fightingForm[(fform-1)/16] & (0x1L << ((fform-1)%16))) && FightingFormSkillLevel(fform) <= P_ISRESTRICTED){
+			unSetFightingForm(fform);
+			You("readjust your stance.");
+		}
+	}
+}
+
+
+STATIC_OVL
+void
 clothes_bite_you()
 {
 	struct obj * uequip[] = WORN_SLOTS;
@@ -2864,6 +2877,7 @@ karemade:
 			androidUpkeep();
 			clothes_bite_you();
 			mercurial_repair();
+			clear_stale_fforms();
 
 		    if(!(Invulnerable)) {
 			if(Teleportation && !rn2(85) && !(

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2082,6 +2082,13 @@ boolean mod;
 				if(otmp->oartifact == ART_SCORPION_CARAPACE){
 					artinstance[ART_SCORPION_CARAPACE].CarapaceLevel = 10;//Starts off at "10th level" Max upgrade points is therefor 20, and it takes a while to earn the first
 				}
+				if(otmp->oartifact == ART_SILVER_SKY){
+					artinstance[ART_SILVER_SKY].GithStyle = 0;
+					artinstance[ART_SILVER_SKY].GithStylesSeen = 0;
+				}
+				if(otmp->oartifact == ART_SKY_REFLECTED){
+					artinstance[ART_SKY_REFLECTED].ZerthUpgrades = 0;
+				}
 			}
 			if(otmp->oartifact && (get_artifact(otmp)->inv_prop == NECRONOMICON || get_artifact(otmp)->inv_prop == SPIRITNAMES)){
 				otmp->ovar1_necronomicon = 0;//used to track special powers, via flags

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -2015,7 +2015,7 @@ boolean
 activeMentalEdge(fform)
 int fform;
 {
-	return (artinstance[ART_SILVER_SKY].GithStyle == fform && !blockedMentalEdge(fform));
+	return ((artinstance[ART_SILVER_SKY].GithStyle & (1 << fform)) != 0 && !blockedMentalEdge(fform));
 }
 
 boolean

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1978,16 +1978,19 @@ int fform;
 	if (fform >= FIRST_LS_FFORM && fform <= LAST_LS_FFORM){
 		first = FIRST_LS_FFORM;
 		last = LAST_LS_FFORM;
-	} else if (fform >= FIRST_KNI_FFORM && fform <= LAST_KNI_FFORM){
-		first = FIRST_KNI_FFORM;
-		last = LAST_KNI_FFORM;
+	} else if (fform >= FIRST_BASIC_KNI_FFORM && fform <= LAST_BASIC_KNI_FFORM){
+		first = FIRST_BASIC_KNI_FFORM;
+		last = LAST_BASIC_KNI_FFORM;
+	} else if (fform >= FIRST_ADV_KNI_FFORM && fform <= LAST_ADV_KNI_FFORM){
+		first = FIRST_ADV_KNI_FFORM;
+		last = LAST_ADV_KNI_FFORM;
 	} else {
 		first = 0;
-		last = FFORM_LISTSIZE*32;
+		last = FFORM_LISTSIZE*16;
 	}
 
-	/* this code assumes that each batch of 32 fighting forms are mutually exclusive, but not with other batches of 32 */
-	for(i=first/32; i <= last/32; i++)
+	/* this code assumes that each batch of 16 fighting forms are mutually exclusive, but not with other batches of 16 */
+	for(i=first/16; i <= last/16; i++)
 		u.fightingForm[i] = 0L;
 
 }
@@ -1996,9 +1999,9 @@ void
 setFightingForm(fform)
 int fform;
 {
-	/* this code assumes that each batch of 32 fighting forms are mutually exclusive, but not with other batches of 32 */
+	/* this code assumes that each batch of 16 fighting forms are mutually exclusive, but not with other batches of 16 */
 	unSetFightingForm(fform);
-	u.fightingForm[(fform-1)/32] |= (0x1L << ((fform-1)%32));
+	u.fightingForm[(fform-1)/16] |= (0x1L << ((fform-1)%16));
 }
 
 boolean
@@ -2033,7 +2036,7 @@ int fform;
 		return TRUE; //Found no fighting forms, return TRUE
 	}
 	
-	return !!(u.fightingForm[(fform-1)/32] & (0x1L << ((fform-1)%32)));
+	return !!(u.fightingForm[(fform-1)/16] & (0x1L << ((fform-1)%16)));
 }
 
 int

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1296,13 +1296,13 @@ doGithForm()
 
 
 	for (i = FIRST_GSTYLE; i <= LAST_GSTYLE; i++) {
-		if (i == GSTYLE_RESONANT && (u.ulevel < 30 || u.uinsight < 81))
+		if (i == GSTYLE_RESONANT && (u.ulevel < 30 || u.uinsight < 81) && (artinstance[ART_SILVER_SKY].GithStylesSeen & 2) == 0)
 			continue;
-		if (i == GSTYLE_COLD && u.uinsight < 9)
+		if (i == GSTYLE_COLD && u.uinsight < 9 && (artinstance[ART_SILVER_SKY].GithStylesSeen & 1) == 0)
 			continue;
 
 		/* knight forms are shown if unskilled but not restricted, since training involves starting from unskilled */
-		boolean active = artinstance[ART_SILVER_SKY].GithStyle == i;
+		boolean active = (artinstance[ART_SILVER_SKY].GithStyle & (1 << i)) != 0;
 		boolean blocked = blockedMentalEdge(i);
 
 		Strcpy(buf, nameOfMentalEdge(i));
@@ -1312,7 +1312,9 @@ doGithForm()
 		else if (i == GSTYLE_PENETRATE)
 			block_reason = "lack of hate";
 		else if (i == GSTYLE_COLD)
-			block_reason = "lack of wrath";
+			block_reason = (u.uinsight < 9) ? "lack of knowledge" : "lack of wrath";
+		else if (i == GSTYLE_RESONANT)
+			block_reason = (u.ulevel < 30) ? "lack of skill" : ((u.uinsight < 81) ? "lack of knowledge" : "lack of mental discipline");
 		else
 			block_reason = "lack of mental discipline";
 
@@ -1344,12 +1346,21 @@ doGithForm()
 
 	if(n <= 0){
 		return MOVE_CANCELLED;
-	} else if (artinstance[ART_SILVER_SKY].GithStyle == selected[0].item.a_int) {
-		artinstance[ART_SILVER_SKY].GithStyle = 0;
+	} else if ((artinstance[ART_SILVER_SKY].GithStyle&(1 << selected[0].item.a_int)) != 0) {
+		artinstance[ART_SILVER_SKY].GithStyle &= ~(1 << selected[0].item.a_int);
 		free(selected);
 		return MOVE_INSTANT;
 	} else {
-		artinstance[ART_SILVER_SKY].GithStyle = selected[0].item.a_int;
+		if (selected[0].item.a_int == GSTYLE_COLD || selected[0].item.a_int == GSTYLE_PENETRATE)
+			artinstance[ART_SILVER_SKY].GithStyle &= ~((1 << GSTYLE_PENETRATE) | (1 << GSTYLE_COLD));
+		else
+			artinstance[ART_SILVER_SKY].GithStyle &= ~((1 << GSTYLE_DEFENSE) | (1 << GSTYLE_ANTIMAGIC) | (1 << GSTYLE_RESONANT));
+
+		artinstance[ART_SILVER_SKY].GithStyle |= (1 << selected[0].item.a_int);
+
+		if (selected[0].item.a_int == GSTYLE_RESONANT) artinstance[ART_SILVER_SKY].GithStylesSeen |= 2;
+		if (selected[0].item.a_int == GSTYLE_COLD) artinstance[ART_SILVER_SKY].GithStylesSeen |= 1;
+
 		free(selected);
 		return MOVE_INSTANT;
 	}

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1180,11 +1180,11 @@ doKnightForm()
 	int curskill;
 	char* block_reason;
 
-	for (i = FIRST_KNI_FFORM; i <= LAST_KNI_FFORM; i++) {
+	for (i = FIRST_BASIC_KNI_FFORM; i <= LAST_ADV_KNI_FFORM; i++) {
+		if (i > LAST_BASIC_KNI_FFORM && i < FIRST_ADV_KNI_FFORM) continue;
 		if (FightingFormSkillLevel(i) >= P_BASIC)
 			remotely_competent = TRUE;
 	}
-
 	tmpwin = create_nhwindow(NHW_MENU);
 	start_menu(tmpwin);
 	any.a_void = 0;		/* zero out all bits */
@@ -1193,7 +1193,9 @@ doKnightForm()
 	add_menu(tmpwin, NO_GLYPH, &any, 0, 0, ATR_BOLD, buf, MENU_UNSELECTED);
 
 
-	for (i = FIRST_KNI_FFORM; i <= LAST_KNI_FFORM; i++) {
+	for (i = FIRST_BASIC_KNI_FFORM; i <= LAST_ADV_KNI_FFORM; i++) {
+		if (i > LAST_BASIC_KNI_FFORM && i < FIRST_ADV_KNI_FFORM) continue;
+
 		curskill = FightingFormSkillLevel(i);
 		if (curskill == P_ISRESTRICTED)
 			continue;
@@ -1456,7 +1458,8 @@ hasfightingforms(){
 			formmask |= LIGHTSABER_FORMS;
 	}
 
-	for (i = FIRST_KNI_FFORM; i <= LAST_KNI_FFORM; i++) {
+	for (i = FIRST_BASIC_KNI_FFORM; i <= LAST_ADV_KNI_FFORM; i++) {
+		if (i > LAST_BASIC_KNI_FFORM && i < FIRST_ADV_KNI_FFORM) continue;
 		if (FightingFormSkillLevel(i) >= P_BASIC)
 			formmask |= KNIGHT_FORMS;
 	}


### PR DESCRIPTION
VERY SAVEBREAKING DO NOT MERGE INTO A CURRENT TEST GAME

Stale fighting forms (defined as "fighting form you have active but restricted") are cleared at the top of the turn now. This prints a brief message "You readjust your stance".

Knight fighting forms are now in two chunks - the basic 4 are mutually exclusive with each other, and ditto for the xp14 3, but not with the opposite pool. So you can shield bash + eldritch, for example.

GithStyle is a mask now and you check it against `(1 << GSTYLE_FOO)`. The two low-san forms are mutually exclusive, and the three high-san forms are mutually exclusive. It's technically possible to have one of each category active at exactly 50 sanity, amusingly enough, but anywhere other than 50 san only one will be active at once.

Also, once you've activated a skill ever (doesn't need to have been not-blocked, just selected) it'll linger in your invoke menu list. That way you don't get awkwardly ghosted on a technically-not-active GSTYLE_COLD or GSTYLE_RESONANT. Uses avar3 to track this.

Also, zeroes out GithStyle & GithStylesSeen (the new avar3 one), along with ZerthUpgrades, on item creation. I'm not really sure if this is strictly required per se but I see no harm in it.