### PR TITLE
Don't limit inheritor artifacts by alignment when set in rcfile

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -3769,7 +3769,6 @@ find_preset_inherited(name)
 		if(artilist[i].gflags&ARTG_INHER
 		&& !Role_if(artilist[i].role) && !Pantheon_if(artilist[i].role)
 		&& !(urole.questarti == i)
-		&& (artilist[i].alignment == A_NONE || artilist[i].alignment == u.ualign.type)
 		){
 			aname = (char *)artilist[i].name;
 			if(!strncmpi(aname, "the ", 4)) aname += 4;


### PR DESCRIPTION
Previous commit 22c6ee only removes the limit when select from menu