### PR TITLE
Update falling star effect description

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -3382,7 +3382,7 @@ winid *datawin;
 					OBJPUTSTR(buf2);
 				}
 				if (Insight >= 42){
-					Sprintf(buf2, "Randomly drops falling stars on a hit, causing up to %d physical & fiery explosions centered anywhere in your life of sight.",
+					Sprintf(buf2, "Randomly drops falling stars on a hit, causing up to %d physical & fiery explosions centered anywhere in your line of sight.",
 						min(6, (Insight - 36)/6));
 					OBJPUTSTR(buf2);
 				}

--- a/src/invent.c
+++ b/src/invent.c
@@ -3382,7 +3382,7 @@ winid *datawin;
 					OBJPUTSTR(buf2);
 				}
 				if (Insight >= 42){
-					Sprintf(buf2, "Randomly drops falling stars on a hit, causing up to %d physical & fiery explosions centered anywhere on the level.",
+					Sprintf(buf2, "Randomly drops falling stars on a hit, causing up to %d physical & fiery explosions centered anywhere in your life of sight.",
 						min(6, (Insight - 36)/6));
 					OBJPUTSTR(buf2);
 				}


### PR DESCRIPTION
When choosing the location for the falling stars the game checks `clear_path()` first (artifact.c, line 8582), therefore the stars will only fall within the hero's line of site.

In-game testing confirms this, stars indeed tend to fall in the same corridor as me, even though that would be extremely unlikely if they were actually picking a random spot anywhere on the level. 

The current description saying "Randomly drops falling stars on a hit, causing up to %d physical & fiery explosions centered anywhere on the level." is misleading - it implies that the player could with enough luck make stars fall in, for example, a nasty throne room, without coming anywhere near it. 

This PR changes it to "Randomly drops falling stars on a hit, causing up to %d physical & fiery explosions centered anywhere in your line of sight."