### PR TITLE
Allow wishing for specific Sky Reflected weapon type

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -6181,6 +6181,9 @@ typfnd:
 		aname = artifact_name(name, &objtyp, NULL);
 
 		if (aname) {
+			if (!strcmp((&artilist[ART_SKY_REFLECTED])->name, aname))
+				set_material_gm(otmp, MERCURIAL);
+
 			/* attempt to create an artifact with the modified name */
 			otmp = oname(otmp, aname);
 


### PR DESCRIPTION
instead of

> Born of level 0 of The Dungeons of Doom."  You cannot wish for an existing artifact.