### PR TITLE
Remove the bad bugfix for ghost symbols setting

### DIFF
--- a/src/drawing.c
+++ b/src/drawing.c
@@ -999,7 +999,6 @@ int glth, maxlen, offset;
     for (i = 0; i < maxlen; i++)
 	showsyms[i+offset] = (((i < glth) && graph_chars[i]) ?
 		       graph_chars[i] : defsyms[i+offset].sym);
-    if (monsyms[S_GHOST] == DEF_GHOST) monsyms[S_GHOST] = showsyms[S_litroom];
 }
 
 #ifdef USER_DUNGEONCOLOR


### PR DESCRIPTION
The ghost symbol will now be mismatched if your symset changes the floor. This fixes the bug where ghost rendering badly broke if you didn't manually set a ghost symbol in your rcfile, and made certain levels borderline unplayable if you didn't know the right fix.