### PR TITLE
Bloodletter benefits from blood rip & blood impurity

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -7186,10 +7186,16 @@ boolean printmessages; /* print generic elemental damage messages */
 		}
 		if (spec_dbon_applies && !(otmp->oartifact == ART_BLOODLETTER && artinstance[otmp->oartifact].BLactive < monstermoves)){
 			*truedmgptr += mlev(mdef);
-			if(youagr)
+			IMPURITY_UP(u.uimp_blood);
+
+			if(youagr){
 				*plusdmgptr += u.uimpurity/2;
-			if (otmp->oartifact == ART_BLOODLETTER)
-				artinstance[otmp->oartifact].BLactive += max(0, mlev(mdef)/10 + rn2(5));
+				if (check_vampire(VAMPIRE_BLOOD_RIP) && !rn2(10)){
+					pline("%s blood forms spears that pierce %s %s!", s_suffix(Monnam(mdef)), mhis(mdef), mbodypart(mdef, BODY_SKIN));
+					totldmg += max(400, 3*mdef->mhpmax/10);
+				}
+			}
+			if (otmp->oartifact == ART_BLOODLETTER) artinstance[otmp->oartifact].BLactive += max(0, mlev(mdef)/10 + rn2(5));
 		}
 	}
 	if (otmp->oartifact == ART_BOREAL_SCEPTER){
@@ -13315,6 +13321,7 @@ arti_invoke(obj)
 					You("plunge Bloodletter into your chest, making an offering of your tainted blood.");
 					losehp(Upolyd ? u.mhmax * 0.2 : u.uhpmax * 0.2, "purging tainted blood", KILLED_BY);
 					artinstance[obj->oartifact].BLactive = monstermoves + 20 + rn2(10) + rn2(10);
+					IMPURITY_UP(u.uimp_blood);
 				} else {
 					You("are free of tainted blood, and have none to offer.");
 				}


### PR DESCRIPTION
Or more accurately - it ups blood impurity on-hit (for any AD_BLUD weapon while active, aka bloodletter only when lit/bloodstained), and then benefits from blood rip vampire upgrade. Niche enough interaction, not better for the majority of characters with access I think, but the impurity up is reasonable and makes sense.

x