### PR TITLE
Enable menucolors attributes in perm_invent view

### DIFF
--- a/win/curses/cursinvt.c
+++ b/win/curses/cursinvt.c
@@ -94,6 +94,7 @@ curses_add_inv(int y, int glyph, CHAR_P accelerator, attr_t attr,
         attr = 0;
         int attr_int = (int) attr;
         get_menu_coloring(str_mutable, &color, &attr_int);
+		attr = (attr_t) attr_int;
         if (color != NO_COLOR)
             attr |= curses_color_attr(color, 0);
     }


### PR DESCRIPTION
Previously, attributes were being accidentally neglected - lost in a temp argument made to fix a warning about mismatched argument types.