### PR TITLE
poison name mismatch in objnam.c

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -4422,7 +4422,7 @@ int wishflags;
 		} else if(!strncmpi(bp, "silvered ",l=9)) {
 			ispoisoned=OPOISON_SILVER;
 		} else if(!strncmpi(bp, "ergot-coated ",l=13)) {
-			ispoisoned=OPOISON_SILVER;
+			ispoisoned=OPOISON_HALLU;
 		} else if(!strncmpi(bp, "greased ",l=8)) {
 			isgreased=1;
 		} else if(!strncmpi(bp, "world-serpent ",l=14)


### PR DESCRIPTION
Per the title - hallucination poison's object name phrase got attributed to silver poison.