### PR TITLE
#NoElfRings2026

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -4879,7 +4879,7 @@ use_dissection_kit(struct obj *obj)
 		// pline("That's too insubstantial to dissect.");
 		// return;
 	// }
-	splitobj(otmp, otmp->quan - 1L);
+	if (otmp->quan > 1) splitobj(otmp, otmp->quan - 1L);
 	consume_obj_charge(obj, TRUE);
 
 	//San check

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -839,6 +839,9 @@ aligntyp alignment;
 			/* skip cross-aligned artifacts */
 			skip_if(a->alignment != A_NONE && a->alignment != alignment);
 
+			/* skip race-favoring intel artifacts (they blast but don't evade) */
+			skip_if(a->gflags & ARTG_MAJOR && a->race != NON_PM && !Race_if(a->race));
+
 			/* if we made it through that gauntlet, we're good */
 			eligible[n++] = m;
 		}

--- a/src/potion.c
+++ b/src/potion.c
@@ -3262,7 +3262,7 @@ dodip()
 			if(obj->otyp != VIPERWHIP) obj->opoisoned = 0;
 			if(obj->otyp == VIPERWHIP) pline("%s is drawn up into %s.",
 				  buf, the(xname(obj)));
-			else pline("%s forms a coating on %s.",
+			else pline("%s forms an acidic coating on %s.",
 				  buf, the(xname(obj)));
 			if(obj->otyp == VIPERWHIP){
 				if(obj->opoisonchrgs && obj->opoisoned == OPOISON_ACID) obj->opoisonchrgs += 2;


### PR DESCRIPTION
[Acid potion shows up in poisoning](https://github.com/Chris-plus-alphanumericgibberish/dNAO/commit/427071e2cc1b8fe3ab095b6fa283ec5cbfdcf39e)

That way you can name it immediately. It's the only non-ambiguous potion (because I assumed when I changed it that acid would always corrode. no, dipshit, materials exist now (?)).

[Ban self-willed race-favoring artis from gifting](https://github.com/Chris-plus-alphanumericgibberish/dNAO/commit/29ebeb60b03a92e86d80ac02bf3bf988e84374f4)

They blast you if you're not that race :((((

[Anguirel counts as obsidian too](https://github.com/Chris-plus-alphanumericgibberish/dNAO/pull/2360/commits/558dc01d6bcd7921c11b74069e41032e323e4a08)

Fixes dice override (by moving it, really) so that it's actually comparable, damage-wise, to a normal droven greatsword (rather than being _noticeably_ worse, due to the more consistent damage not interacting well with GWF).

Add obj_is_material for Anguirel & obsidian specifically, which is only used in the Rising Cut move case for Drow Kensei. All other checks that I see are related to object destruction, which is NOT what obj_is_material should probably be linked to.