### PR TITLE
Add additional divine smites (stumbling blind, blood boiling, pillar …

### DIFF
--- a/include/hack.h
+++ b/include/hack.h
@@ -96,18 +96,19 @@
 #define CRUSHING	 8
 #define STONING		 9
 #define GOLDING		10
-#define GLASSED		11
-#define TURNED_SLIME	12
-#define OVERWOUND 	13
-#define WEEPING 	14
-#define DISINTEGRATED 15
-#define GENOCIDED	16 //Life saving triggers here and below, including wizard lifesaving
-#define APOCALYPSE	17
-#define PANICKED	18 //Below this, umortality is incremented
-#define TRICKED		19
-#define QUIT		20
-#define ESCAPED		21
-#define ASCENDED	22
+#define SALTING		11
+#define GLASSED		12
+#define TURNED_SLIME	13
+#define OVERWOUND 	14
+#define WEEPING 	15
+#define DISINTEGRATED 16
+#define GENOCIDED	17 //Life saving triggers here and below, including wizard lifesaving
+#define APOCALYPSE	18
+#define PANICKED	19 //Below this, umortality is incremented
+#define TRICKED		20
+#define QUIT		21
+#define ESCAPED		22
+#define ASCENDED	23
 
 #include "align.h"
 #include "dungeon.h"

--- a/include/prop.h
+++ b/include/prop.h
@@ -47,7 +47,8 @@
 #define WOUNDED_LEGS				1 + SLEEPING
 #define STONED						1 + WOUNDED_LEGS
 #define GOLDED						1 + STONED
-#define STRANGLED					1 + GOLDED
+#define SALTED						1 + GOLDED
+#define STRANGLED					1 + SALTED
 #define FROZEN_AIR					1 + STRANGLED
 #define HALLUC						1 + FROZEN_AIR
 #define HALLUC_RES					1 + HALLUC

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -226,6 +226,7 @@
 #define Sick			u.uprops[SICK].intrinsic
 #define Stoned			u.uprops[STONED].intrinsic
 #define Golded			u.uprops[GOLDED].intrinsic
+#define Salted			u.uprops[SALTED].intrinsic
 #define Vomiting		u.uprops[VOMITING].intrinsic
 #define Glib			u.uprops[GLIB].intrinsic
 #define Slimed			u.uprops[SLIMED].intrinsic	/* [Tom] */

--- a/src/apply.c
+++ b/src/apply.c
@@ -7470,8 +7470,7 @@ use_doll(obj)
 				flags.botl = 1;
 			}
 			healup(0, 0, TRUE, FALSE);
-			if (Stoned) fix_petrification();
-			if (Golded) fix_petrification();
+			if (Stoned || Golded || Salted) fix_petrification();
 			res = MOVE_STANDARD;
 			pline("You feel very healthy.");
 			give_intrinsic(GOOD_HEALTH, 100L);
@@ -11068,6 +11067,7 @@ unfixable_trouble_count(is_horn)
 
 	if (Stoned) unfixable_trbl++;
 	if (Golded) unfixable_trbl++;
+	if (Salted) unfixable_trbl++;
 	if (Strangled) unfixable_trbl++;
 	if (Panicking) unfixable_trbl++;
 	if (StumbleBlind) unfixable_trbl++;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3281,6 +3281,7 @@ get_premium_heart_multiplier()
 	if (Sick) multiplier++;
 	if (Stoned) multiplier++;
 	if (Golded) multiplier++;
+	if (Salted) multiplier++;
 	if (Strangled) multiplier++;
 	if (Vomiting) multiplier++;
 	if (Slimed) multiplier++;

--- a/src/bones.c
+++ b/src/bones.c
@@ -280,6 +280,7 @@ int y;
 
 		otmp->owornmask = 0;
 		if(u.ugrave_arise == (NON_PM - 3)) set_material(otmp, GOLD);
+		if(u.ugrave_arise == (NON_PM - 4)) set_material(otmp, SALT);
 		/* lamps don't go out when dropped */
 		if ((cont || artifact_light(otmp)) && obj_is_burning(otmp))
 		    end_burn(otmp, TRUE);	/* smother in statue */
@@ -530,6 +531,16 @@ struct obj *corpse;
 		if (!otmp) return;	/* couldn't make statue */
 		mtmp = (struct monst *)0;
 	} else if (u.ugrave_arise == (NON_PM - 4)) {
+		struct obj *otmp;
+
+		/* embed your possessions in your statue */
+		otmp = mk_named_object(STATUE, &mons[u.umonnum],
+				       x, y, plname);
+		set_material_gm(otmp, SALT);
+		drop_upon_death((struct monst *)0, otmp, x, y);
+		if (!otmp) return;	/* couldn't make statue */
+		mtmp = (struct monst *)0;
+	} else if (u.ugrave_arise == (NON_PM - 5)) {
 		struct obj *otmp;
 
 		/* embed your possessions in your statue */

--- a/src/botl.c
+++ b/src/botl.c
@@ -64,7 +64,7 @@ long get_status_duration(long long mask) {
 
 long long get_status_mask() {
 	long long mask = 0;
-	if(Stoned || Golded)
+	if(Stoned || Golded || Salted)
 		mask |= BL_MASK_STONE;
 	if(Slimed)
 		mask |= BL_MASK_SLIME;

--- a/src/eat.c
+++ b/src/eat.c
@@ -763,16 +763,14 @@ BOOLEAN_P bld, nobadeffects;
 	    case PM_SMALL_CAVE_LIZARD:
 	    case PM_CAVE_LIZARD:
 	    case PM_LARGE_CAVE_LIZARD:
-			if (Stoned) fix_petrification();
-			if (Golded) fix_petrification();
+			if (Stoned || Golded || Salted) fix_petrification();
 		break;
 	    case PM_MANDRAKE:
 			if(!nobadeffects){
 				pline ("Oh wow!  Great stuff!");
 				make_hallucinated(HHallucination + 200,FALSE,0L);
 			}
-			if (Stoned) fix_petrification();
-			if (Golded) fix_petrification();
+			if (Stoned || Golded || Salted) fix_petrification();
 			make_sick(0L, (char *) 0, TRUE, SICK_ALL);
 		break;
 	    case PM_GREEN_SLIME:
@@ -803,7 +801,7 @@ BOOLEAN_P bld, nobadeffects;
 			victual.piece = (struct obj *)0;
 		    return;
 		}
-		if (acidic(&mons[pm]) && (Stoned || Golded))
+		if (acidic(&mons[pm]) && (Stoned || Golded || Salted))
 		    fix_petrification();
 		break;
 	}
@@ -824,8 +822,7 @@ struct monst *mon;
 	case PM_SMALL_CAVE_LIZARD:
 	case PM_CAVE_LIZARD:
 	case PM_LARGE_CAVE_LIZARD:
-	    if (Stoned) fix_petrification();
-	    if (Golded) fix_petrification();
+	    if (Stoned || Golded || Salted) fix_petrification();
 	    break;
 	// case PM_MANDRAKE: No blood
 		// if(!nobadeffects){
@@ -851,7 +848,7 @@ struct monst *mon;
 	    }
 	    /* Fall through */
 	default:
-	    if (acidic(mon->data) && (Stoned || Golded))
+	    if (acidic(mon->data) && (Stoned || Golded || Salted))
 		fix_petrification();
 	    break;
     }
@@ -863,6 +860,7 @@ fix_petrification()
 {
 	Stoned = 0;
 	Golded = 0;
+	Salted = 0;
 	delayed_killer = 0;
 	if (Hallucination)
 	    pline("What a pity - you just ruined a future piece of %sart!",

--- a/src/end.c
+++ b/src/end.c
@@ -1329,8 +1329,10 @@ die:
 		u.ugrave_arise = (NON_PM - 1);	/* statue instead of corpse */
 	    else if (how == GOLDING)
 		u.ugrave_arise = (NON_PM - 3);	/* statue instead of corpse */
-	    else if (how == GLASSED)
+		else if (how == SALTING)
 		u.ugrave_arise = (NON_PM - 4);	/* statue instead of corpse */
+	    else if (how == GLASSED)
+		u.ugrave_arise = (NON_PM - 5);	/* statue instead of corpse */
 	    else if (u.ugrave_arise == NON_PM &&
 		     !(mvitals[u.umonnum].mvflags & G_NOCORPSE && !uandroid)) {
 		int mtyp = u.umonnum;

--- a/src/enlighten.c
+++ b/src/enlighten.c
@@ -857,6 +857,7 @@ boolean dumping;
 	}
 	if (Stoned) you_are("turning to stone");
 	if (Golded) you_are("turning to gold");
+	if (Salted) you_are("turning to salt");
 	if (Slimed) you_are("turning into slime");
 	if (FrozenAir) you_are("suffocating in the cold night");
 	if (BloodDrown) you_are("drowning in blood");

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -7268,7 +7268,7 @@ int tary;
 		))
 		return TRUE;
 	/* Don't de-stone the player */
-	if (youdef && (Stoned || Golded) && (
+	if (youdef && (Stoned || Golded || Salted) && (
 		spellnum == ACID_RAIN
 		))
 		return TRUE;

--- a/src/pline.c
+++ b/src/pline.c
@@ -660,6 +660,7 @@ ustatusline()
 	}
 	if (Stoned)		Strcat(info, ", solidifying");
 	if (Golded)		Strcat(info, ", aurelifying");
+	if (Golded)		Strcat(info, ", salifying");
 	if (Slimed)		Strcat(info, ", becoming slimy");
 	if (BloodDrown)		Strcat(info, ", drowning");
 	if (FrozenAir)		Strcat(info, ", can't breath");

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -212,6 +212,7 @@ newman()
 	if (Sick) make_sick(0L, (char *) 0, FALSE, SICK_ALL);
 	Stoned = 0;
 	Golded = 0;
+	Salted = 0;
 	delayed_killer = 0;
 	if (u.uhp <= 0 || u.uhpmax <= 0) {
 		if (Polymorph_control) {
@@ -496,10 +497,15 @@ int	mntmp;
 		delayed_killer = 0;
 		You("no longer seem to be petrifying.");
 	}
-	if (Stone_resistance && Golded) { /* parnes@eniac.seas.upenn.edu */
+	if (Stone_resistance && Golded) {
 		Golded = 0;
 		delayed_killer = 0;
 		You("no longer seem to be turning to gold.");
+	}
+	if (Stone_resistance && Salted) {
+		Salted = 0;
+		delayed_killer = 0;
+		You("no longer seem to be turning to salt.");
 	}
 	if (Sick_resistance && Sick) {
 		make_sick(0L, (char *) 0, FALSE, SICK_ALL);

--- a/src/potion.c
+++ b/src/potion.c
@@ -1344,8 +1344,7 @@ as_extra_healing:
 					"potion of acid", KILLED_BY_AN);
 			exercise(A_CON, FALSE);
 		}
-		if (Stoned) fix_petrification();
-		if (Golded) fix_petrification();
+		if (Stoned || Golded || Salted) fix_petrification();
 		unkn++; /* holy/unholy water can burn like acid too */
 		break;
 	case POT_PRIMORDIAL_WATERS:{
@@ -1359,8 +1358,7 @@ as_extra_healing:
 					"primordial water", KILLED_BY);
 			exercise(A_CON, FALSE);
 		}
-		if (Stoned) fix_petrification();
-		if (Golded) fix_petrification();
+		if (Stoned || Golded || Salted) fix_petrification();
 
 		int num;
 		num = rnd(5) + 5 * otmp->blessed + 1;

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -11,6 +11,7 @@
 
 STATIC_DCL void NDECL(stoned_dialogue);
 STATIC_DCL void NDECL(golded_dialogue);
+STATIC_DCL void NDECL(salted_dialogue);
 #ifdef CONVICT
 STATIC_DCL void NDECL(phasing_dialogue);
 #endif /* CONVICT */
@@ -158,6 +159,30 @@ golded_dialogue()
 		HFast = 0L;
 	if (i == 3L && !Free_action)
 		nomul(-3, "turning to gold");
+	exercise(A_DEX, FALSE);
+}
+
+static NEARDATA const char * const salted_texts[] = {
+	"You are slowing down.",		/* 5 */
+	"Your limbs are stiffening.",		/* 4 */
+	"Your limbs have turned to salt.",	/* 3 */
+	"You have turned to salt.",		/* 2 */
+	"You have become a pillar of salt."			/* 1 */
+};
+
+STATIC_OVL void
+salted_dialogue()
+{
+	register long i = (Salted & TIMEOUT);
+
+	if (i > 0L && i <= SIZE(salted_texts)) {
+		pline1(salted_texts[SIZE(salted_texts) - i]);
+		nomul(0, NULL); /* fix for C343-74 */
+	}
+	if (i == 5L)
+		HFast = 0L;
+	if (i == 3L && !Free_action)
+		nomul(-3, "turning to salt");
 	exercise(A_DEX, FALSE);
 }
 
@@ -562,6 +587,7 @@ nh_timeout()
 	if(Invulnerable) return; /* things past this point could kill you */
 	if(Stoned) stoned_dialogue();
 	if(Golded) golded_dialogue();
+	if(Salted) salted_dialogue();
 	if(Slimed) slime_dialogue();
 	if(Vomiting) vomiting_dialogue();
 	if((Strangled || FrozenAir || BloodDrown) && !Breathless) choke_dialogue();
@@ -825,6 +851,24 @@ nh_timeout()
 				IMPURITY_UP(u.uimp_bloodlust)
 			}
 			done(GOLDING);
+			break;
+		case SALTED:
+			if (delayed_killer && !killer) {
+				killer = delayed_killer;
+				delayed_killer = 0;
+			}
+			if (!killer) {
+				/* leaving killer_format would make it
+				   "petrified by petrification" */
+				killer_format = NO_KILLER_PREFIX;
+				killer = "killed by turning to salt";
+			}
+			if (!u.uconduct.killer){
+				//Pcifist PCs aren't combatants so if something kills them up "killed peaceful" type impurities
+				IMPURITY_UP(u.uimp_murder)
+				IMPURITY_UP(u.uimp_bloodlust)
+			}
+			done(SALTING);
 			break;
 		case FROZEN_AIR:
 			pline("The frozen air surrounding you becomes vapor.");


### PR DESCRIPTION
…of salt)

Expands the list of smites to add 3 new options. A full list is presented below for reference. rn2(anger*3) is rolled on the table:

- 0/1: nothing
- 2/3: lose xp & wis
- 4/5: curse items
- 6: punishment
- 7/8: minions

And the new options:
- 9/10: stumbling blind for 80+1d150 turns
- 11/12: blood boiling, doing CON-3 (if you have blood) or wounded legs for 100+d80 turns (if you don't have blood), and dealing `(anger*3)d(anger*3)` damage
- 13/14: pillar of salt, delayed salting instadeath (7 turns, functions identically to stone/gold)
- 15+: wide angle disint (used to be 9+)

In essence - you now need to be rolling with 6+ anger to get wide angle disintegration beamed. Hopefully that prevents wide angle disint from effectively ever showing up unless you've been _really_ sinning, but still blocks off "cults will still kill you". If nothing else, 150 turns of stumbling should consistently make life miserable if you're trying to ignore anger.

------

SAVEBREAKING