### PR TITLE
Relegate artifact keys to third class citizens in the autounlock automatic key getting function

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -392,17 +392,18 @@ reset_pick()
 /* pick a tool for autounlock */
 struct obj *
 autokey(opening)
-boolean opening; /* True: key, pick, or card; False: key or pick */
+boolean opening; /* True: key, pick, artikey, or card; False: key, pick, or artikey */
 {
-    struct obj *o, *key, *pick, *card;
+    struct obj *o, *key, *pick, *artikey, *card;
 
     /* mundane item or regular artifact or own role's quest artifact */
-    key = pick = card = (struct obj *) 0;
+    key = pick = artikey = card = (struct obj *) 0;
     for (o = invent; o; o = o->nobj) {
 		if (!touch_artifact(o, &youmonst, TRUE)) continue;
         switch (o->otyp) {
             case SKELETON_KEY:
-                if (!key)  key = o;
+                if (!key && !o->oartifact)  key = o;
+				if (!artikey && o->oartifact)  artikey = o;
                 break;
             case LOCK_PICK:
                 if (!pick) pick = o;
@@ -416,7 +417,7 @@ boolean opening; /* True: key, pick, or card; False: key or pick */
     }
     if (!opening)
         card = 0;
-    return key ? key : pick ? pick : card ? card : 0;
+    return key ? key : pick ? pick : artikey ? artikey : card ? card : 0;
 }
 
 int


### PR DESCRIPTION
This will prefer a non-artifact key or a lockpick over an artifact key.

They are really annoying, and it kept making alignment keys blast me when I had a perfectly good non blasty mundane key. This change would prevent that. This has made me really mad and I would argue as a whole, autounlock is antiqol without this.

Looks like tabs and spaces got mixed here or something. I don't know. Have a standard. Looks fine for me but bad in the preview. Maybe if I'm feeling really good, I'll fix it. Probably not.
![image](https://github.com/user-attachments/assets/24128f6f-6845-4658-9579-096be0f6230e)
