### PR TITLE
The Mortal Blade (new artifact proposal)

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -6747,6 +6747,13 @@ mortai
 	on the surface of its clouds.
 		[ Adapted from Dungeons and Dragons 2nd Edition 
 			Complete Monstrous Manual ]
+mortal blade
+	An odachi capable of slaying the undying. Its crimson blade 
+	will take the life of any who dares draw it. Without the 
+	power of Resurrection, one could not hope to wield this 
+	weapon, which allows one to defeat even infested beings.
+
+		[ Sekiro, by FromSoftware ]
 mumak*
 	... the Mumak of Harad was indeed a beast of vast bulk, and
 	the like of him does not walk now in Middle-Earth; his kin

--- a/include/artifact.h
+++ b/include/artifact.h
@@ -345,7 +345,7 @@ struct artinstance{
 #define LAST_GSTYLE			GSTYLE_RESONANT
 #define ZerthOtyp	avar2
 #define CarapaceLevel avar2
-
+#define mortalLives avar2
 	long avar3;
 #define SnSd3 avar3
 #define IbiteBoons avar3

--- a/include/artifact.h
+++ b/include/artifact.h
@@ -472,7 +472,7 @@ extern struct artifact * artilist;
 #define AMALGUM_ART		(LAST_PROP+94)
 #define MORGOTH         (LAST_PROP+95)
 #define SCORPION_UPGRADES  (LAST_PROP+96)
-
+#define MORTAL_DRAW  (LAST_PROP+97)
 
 #define MASTERY_ARTIFACT_LEVEL 20
 

--- a/include/artifact.h
+++ b/include/artifact.h
@@ -56,6 +56,7 @@
 #define ARTA_KNOCKBACKX	0x04000000L /* knockback; 100% chance*/
 #define ARTA_RETURNING  0x08000000L /* returns to the hand when thrown */
 #define ARTA_SONICX		0x10000000L /* thunderblasts */
+#define ARTA_LAIDTOREST	0x20000000L /* slain monsters cannot lifesave or revive post-mortem (except riders) */
 
 #define ARTP_SEEK		0x0001L /* helps you search, ie, adds enhancement bonus to attempts -- only coded for mainhand weapons */
 #define ARTP_NOCALL		0x0002L /* prevents demons from being gated in */
@@ -327,7 +328,7 @@ struct artinstance{
 #define TwinSkiesEtraits	avar2
 #define CarapaceXP avar1
 #define FingerprintProgress avar1
-
+#define drawnMortal avar1
 	long avar2;
 #define SnSd2 avar2
 #define RoSPflights avar2

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -679,6 +679,19 @@ A("Tensa Zangetsu",		TSURUGI,						"black %s",
 	SPEED_BANKAI, NOFLAG
 	),
 
+/* Kills the user (unavoidable, not intended to be avoidable) when drawn */
+/* Does 2x to all, 3x to mortal/undead (dark-vuln) */
+/* Prevents slain foes from reviving or lifesaving (without consuming "oLS!), */
+A("The Mortal Blade",		TSURUGI,						"sakura-hilted %s",
+	7770L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
+	A_LAWFUL, NON_PM, NON_PM, TIER_C, (ARTG_INHER),
+	NO_MONS(),
+	ATTK(AD_DARK, 1, 0), (ARTA_LAIDTOREST),
+	PROPS(), NOFLAG,
+	PROPS(), NOFLAG,
+	NOINVOKE, NOFLAG
+	),
+
 /*//////////Other Artifacts//////////*/
 
 /*Sort of intermediate between a double damage and a utility weapon,*/

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -682,11 +682,11 @@ A("Tensa Zangetsu",		TSURUGI,						"black %s",
 /* Kills the user (unavoidable, not intended to be avoidable) when drawn */
 /* Does 2x to all, 3x to mortal/undead (dark-vuln) */
 /* Prevents slain foes from reviving or lifesaving (without consuming "oLS!), */
-A("The Mortal Blade",		TSURUGI,						"sakura-hilted %s",
+A("The Mortal Blade",		TSURUGI,						"bloodstained sakura-hilted %s",
 	7770L, MT_DEFAULT, MZ_DEFAULT, WT_DEFAULT,
 	A_LAWFUL, NON_PM, NON_PM, TIER_C, (ARTG_INHER),
 	NO_MONS(),
-	ATTK(AD_DARK, 1, 0), (ARTA_LAIDTOREST),
+	ATTK(AD_DARK, 20, 0), (ARTA_LAIDTOREST|ARTA_PHASING),
 	PROPS(), NOFLAG,
 	PROPS(), NOFLAG,
 	NOINVOKE, NOFLAG

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -689,7 +689,7 @@ A("The Mortal Blade",		TSURUGI,						"bloodstained sakura-hilted %s",
 	ATTK(AD_DARK, 20, 0), (ARTA_LAIDTOREST|ARTA_PHASING),
 	PROPS(), NOFLAG,
 	PROPS(), NOFLAG,
-	NOINVOKE, NOFLAG
+	MORTAL_DRAW, NOFLAG
 	),
 
 /*//////////Other Artifacts//////////*/

--- a/include/extern.h
+++ b/include/extern.h
@@ -931,6 +931,7 @@ E void VDECL(panic, (const char *,...)) PRINTF_F(1,2);
 E const char* NDECL(get_alignment_code);
 E const char* NDECL(get_alignment_adj);
 E boolean NDECL(Check_crystal_lifesaving);
+E void NDECL(Use_crystal_lifesaving);
 E boolean NDECL(Check_iaso_lifesaving);
 E boolean NDECL(Check_twin_lifesaving);
 E void FDECL(done, (int));

--- a/include/extern.h
+++ b/include/extern.h
@@ -165,6 +165,7 @@ E boolean FDECL(arti_plussev, (struct obj *));
 E boolean FDECL(arti_plusten, (struct obj *));
 E boolean FDECL(arti_silvered, (struct obj *));
 E boolean FDECL(arti_returning, (struct obj *));
+E boolean FDECL(arti_laidtorest, (struct obj *));
 E boolean FDECL(arti_reflects, (struct obj *));
 E int FDECL(artifact_weight, (struct obj *));
 E boolean FDECL(arti_light, (struct obj *));

--- a/include/monst.h
+++ b/include/monst.h
@@ -162,6 +162,7 @@ struct monst {
 	Bitfield(mgoatmarked,1);/* will be eaten by the goat if you kill it this turn */ /*91*/
 	Bitfield(mflamemarked,1); /* monster was damaged by a silver flame weapon and will be sacced if they die */ /*92*/
 	Bitfield(myoumarked,1); /* monster was marked for cult sacrifice on your behalf */ /*93*/
+	Bitfield(mlaidtorest,1); /* should not come back under any circumstances (save riders), mortal blade*/
 	Bitfield(mpetitioner,1);/* already dead (shouldn't leave a corpse) */ /*94*/
 	Bitfield(mdoubt,1);/* clerical spellcasting blocked */ /*95*/
 	Bitfield(menvy,1);/* wants only others stuff */ /*96*/

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -12508,6 +12508,72 @@ arti_invoke(obj)
 		case SCORPION_UPGRADES:
 			scorpion_upgrade_menu(obj);
 		break;
+		case MORTAL_DRAW:
+			obj->age = 0;
+			if (!(uwep && uwep == obj)) {
+				You_feel("that you should be wielding %s.", the(xname(obj)));
+				break;
+			}
+			const char all_classes[] = { ALL_CLASSES, 0 };
+			struct obj *otmp  = getobj(all_classes, "offer to the blade");
+			if (!otmp){
+				pline("Never mind.");
+				break;
+			}
+			if (otmp->owornmask & (W_ARMOR | W_ACCESSORY)){
+				You("need to take that off first.");
+				break;
+			} else if (otmp == uwep){
+				You("have no clue how you would go about doing that.");
+				break;
+			}
+
+			char buf[BUFSZ];
+			Sprintf(buf, "Offer %s to the blade?", the(xname(otmp)));
+			if (yn(buf) == 'n') break;
+
+			if (is_asc_obj(otmp) || objects[otmp->otyp].oc_unique){
+				pline("You plunge the sword down, but the blade bounces off!");
+				break;
+			}
+
+			if (item_has_property(otmp, LIFESAVED)){
+				You("plunge the blade into %s, and it crumbles to dust.", the(xname(otmp)));
+				pline("The smoke surrounding the blade thickens.");
+				artinstance[ART_MORTAL_BLADE].mortalLives++;
+			} else if (otmp->otyp == RIN_WISHES && otmp->spe > 0){
+				You("plunge the blade into %s, and it crumbles to dust.", the(xname(otmp)));
+				pline("The smoke surrounding the black thickens%s.", (otmp->spe > 1) ? " greatly" : "");
+				artinstance[ART_MORTAL_BLADE].mortalLives += otmp->spe;
+			} else if (otmp->oartifact == ART_BLACK_CRYSTAL && Check_crystal_lifesaving()){
+				You("plunge the blade straight through %s.", the(xname(otmp)));
+				Use_crystal_lifesaving();
+				if (otmp->oeroded3 == 1){
+					if (Hallucination){
+						pline("You catch a glimpse of a man in dark, horned armor. He looks friendly!");
+						change_uinsight(-1);
+					} else if (u.uinsight > 40) {
+						pline("In a flash, you see the fabric of time unspooled before your very eyes. The moment passes.");
+						change_uinsight(1);
+					} else if (u.uinsight > 5){
+						You_feel("an odd spiraling sensation for a moment, but it passes quickly.");
+						change_uinsight(1);
+					}
+				}
+				artinstance[ART_MORTAL_BLADE].mortalLives++;
+				break;
+			} else if (otmp->oartifact){
+				pline("The blade seems to pass right through!");
+				break;
+			} else {
+				pline("Nothing else happens.");
+			}
+			if (otmp->unpaid) {
+				check_unpaid(otmp);
+				bill_dummy_object(otmp);
+			}
+			delobj(otmp);
+		break;
 		default: pline("Program in disorder.  Artifact invoke property not recognized");
 		break;
 	} //end of first case:  Artifact Specials!!!!

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -801,6 +801,9 @@ aligntyp alignment;
 			/* skip Callandor for non-males */
 			skip_if(m == ART_CALLANDOR && flags.initgend);
 
+			/* Skip the Mortal Blade, it's an opt-in kind of artifact */
+			skip_if(m == ART_MORTAL_BLADE);
+
 			/* skip artifacts that outright hate the player */
 			skip_if((a->aflags & ARTA_HATES) && (urace.selfmask & a->mflagsa));
 

--- a/src/do.c
+++ b/src/do.c
@@ -599,6 +599,10 @@ struct obj *obj;
 			weldmsg(obj);
 			return(0);
 		}
+
+		if (obj->oartifact == ART_MORTAL_BLADE && yesno("Release the Mortal Blade?", TRUE) == 'n')
+			return(0);
+
 		setuwep((struct obj *)0);
 	}
 	if(obj == uquiver) {

--- a/src/end.c
+++ b/src/end.c
@@ -5,6 +5,7 @@
 #define NEED_VARARGS	/* comment line for pre-compiled headers */
 
 #include "hack.h"
+#include "artifact.h"
 
 #ifndef NO_SIGNAL
 #include <signal.h>
@@ -1139,6 +1140,10 @@ int how;
 		} else if(u.sealsActive&SEAL_JACK){
 			lsvd = LSVD_JACK;
 			unbind_lifesaving(SEAL_JACK);
+		} else if(uwep && uwep->oartifact == ART_MORTAL_BLADE && artinstance[ART_MORTAL_BLADE].mortalLives){
+			lsvd = LSVD_MISC;
+			pline("The smoke emanating from the crimson blade wanes.");
+			artinstance[ART_MORTAL_BLADE].mortalLives--;
 		} else if(Check_crystal_lifesaving()){
 			lsvd = LSVD_MISC;
 			pline("Time unwinds and twists!");

--- a/src/end.c
+++ b/src/end.c
@@ -872,7 +872,7 @@ Check_twin_lifesaving()
 	return FALSE;
 }
 
-STATIC_OVL void
+void
 Use_crystal_lifesaving()
 {
 	//Use less advantageous l.s. first (the full set of 5 crystals is heavy and riskier for theft)

--- a/src/invent.c
+++ b/src/invent.c
@@ -873,7 +873,8 @@ carrying_readable_weapon()
 				otmp->oartifact == ART_HOLY_MOONLIGHT_SWORD ||
 				otmp->oartifact == ART_ESSCOOAHLIPBOOURRR ||
 				otmp->oartifact == ART_RED_CORDS_OF_ILMATER ||
-				otmp->oartifact == ART_STAFF_OF_NECROMANCY
+				otmp->oartifact == ART_STAFF_OF_NECROMANCY ||
+				(otmp->oartifact == ART_MORTAL_BLADE && otmp->owornmask&W_WEP && !u.veil)
 			))
 		)
 			return TRUE;

--- a/src/invent.c
+++ b/src/invent.c
@@ -2769,6 +2769,9 @@ winid *datawin;
 	if(check_oprop(obj,OPROP_SOTHW) && !(obj->where == OBJ_INVENT && YOG_BAD))
 		sothweaponturn = soth_weapon_damage_turn(obj);
 
+	/* mortal blade has no bonus dmg when sheathed */
+	if (obj && oartifact == ART_MORTAL_BLADE && obj != uwep)
+		has_artidmg = FALSE;
 
 #define OBJPUTSTR(str) putstr(*datawin, ATR_NONE, str)
 #define ADDCLASSPROP(cond, str)         \
@@ -3021,6 +3024,9 @@ winid *datawin;
 			case ART_FALLINGSTAR_MANDIBLES:
 				Strcat(buf, "magic damage, doubled against those who came from the stars.");
 				break;
+			case ART_MORTAL_BLADE:
+				Strcat(buf, "damage to all, and triple to those that live or live again.");
+			break;
 			default:
 				switch (oart->adtyp) {
 					case AD_FIRE: Strcat(buf, "fire damage"); break;
@@ -3320,6 +3326,9 @@ winid *datawin;
 			if(is_vibroweapon(obj)){
 				Sprintf(buf2, "Drains one charge per hit and deals less damage when uncharged.");
 				OBJPUTSTR(buf2);
+			}
+			if (obj->oartifact == ART_MORTAL_BLADE){
+				Sprintf(buf2, "Slain foes will not lifesave or resurrect.");
 			}
 		}
 		/* poison */
@@ -3755,6 +3764,7 @@ winid *datawin;
 
 		buf[0] = '\0';
 		ADDCLASSPROP((oart->aflags&ARTA_RETURNING), "returns when thrown");
+		ADDCLASSPROP((oart->aflags&ARTA_LAIDTOREST), "lays foes to rest");
 		ADDCLASSPROP((oart->aflags&ARTA_HASTE), "hastens the wielder's attacks");
 		if (buf[0] != '\0')
 		{

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1910,8 +1910,7 @@ start_corpse_timeout(body)
 			when = age;
 			break;
 		    }
-	} else if (is_fungus(&mons[body->corpsenm]) && 
-			  !is_migo(&mons[body->corpsenm])) {
+	} else if (is_fungus(&mons[body->corpsenm]) && !is_migo(&mons[body->corpsenm]) && !body->norevive) {
 		/* Fungi come back with a vengeance - if you don't eat it or
 		 * destroy it,  any live cells will quickly use the dead ones
 		 * as food and come back.
@@ -3096,8 +3095,9 @@ boolean init;
 			if (otmp->otyp == CORPSE) {
 				stop_all_timers(otmp->timed);
 				/* if the monster was cancelled, don't self-revive */
-				if (mtmp && mtmp->mcan && !is_rider(ptr))
+				if (mtmp && (mtmp->mcan || mtmp->mlaidtorest) && !is_rider(ptr)){
 					otmp->norevive = 1;
+				}
 				start_corpse_timeout(otmp);
 			}
 	    }

--- a/src/mon.c
+++ b/src/mon.c
@@ -4488,15 +4488,17 @@ struct monst *mtmp;
 	if (mvitals[monsndx(mtmp->data)].mvflags & G_GENOD && !In_quest(&u.uz))
 		lifesavers &= ~(LSVD_FRC | LSVD_NBW | LSVD_KAM | LSVD_HLO);
 
-	/* monsters laid to rest cannot lifesave by any means, except the twin sibling & the puppet emperors,
-	 * due to potentially weird/bleh behavior. yog & the suzerain send replacements.
+	/* monsters laid to rest cannot lifesave by any means.
+	   yog's twin stays dead (no replacement), suzerain still shows up on astral.
+	   iffy on tettigons (armored, lifesaving is the armor cracking) and maybe ana timestream fuckery,
+	   but it works for right now
 	 */
 	if (mtmp->mlaidtorest) {
 		if (uwep && uwep->oartifact == ART_MORTAL_BLADE && (lifesavers&(LSVD_NIT|LSVD_NBW|LSVD_ASC))) {
 			artinstance[ART_MORTAL_BLADE].mortalLives++;
 			pline("Red smoke flows into the blade!");
 		}
-		lifesavers &= (LSVD_YEL | LSVD_TWN);
+		lifesavers = 0;
 	}
 	/* quick check -- if no lifesavers, let's fail immediately */
 	if (!lifesavers) {
@@ -5240,7 +5242,9 @@ register struct monst *mtmp;
 		u.umadness |= MAD_REACHER;
 	}
 	if(mtmp->mtyp == PM_PUPPET_EMPEROR_XELETH || mtmp->mtyp == PM_PUPPET_EMPRESS_XEDALLI){
-		makemon(&mons[PM_SUZERAIN], 0, 0, MM_ADJACENTOK);
+		struct monst *suze = makemon(&mons[PM_SUZERAIN], 0, 0, MM_ADJACENTOK);
+		migrate_to_level(suze, ledger_no(&astral_level), MIGR_RANDOM, (coord *)0);
+		mtmp->marriving = TRUE;
 	}
 #ifdef RECORD_ACHIEVE
 	if(mtmp->mtyp == PM_LUCIFER){

--- a/src/mon.c
+++ b/src/mon.c
@@ -4491,9 +4491,13 @@ struct monst *mtmp;
 	/* monsters laid to rest cannot lifesave by any means, except the twin sibling & the puppet emperors,
 	 * due to potentially weird/bleh behavior. yog & the suzerain send replacements.
 	 */
-	if (mtmp->mlaidtorest)
+	if (mtmp->mlaidtorest) {
+		if (uwep && uwep->oartifact == ART_MORTAL_BLADE && (lifesavers&(LSVD_NIT|LSVD_NBW|LSVD_ASC))) {
+			artinstance[ART_MORTAL_BLADE].mortalLives++;
+			pline("Red smoke flows into the blade!");
+		}
 		lifesavers &= (LSVD_YEL | LSVD_TWN);
-
+	}
 	/* quick check -- if no lifesavers, let's fail immediately */
 	if (!lifesavers) {
 		return;

--- a/src/mon.c
+++ b/src/mon.c
@@ -4488,6 +4488,12 @@ struct monst *mtmp;
 	if (mvitals[monsndx(mtmp->data)].mvflags & G_GENOD && !In_quest(&u.uz))
 		lifesavers &= ~(LSVD_FRC | LSVD_NBW | LSVD_KAM | LSVD_HLO);
 
+	/* monsters laid to rest cannot lifesave by any means, except the twin sibling & the puppet emperors,
+	 * due to potentially weird/bleh behavior. yog & the suzerain send replacements.
+	 */
+	if (mtmp->mlaidtorest)
+		lifesavers &= (LSVD_YEL | LSVD_TWN);
+
 	/* quick check -- if no lifesavers, let's fail immediately */
 	if (!lifesavers) {
 		return;

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2307,7 +2307,10 @@ weapon:
 			else if (obj->oartifact == ART_HOLY_MOONLIGHT_SWORD && obj->lamplit) {
 				Strcat(buf, " (lit)");
 			}
-			else if (obj->oartifact == ART_MORTAL_BLADE && obj != uwep) {
+			else if (obj->oartifact == ART_MORTAL_BLADE && obj == uwep) {
+				Strcat(buf, " (drawn)");
+			}
+			else if (obj->oartifact == ART_MORTAL_BLADE && !(obj->owornmask&W_WEP)) {
 				Strcat(buf, " (sheathed)");
 			}
 			else if (obj->otyp == TONITRUS && obj->lamplit) {

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1382,6 +1382,12 @@ char *buf;
 		else
 			Strcat(buf, "budding ");
 	}
+	if (obj->oartifact == ART_MORTAL_BLADE && obj == uwep && artinstance[ART_MORTAL_BLADE].mortalLives){
+		if (artinstance[ART_MORTAL_BLADE].mortalLives > 1)
+			Strcat(buf, "seething ");
+		else
+			Strcat(buf, "fuming ");
+	}
 	if (rakuyo_prop(obj)){
 		if(Insight >= 40)
 			Strcat(buf, "burning ");
@@ -2306,9 +2312,6 @@ weapon:
 			}
 			else if (obj->oartifact == ART_HOLY_MOONLIGHT_SWORD && obj->lamplit) {
 				Strcat(buf, " (lit)");
-			}
-			else if (obj->oartifact == ART_MORTAL_BLADE && obj == uwep) {
-				Strcat(buf, " (drawn)");
 			}
 			else if (obj->oartifact == ART_MORTAL_BLADE && !(obj->owornmask&W_WEP)) {
 				Strcat(buf, " (sheathed)");

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2307,6 +2307,9 @@ weapon:
 			else if (obj->oartifact == ART_HOLY_MOONLIGHT_SWORD && obj->lamplit) {
 				Strcat(buf, " (lit)");
 			}
+			else if (obj->oartifact == ART_MORTAL_BLADE && obj != uwep) {
+				Strcat(buf, " (sheathed)");
+			}
 			else if (obj->otyp == TONITRUS && obj->lamplit) {
 				Strcat(buf, " (crackling)");
 			}

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2277,6 +2277,8 @@ register struct obj *obj;
 			weldmsg(obj);
 			return 0;
 		}
+		if (obj->oartifact == ART_MORTAL_BLADE && yesno("Sheathe the Mortal Blade?", TRUE) == 'n')
+			return(0);
 		setuwep((struct obj *) 0);
 		if (uwep) return 0;	/* unwielded, died, rewielded */
 	} else if (obj == uswapwep) {

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -2698,6 +2698,8 @@ boolean forcedestroy;
 		weldmsg(ammo);
 		return MOVE_STANDARD;
 	}
+	if (uwep && uwep->oartifact == ART_MORTAL_BLADE && yesno("Release the Mortal Blade?", TRUE) == 'n')
+		return MOVE_STANDARD;
 
 	/* blasters */
 	if (launcher && is_blaster(launcher)) {

--- a/src/read.c
+++ b/src/read.c
@@ -217,6 +217,16 @@ doread()
 				pline("\"Turgon aran Gondolin tortha gar a matha i vegil Glamdring gud daedheloth, dam an Glamhoth\".");
 			}
 			return MOVE_READ;
+		} else if(scroll->oartifact == ART_MORTAL_BLADE){
+			if (Blind) {
+				You_cant("see the blade!");
+				return MOVE_INSTANT;
+			} else if(Role_if(PM_SAMURAI)) {
+				pline("\"Gracious Gift of Tears\".");
+			} else {
+				pline("\"Hairui\".");
+			}
+			return MOVE_READ;
 		} else if(scroll->oartifact == ART_BOW_OF_SKADI){
 			if (Blind) {
 				You_cant("see the bow!");

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -426,6 +426,11 @@ struct monst *magr;
 			attackmask |= PIERCE;
 		else attackmask |= SLASH;
 	}
+	if (obj && oartifact == ART_MORTAL_BLADE){
+		/* hard to resist when drawn, but the sheath is just a club really */
+		if (obj == uwep) attackmask |= EXPLOSION;
+		else attackmask = WHACK;
+	}
 	/* if it's not any of the above, we're just smacking things with it */
 	if (!attackmask)
 		attackmask = WHACK;
@@ -1124,6 +1129,14 @@ struct monst *magr;
 		/* Fluorite Octet overrides the number of dice -- only 1 per blade, not 3 */
 		ocn /= 3;
 		/* but keep spe_mult */
+	}
+
+	if (obj && obj->oartifact == ART_MORTAL_BLADE && obj != uwep) {
+		/* when sheathed, it's barely a weapon - large club stats */
+		ocn = 1;
+		ocd = (large) ? 5 : 8;
+		bonn = 0;
+		bond = 0;
 	}
 
 	/* the Tentacle Rod gets no damage from enchantment */

--- a/src/wield.c
+++ b/src/wield.c
@@ -142,13 +142,21 @@ struct obj* wep;
 	confirmation = (yesno("Knowing this, do you still wish to attempt this?", TRUE) == 'y');
 	if (confirmation){
 		You("draw the Mortal Blade from its sheath... and fall to the ground, dead.");
-		killer_format = KILLED_BY;
-		killer = "drawing the blade that could not be drawn";
-		done(DIED);
+		/* Bad hack to check if you have lifesaving that triggers before this */
+		if (artinstance[ART_MORTAL_BLADE].mortalLives && !(ELifesaved || Check_iaso_lifesaving() || Check_twin_lifesaving())){
+			pline("For a moment, you smell the sweet scent of cherry blossoms.");
+			artinstance[ART_MORTAL_BLADE].mortalLives--;
+		} else {
+			killer_format = KILLED_BY;
+			killer = "drawing the blade that could not be drawn";
+			done(DIED);
+		}
 
 		/* for fun, a little conduct tracker. could just be 0/1 but why not? */
 		artinstance[wep->oartifact].drawnMortal++;
 		You("stand up, with the blade in hand.");
+		discover_artifact(ART_MORTAL_BLADE);
+		wep->known = 1;
 		return TRUE;
 	} else {
 		You("decide against such a risky maneuver.");

--- a/src/wield.c
+++ b/src/wield.c
@@ -134,12 +134,12 @@ struct obj* wep;
 		if (undiscovered_artifact(wep->oartifact))
 			You_feel("a creeping doom from this blade. If you were to draw it, you're not sure you'd survive.");
 		else
-			You("know this blade - it is the blade that cannot be drawn. It is so-called as not one who has drawn it has survived.");
+			You("know this blade - it is the blade that cannot be drawn. Not one who has drawn it has survived the effort.");
 	}
 	else
 		pline("If you draw the blade again, it will surely slay you once more.");
 
-	confirmation = (yn("Knowing this, do you still wish to attempt this?") == 'y');
+	confirmation = (yesno("Knowing this, do you still wish to attempt this?", TRUE) == 'y');
 	if (confirmation){
 		You("draw the Mortal Blade from its sheath... and fall to the ground, dead.");
 		killer_format = KILLED_BY;
@@ -332,21 +332,23 @@ dowield()
 	}
 
 	/* Handle no object, or object in other slot */
-	if (wep == &zeroobj)
-		wep = (struct obj *) 0;
-	else if (wep == uswapwep){
-		if(wep->ostolen && u.sealsActive&SEAL_ANDROMALIUS) unbind(SEAL_ANDROMALIUS, TRUE);
-		return (doswapweapon());
-	} else if (wep == uquiver){
-		if(wep->ostolen && u.sealsActive&SEAL_ANDROMALIUS) unbind(SEAL_ANDROMALIUS, TRUE);
-		setuqwep((struct obj *) 0);
-	} else if (wep->owornmask & (W_ARMOR | W_RING | W_AMUL | W_BELT | W_TOOL
+	if (wep->owornmask & (W_ARMOR | W_RING | W_AMUL | W_BELT | W_TOOL
 #ifdef STEED
 			| W_SADDLE
 #endif
 			)) {
 		You("cannot wield that!");
 		return MOVE_CANCELLED;
+	} else if (uwep && uwep->oartifact == ART_MORTAL_BLADE && yesno("Sheathe the Mortal Blade?", TRUE) == 'n') {
+		return MOVE_INSTANT;
+	} else if (wep == &zeroobj){
+		wep = (struct obj *) 0;
+	} else if (wep == uswapwep){
+		if(wep->ostolen && u.sealsActive&SEAL_ANDROMALIUS) unbind(SEAL_ANDROMALIUS, TRUE);
+		return (doswapweapon());
+	} else if (wep == uquiver){
+		if(wep->ostolen && u.sealsActive&SEAL_ANDROMALIUS) unbind(SEAL_ANDROMALIUS, TRUE);
+		setuqwep((struct obj *) 0);
 	}
 
 	/* Set your new primary weapon */
@@ -382,6 +384,9 @@ doswapweapon()
 		weldmsg(uwep);
 		return MOVE_INSTANT;
 	}
+
+	if (uwep && uwep->oartifact == ART_MORTAL_BLADE && yesno("Sheathe the Mortal Blade?", TRUE) == 'n')
+		return MOVE_INSTANT;
 
 	/* Unwield your current secondary weapon */
 	oldwep = uwep;

--- a/src/wield.c
+++ b/src/wield.c
@@ -143,7 +143,7 @@ struct obj* wep;
 	if (confirmation){
 		You("draw the Mortal Blade from its sheath... and fall to the ground, dead.");
 		/* Bad hack to check if you have lifesaving that triggers before this */
-		if (artinstance[ART_MORTAL_BLADE].mortalLives && !(ELifesaved || Check_iaso_lifesaving() || Check_twin_lifesaving())){
+		if (artinstance[ART_MORTAL_BLADE].mortalLives){
 			pline("For a moment, you smell the sweet scent of cherry blossoms.");
 			artinstance[ART_MORTAL_BLADE].mortalLives--;
 		} else {

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -14807,8 +14807,11 @@ hmoncore(struct monst *magr, struct monst *mdef, struct attack *attk, struct att
 			poisons |= OPOISON_DIRE;
 		if (Insight >= 40 && poisonedobj->oartifact == ART_LOLTH_S_FANG)
 			poisons |= OPOISON_DIRE;
-		if (poisonedobj->oartifact == ART_MORTAL_BLADE && poisonedobj == uwep && artinstance[ART_MORTAL_BLADE].mortalLives)
-			poisons |= OPOISON_DIRE;
+		if (poisonedobj->oartifact == ART_MORTAL_BLADE && poisonedobj == uwep && artinstance[ART_MORTAL_BLADE].mortalLives){
+			poisons |= OPOISON_BASIC;
+			if (artinstance[ART_MORTAL_BLADE].mortalLives > 1)
+				poisons |= OPOISON_DIRE;
+		}
 		if (poisonedobj->otyp == GREATCLUB){
 			poisons |= OPOISON_BASIC;
 			//All greatclubs upgrade to filth due to your influence on the world

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -14807,6 +14807,8 @@ hmoncore(struct monst *magr, struct monst *mdef, struct attack *attk, struct att
 			poisons |= OPOISON_DIRE;
 		if (Insight >= 40 && poisonedobj->oartifact == ART_LOLTH_S_FANG)
 			poisons |= OPOISON_DIRE;
+		if (poisonedobj->oartifact == ART_MORTAL_BLADE && poisonedobj == uwep && artinstance[ART_MORTAL_BLADE].mortalLives)
+			poisons |= OPOISON_DIRE;
 		if (poisonedobj->otyp == GREATCLUB){
 			poisons |= OPOISON_BASIC;
 			//All greatclubs upgrade to filth due to your influence on the world

--- a/src/xhity.c
+++ b/src/xhity.c
@@ -4839,6 +4839,9 @@ boolean ranged;
 		/* DEAL THE DAMAGE */
 		result = xmeleehurty_core(magr, mdef, attk, attk, weapon_p, TRUE, -1, dieroll, vis, ranged, longslash);
 
+		/* if the monster didn't die as part of that attack, clear its laid to rest status */
+		if (mdef->mlaidtorest) mdef->mlaidtorest = 0;
+
 		/* the player exercises dexterity when hitting */
 		if (youagr)
 			exercise(A_DEX, TRUE);


### PR DESCRIPTION
The Mortal Blade:

- lawful tsurugi
- +1d20 to hit
- 3x damage to all, but only 2x damage to unalive targets
- Attacks are phasing
- Lays slain foes to rest, bypassing all forms of lifesaving and preventing them from resurrecting
  - Lifesaving items are unconsumed and untouched, and can be looted
- When not wielded, all attack effects and damage are turned off (accuracy, damage, phasing/laying to rest)
- When wielded, instantly kills you
  - Can't be avoided, lifesaving must be spent to survive
  - Unwielding by any means ('sheathing it') means you'll need to die again next time you want to wield it
  - Has paranoid yesno prompt for wielding and most intentional unwielding methods (manual unwield, swapping to offhand, throwing, dropping, bagging)
 - Can be invoked to consume lifesaving charges by destroying an item, transferring the lifesaving effect into the sword
   - Lifesaving effects stored in the sword apply after lifesaving consumables, jack, ias archon lifesaving, and twin lifesaving - but before crystals, rings of wishes, and centipede/dark young poly.
     - Lifesaving effects stored in the store apply preferentially when wielding it, but do NOT count as real deaths - you merely lose a charge and stand up immediately (no gevurah, for example)
   - Unique items can't be destroyed, even if they've got a lifesaving property somehow. Artifacts without lifesaving effects are unaffected, but artifacts that provide lifesaving (including from object property) are consumed whole (it does not simply strip the oprop or something). All other items, lifesaving or not, are destroyed.
   - The sword shows as "fuming" if it has 1 charge, and becomes poisoned. It changes to "seething" at 2+ charges, and also gains dire poison.
   - Killing through the innate lifesaving from Nitocris (wrappings/black waters OR the part preventing her from becoming a ghoul) or Blib/Cyclops (lifeforce drain) will also store a charge. Other forms of monster lifesaving do not store charges (due to being trivial/farmable).