### PR TITLE
Fix offset used for not randomizing potion labels to include midas.

### DIFF
--- a/src/o_init.c
+++ b/src/o_init.c
@@ -195,7 +195,7 @@ shuffle_all()
 			int j = last-1;
 
 			if (oclass == POTION_CLASS)
-			    j -= 7;  /* primordial waters, goat's milk, space mead, water, starlight, amnesia, and blood have fixed descriptions */
+			    j -= 8;  /* primordial waters, goat's milk, space mead, midas, water, starlight, amnesia, and blood have fixed descriptions */
 			if (oclass == RING_CLASS)
 				first += 2;	/* three wishes and nothing have fixed descriptions */
 			if (oclass == WAND_CLASS)


### PR DESCRIPTION
Oops.