### PR TITLE
Nerf Blade Singer's Saber/Dagger/Rakuyo

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -675,13 +675,13 @@ boolean affect_game_state;
 			}
 
 			/* some artifacts are faster */
-			// note - you don't have to actually be two-weaponing, and that's intentional,
-			// but you must have another ARTA_HASTE wep offhanded (and there's only 2 so)
+			/* similar/identical to ARTA_HASTE, but does not require skill */
 			if (uwep && uwep->oartifact && arti_attack_prop(uwep, ARTA_HASTE)){
-				current_cost -= NORMAL_SPEED / 3;
+				current_cost -= NORMAL_SPEED / 4;
 				if (uswapwep && uswapwep->oartifact && arti_attack_prop(uwep, ARTA_HASTE))
-					current_cost -= NORMAL_SPEED / 6;
+					current_cost -= NORMAL_SPEED / 12;
 			}
+
 			break;
 
 		case MOVE_QUAFFED:

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -11004,13 +11004,13 @@ arti_invoke(obj)
 		else dancer = 1;
 		
 		pline("You enter a %strance, giving you an edge in battle.", (dancer==2) ? "deep ":"");
-		// heal you up to half of your lost hp, modified by enchantment
-		int healamt = (maybe_polyd(u.mhmax - u.mh, u.uhpmax - u.uhp) + 1) / ((dancer == 2) ? 2 : 4);
-		healamt = max(0, healamt * (obj->spe/10));
-		healup(healamt, 0, FALSE, FALSE);
 
 		// make you very fast for a limited time
 		incr_itimeout(&HFast, rn1(u.ulevel, 50*dancer));
+
+		// triggers bladesong as an <enchantment> level spell
+		if (obj->spe > 0)
+			u.bladesong = monstermoves + obj->spe*dancer/2;
 		
 		// give you some protection
 		int l = u.ulevel;


### PR DESCRIPTION
Reduced speed buff from -4/6 to -3/4, equivalent to expert ETRAIT_QUICK when paired. Considered just slapping on ETRAIT_QUICK, figured eh, better to be like this to be more fun when gifted
 (and capped at basic).

That's the big change, and probably affects the weapon significantly, though I still imagine it's S-tier. But in addition, replaced Bladesong invoke heal with counting as a level <enchantment> spell when used - triggering ETRAIT_BLADESONG. Might actually more than compensate for the speed nerf in many situations, but at least that's on a timer? Dunno. This thing is GOOD, still.